### PR TITLE
Fix CI failure after Nix 2.6.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
       uses: cachix/install-nix-action@v16
       with:
         nix_path: "${{ matrix.nixPath }}"
+        # nix 2.6 breaks restrict-eval, when using the NIX_PATH
+        # see https://github.com/NixOS/nix/issues/5980
+        install_url: https://releases.nixos.org/nix/nix-2.5.1/install
         extra_nix_config: |
           experimental-features = nix-command flakes
     - name: Show nixpkgs version


### PR DESCRIPTION
CI build stopped working after Nix 2.6.0 release, apparently because of NixOS/nix#5980. Until a fixed version of Nix is released, revert to Nix 2.5.1 for CI.

Upstream fix for the template: nix-community/nur-packages-template#57