### PR TITLE
New package: `terminus-font-custom`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,5 +12,6 @@
   overlays = import ./overlays; # nixpkgs overlays
 
   cosevka = pkgs.callPackage ./pkgs/cosevka {};
+  terminus-font-custom = pkgs.callPackage ./pkgs/terminus-font-custom {};
   virt-manager = pkgs.callPackage ./pkgs/virt-manager {};
 }

--- a/pkgs/terminus-font-custom/default.nix
+++ b/pkgs/terminus-font-custom/default.nix
@@ -1,0 +1,26 @@
+{
+  pkgs,
+  lib,
+  characterVariants ? ["dv1" "ij1" "ll2"],
+}: let
+  inherit (lib) concat mergeAttrs optionalString;
+in
+  pkgs.terminus_font.overrideAttrs (old: {
+    patches = concat (old.patches or []) (
+      map (variant: "alt/${variant}.diff") characterVariants
+    );
+
+    meta = mergeAttrs old.meta {
+      description =
+        (old.meta.description or "")
+        + optionalString (characterVariants != []) " (customized version)";
+
+      longDescription =
+        (old.meta.longDescription or "")
+        + optionalString (characterVariants != []) ''
+
+          This package is customized to use several non-default character variants
+          (enabled patches: ${toString characterVariants}).
+        '';
+    };
+  })


### PR DESCRIPTION
The `terminus-font-custom` package is actually an override for the `terminus_font` package provided by Nixpkgs which enables several non-default character variants using patches provided by upstream. Currently the "dv1", "ij1" and "ll2" variants are enabled (the list of variants can be changed using the `characterVariants` argument).