### PR TITLE
Reformat all Nix code with Alejandra

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,26 @@ env:
   NUR_REPO: sigprof
 
 jobs:
+  flake-check:
+    name: Flake check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.2
+      - name: Install nix
+        uses: cachix/install-nix-action@v17
+      - name: Setup cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: sigprof
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: "pre-commit-hooks"
+      - name: Run flake check
+        run: nix flake check
+
   tests:
+    needs:
+      - flake-check
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 result
 result-*
 
+.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 result
 result-*
 
+.direnv
 .pre-commit-config.yaml

--- a/ci.nix
+++ b/ci.nix
@@ -8,43 +8,42 @@
 #
 # then your CI will be able to build and cache only those packages for
 # which this is possible.
-
-{ pkgs ? import <nixpkgs> { } }:
-
-with builtins;
-let
+{pkgs ? import <nixpkgs> {}}:
+with builtins; let
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
   isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
   isBuildable = p: !(p.meta.broken or false) && p.meta.license.free or true;
   isCacheable = p: !(p.preferLocalBuild or false);
   shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
 
-  nameValuePair = n: v: { name = n; value = v; };
+  nameValuePair = n: v: {
+    name = n;
+    value = v;
+  };
 
   concatMap = builtins.concatMap or (f: xs: concatLists (map f xs));
 
-  flattenPkgs = s:
-    let
-      f = p:
-        if shouldRecurseForDerivations p then flattenPkgs p
-        else if isDerivation p then [ p ]
-        else [ ];
-    in
+  flattenPkgs = s: let
+    f = p:
+      if shouldRecurseForDerivations p
+      then flattenPkgs p
+      else if isDerivation p
+      then [p]
+      else [];
+  in
     concatMap f (attrValues s);
 
   outputsOf = p: map (o: p.${o}) p.outputs;
 
-  nurAttrs = import ./default.nix { inherit pkgs; };
+  nurAttrs = import ./default.nix {inherit pkgs;};
 
   nurPkgs =
     flattenPkgs
-      (listToAttrs
-        (map (n: nameValuePair n nurAttrs.${n})
-          (filter (n: !isReserved n)
-            (attrNames nurAttrs))));
-
-in
-rec {
+    (listToAttrs
+      (map (n: nameValuePair n nurAttrs.${n})
+        (filter (n: !isReserved n)
+          (attrNames nurAttrs))));
+in rec {
   buildPkgs = filter isBuildable nurPkgs;
   cachePkgs = filter isCacheable buildPkgs;
 

--- a/default.nix
+++ b/default.nix
@@ -5,12 +5,9 @@
 # Having pkgs default to <nixpkgs> is fine though, and it lets you use short
 # commands such as:
 #     nix-build -A mypackage
-
-{ pkgs ? import <nixpkgs> { } }:
-
-{
+{pkgs ? import <nixpkgs> {}}: {
   # The `lib`, `modules`, and `overlay` names are special
-  lib = import ./lib { inherit pkgs; }; # functions
+  lib = import ./lib {inherit pkgs;}; # functions
   modules = import ./modules; # NixOS modules
   overlays = import ./overlays; # nixpkgs overlays
 

--- a/flake.lock
+++ b/flake.lock
@@ -31,10 +31,34 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1652714503,
+        "narHash": "sha256-qQKVEfDe5FqvGgkZtg5Pc491foeiDPIOeycHMqnPDps=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "521a524771a8e93caddaa0ac1d67d03766a8b0b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,22 +6,25 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    let
-      nurPackageOverlay = import ./overlay.nix;
-    in
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }: let
+    nurPackageOverlay = import ./overlay.nix;
+  in
     {
       overlay = final: prev: nurPackageOverlay final prev;
-    } // (
+    }
+    // (
       flake-utils.lib.eachDefaultSystem
-        (system:
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-            nurPackages = nurPackageOverlay nurPackages pkgs;
-          in
-          rec {
-            packages = flake-utils.lib.filterPackages system nurPackages;
-          }
-        )
+      (
+        system: let
+          pkgs = nixpkgs.legacyPackages.${system};
+          nurPackages = nurPackageOverlay nurPackages pkgs;
+        in rec {
+          packages = flake-utils.lib.filterPackages system nurPackages;
+        }
+      )
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,17 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
     flake-utils.url = "github:numtide/flake-utils";
+
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+    pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+    pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    pre-commit-hooks,
   }: let
     nurPackageOverlay = import ./overlay.nix;
   in
@@ -26,5 +31,30 @@
           packages = flake-utils.lib.filterPackages system nurPackages;
         }
       )
+    )
+    // (
+      let
+        checkedSystems = with flake-utils.lib.system; [
+          x86_64-linux
+          x86_64-darwin
+          aarch64-linux
+          aarch64-darwin
+          # No `i686-linux` because `pre-commit-hooks` does not evaluate
+        ];
+      in
+        flake-utils.lib.eachSystem checkedSystems (system: {
+          checks = {
+            pre-commit = pre-commit-hooks.lib.${system}.run {
+              src = ./.;
+              hooks = {
+                alejandra.enable = true;
+              };
+            };
+          };
+
+          devShells.default = nixpkgs.legacyPackages.${system}.mkShell {
+            inherit (self.checks.${system}.pre-commit) shellHook;
+          };
+        })
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,15 +22,12 @@
       overlay = final: prev: nurPackageOverlay final prev;
     }
     // (
-      flake-utils.lib.eachDefaultSystem
-      (
-        system: let
-          pkgs = nixpkgs.legacyPackages.${system};
-          nurPackages = nurPackageOverlay nurPackages pkgs;
-        in rec {
-          packages = flake-utils.lib.filterPackages system nurPackages;
-        }
-      )
+      flake-utils.lib.eachDefaultSystem (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        nurPackages = nurPackageOverlay nurPackages pkgs;
+      in rec {
+        packages = flake-utils.lib.filterPackages system nurPackages;
+      })
     )
     // (
       let

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,4 @@
-{ pkgs }:
-
+{pkgs}:
 with pkgs.lib; {
   # Add your library functions here
   #

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,15 +1,15 @@
 # You can use this file as a nixpkgs overlay. This is useful in the
 # case where you don't want to add the whole NUR namespace to your
 # configuration.
-
-self: super:
-let
+self: super: let
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
-  nameValuePair = n: v: { name = n; value = v; };
-  nurAttrs = import ./default.nix { pkgs = super; };
-
+  nameValuePair = n: v: {
+    name = n;
+    value = v;
+  };
+  nurAttrs = import ./default.nix {pkgs = super;};
 in
-builtins.listToAttrs
+  builtins.listToAttrs
   (map (n: nameValuePair n nurAttrs.${n})
     (builtins.filter (n: !isReserved n)
       (builtins.attrNames nurAttrs)))

--- a/pkgs/cosevka/default.nix
+++ b/pkgs/cosevka/default.nix
@@ -1,33 +1,35 @@
-{ lib, fetchzip }:
-
-let
+{
+  lib,
+  fetchzip,
+}: let
   version = "6.1.3.1";
-in fetchzip rec {
-  name = "cosevka-${version}";
-  url = "https://github.com/sigprof/cosevka/releases/download/cosevka-${version}/ttc-cosevka-${version}.tar.xz";
-  sha256 = "085wlia8j6i0zjsx9amq9caw84kx399bsl0pk8vpg6laq1y1kxhq";
-  # NOTE: This hash is **not** identical to the `nix-prefetch-url --unpack`
-  # output, because moving the font files to `$out/share/fonts/truetype` also
-  # affects the hash.
+in
+  fetchzip rec {
+    name = "cosevka-${version}";
+    url = "https://github.com/sigprof/cosevka/releases/download/cosevka-${version}/ttc-cosevka-${version}.tar.xz";
+    sha256 = "085wlia8j6i0zjsx9amq9caw84kx399bsl0pk8vpg6laq1y1kxhq";
+    # NOTE: This hash is **not** identical to the `nix-prefetch-url --unpack`
+    # output, because moving the font files to `$out/share/fonts/truetype` also
+    # affects the hash.
 
-  postFetch = let
-    basename = baseNameOf url;
-  in ''
-    renamed="$TMPDIR/${basename}"
-    mv "$downloadedFile" "$renamed"
-    unpackFile "$renamed"
-    install -m444 -D -t $out/share/fonts/truetype *.tt[fc]
-  '';
-
-  meta = with lib; {
-    homepage = "https://github.com/sigprof/cosevka";
-    downloadPage = "https://github.com/sigprof/cosevka/releases";
-    description = ''
-      Customized version of the Iosevka font - slender monospace sans-serif and
-      slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono,
-      designed to be the ideal font for programming.
+    postFetch = let
+      basename = baseNameOf url;
+    in ''
+      renamed="$TMPDIR/${basename}"
+      mv "$downloadedFile" "$renamed"
+      unpackFile "$renamed"
+      install -m444 -D -t $out/share/fonts/truetype *.tt[fc]
     '';
-    license = licenses.ofl;
-    platforms = platforms.all;
-  };
-}
+
+    meta = with lib; {
+      homepage = "https://github.com/sigprof/cosevka";
+      downloadPage = "https://github.com/sigprof/cosevka/releases";
+      description = ''
+        Customized version of the Iosevka font - slender monospace sans-serif and
+        slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono,
+        designed to be the ideal font for programming.
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+    };
+  }

--- a/pkgs/virt-manager/default.nix
+++ b/pkgs/virt-manager/default.nix
@@ -1,6 +1,7 @@
-{ pkgs, lib  }:
-
-let
+{
+  pkgs,
+  lib,
+}: let
   # Build the virt-manager 2.2.1 package from the old Nix expression, but using
   # the current libraries (this works much better than trying to use the
   # package from an old nixpkgs snapshot, because that old package would use
@@ -20,21 +21,20 @@ let
   virt-manager-2 = pkgs.callPackage ./virt-manager-2.2.1.nix {
     system-libvirt = pkgs.libvirt;
   };
-
 in
-pkgs.virt-manager.overridePythonAttrs (oldAttrs: rec {
-  # Build a combined `virt-manager` package which included both the latest
-  # version (which supports only some recent `libvirt` versions) and the 2.x
-  # version (renamed to `virt-manager-2`).  This is safer than exporting the
-  # package with just `$out/bin/virt-manager-2` and nothing else, because there
-  # are some global things like GSettings schemas that need to be provided only
-  # once, but might be used by the older version too, and combining both
-  # versions in a single package ensures that those global things are handled
-  # appropriately.
-  #
-  # Using `postFixup` to avoid wrapping the symlink.
-  #
-  postFixup = ''
-    ln -s ${virt-manager-2}/bin/virt-manager $out/bin/virt-manager-2
-  '';
-})
+  pkgs.virt-manager.overridePythonAttrs (oldAttrs: rec {
+    # Build a combined `virt-manager` package which included both the latest
+    # version (which supports only some recent `libvirt` versions) and the 2.x
+    # version (renamed to `virt-manager-2`).  This is safer than exporting the
+    # package with just `$out/bin/virt-manager-2` and nothing else, because there
+    # are some global things like GSettings schemas that need to be provided only
+    # once, but might be used by the older version too, and combining both
+    # versions in a single package ensures that those global things are handled
+    # appropriately.
+    #
+    # Using `postFixup` to avoid wrapping the symlink.
+    #
+    postFixup = ''
+      ln -s ${virt-manager-2}/bin/virt-manager $out/bin/virt-manager-2
+    '';
+  })

--- a/pkgs/virt-manager/virt-manager-2.2.1.nix
+++ b/pkgs/virt-manager/virt-manager-2.2.1.nix
@@ -1,80 +1,110 @@
-{ lib, fetchurl, fetchpatch, python3Packages, intltool, file
-, wrapGAppsHook, gtk-vnc, vte, avahi, dconf
-, gobject-introspection, libvirt-glib, system-libvirt
-, gsettings-desktop-schemas, glib, libosinfo, gnome3
-, gtksourceview4
-, spiceSupport ? true, spice-gtk ? null
-, cpio, e2fsprogs, findutils, gzip
+{
+  lib,
+  fetchurl,
+  fetchpatch,
+  python3Packages,
+  intltool,
+  file,
+  wrapGAppsHook,
+  gtk-vnc,
+  vte,
+  avahi,
+  dconf,
+  gobject-introspection,
+  libvirt-glib,
+  system-libvirt,
+  gsettings-desktop-schemas,
+  glib,
+  libosinfo,
+  gnome3,
+  gtksourceview4,
+  spiceSupport ? true,
+  spice-gtk ? null,
+  cpio,
+  e2fsprogs,
+  findutils,
+  gzip,
 }:
-
 with lib;
+  python3Packages.buildPythonApplication rec {
+    pname = "virt-manager";
+    version = "2.2.1";
 
-python3Packages.buildPythonApplication rec {
-  pname = "virt-manager";
-  version = "2.2.1";
+    src = fetchurl {
+      url = "http://virt-manager.org/download/sources/virt-manager/${pname}-${version}.tar.gz";
+      sha256 = "06ws0agxlip6p6n3n43knsnjyd91gqhh2dadgc33wl9lx1k8vn6g";
+    };
 
-  src = fetchurl {
-    url = "http://virt-manager.org/download/sources/virt-manager/${pname}-${version}.tar.gz";
-    sha256 = "06ws0agxlip6p6n3n43knsnjyd91gqhh2dadgc33wl9lx1k8vn6g";
-  };
-
-  nativeBuildInputs = [
-    intltool file
-    gobject-introspection # for setup hook populating GI_TYPELIB_PATH
-  ];
-
-  buildInputs = [
-    wrapGAppsHook
-    libvirt-glib vte dconf gtk-vnc gnome3.adwaita-icon-theme avahi
-    gsettings-desktop-schemas libosinfo gtksourceview4
-    gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
-  ] ++ optional spiceSupport spice-gtk;
-
-  propagatedBuildInputs = with python3Packages;
-    [
-      pygobject3 ipaddress libvirt libxml2 requests
+    nativeBuildInputs = [
+      intltool
+      file
+      gobject-introspection # for setup hook populating GI_TYPELIB_PATH
     ];
 
-  patches = [
-    # due to a recent change in setuptools-61, "packages=[]" needs to be included
-    (fetchpatch {
-      name = "fix-for-setuptools-61.patch";
-      url = "https://github.com/virt-manager/virt-manager/commit/46dc0616308a73d1ce3ccc6d716cf8bbcaac6474.patch";
-      sha256 = "sha256-/RZG+7Pmd7rmxMZf8Fvg09dUggs2MqXZahfRQ5cLcuM=";
-    })
-  ];
+    buildInputs =
+      [
+        wrapGAppsHook
+        libvirt-glib
+        vte
+        dconf
+        gtk-vnc
+        gnome3.adwaita-icon-theme
+        avahi
+        gsettings-desktop-schemas
+        libosinfo
+        gtksourceview4
+        gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
+      ]
+      ++ optional spiceSupport spice-gtk;
 
-  postPatch = ''
-    sed -i 's|/usr/share/libvirt/cpu_map.xml|${system-libvirt}/share/libvirt/cpu_map.xml|g' virtinst/capabilities.py
-    sed -i "/'install_egg_info'/d" setup.py
-  '';
+    propagatedBuildInputs = with python3Packages; [
+      pygobject3
+      ipaddress
+      libvirt
+      libxml2
+      requests
+    ];
 
-  postConfigure = ''
-    ${python3Packages.python.interpreter} setup.py configure --prefix=$out
-  '';
+    patches = [
+      # due to a recent change in setuptools-61, "packages=[]" needs to be included
+      (fetchpatch {
+        name = "fix-for-setuptools-61.patch";
+        url = "https://github.com/virt-manager/virt-manager/commit/46dc0616308a73d1ce3ccc6d716cf8bbcaac6474.patch";
+        sha256 = "sha256-/RZG+7Pmd7rmxMZf8Fvg09dUggs2MqXZahfRQ5cLcuM=";
+      })
+    ];
 
-  setupPyGlobalFlags = [ "--no-update-icon-cache" ];
-
-  preFixup = ''
-    gappsWrapperArgs+=(--set PYTHONPATH "$PYTHONPATH")
-    # these are called from virt-install in initrdinject.py
-    gappsWrapperArgs+=(--prefix PATH : "${makeBinPath [ cpio e2fsprogs file findutils gzip ]}")
-  '';
-
-  # Failed tests
-  doCheck = false;
-
-  meta = with lib; {
-    homepage = "http://virt-manager.org";
-    description = "Desktop user interface for managing virtual machines";
-    longDescription = ''
-      The virt-manager application is a desktop user interface for managing
-      virtual machines through libvirt. It primarily targets KVM VMs, but also
-      manages Xen and LXC (linux containers).
+    postPatch = ''
+      sed -i 's|/usr/share/libvirt/cpu_map.xml|${system-libvirt}/share/libvirt/cpu_map.xml|g' virtinst/capabilities.py
+      sed -i "/'install_egg_info'/d" setup.py
     '';
-    license = licenses.gpl2;
-    # exclude Darwin since libvirt-glib currently doesn't build there
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ qknight offline fpletz globin ];
-  };
-}
+
+    postConfigure = ''
+      ${python3Packages.python.interpreter} setup.py configure --prefix=$out
+    '';
+
+    setupPyGlobalFlags = ["--no-update-icon-cache"];
+
+    preFixup = ''
+      gappsWrapperArgs+=(--set PYTHONPATH "$PYTHONPATH")
+      # these are called from virt-install in initrdinject.py
+      gappsWrapperArgs+=(--prefix PATH : "${makeBinPath [cpio e2fsprogs file findutils gzip]}")
+    '';
+
+    # Failed tests
+    doCheck = false;
+
+    meta = with lib; {
+      homepage = "http://virt-manager.org";
+      description = "Desktop user interface for managing virtual machines";
+      longDescription = ''
+        The virt-manager application is a desktop user interface for managing
+        virtual machines through libvirt. It primarily targets KVM VMs, but also
+        manages Xen and LXC (linux containers).
+      '';
+      license = licenses.gpl2;
+      # exclude Darwin since libvirt-glib currently doesn't build there
+      platforms = platforms.linux;
+      maintainers = with maintainers; [qknight offline fpletz globin];
+    };
+  }


### PR DESCRIPTION
[Alejandra](https://github.com/kamadorueda/alejandra) enforces the standard formatting style for Nix code much better than other currently existing tools (nixpkgs-fmt, nixfmt), and from looking at [Nix RFC 0101](https://www.github.com/NixOS/rfcs/pull/101) it seems that Alejandra might even become the default formatter for Nix.

- [x] Reformat the existing code using the latest Alejandra release (1.4.0 at the moment).
- [x] Use [cachix/pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) to enforce the code formatting with a pre-commit hook.
- [x] Use `direnv` and `nix-direnv` to set up the pre-commit hook automatically.
- [x] Run `nix flake check` during CI to catch any formatting violations (this should also catch other evaluation problems before proceeding with the build for various Nixpkgs versions).