### PR TITLE
Use `mkShell` from `numtide/devshell`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1654858401,
+        "narHash": "sha256-53bw34DtVJ2bnF6WEwy6Tym+qY0pNEiEwARUlvmTZjs=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f55e05c6d3bbe9acc7363bc8fc739518b2f02976",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1653893745,
@@ -56,6 +79,7 @@
     },
     "root": {
       "inputs": {
+        "devshell": "devshell",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
     pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
+
+    devshell.url = "github:numtide/devshell";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
+    devshell.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = {
@@ -15,6 +19,7 @@
     nixpkgs,
     flake-utils,
     pre-commit-hooks,
+    devshell,
   }: let
     nurPackageOverlay = import ./overlay.nix;
   in
@@ -49,8 +54,13 @@
             };
           };
 
-          devShells.default = nixpkgs.legacyPackages.${system}.mkShell {
-            inherit (self.checks.${system}.pre-commit) shellHook;
+          devShells.default = devshell.legacyPackages.${system}.mkShell {
+            name = "sigprof/nur-packages";
+            motd = "{6}🔨 Welcome to {bold}sigprof/nur-packages{reset}";
+            packages = [
+              pre-commit-hooks.packages.${system}.alejandra
+            ];
+            devshell.startup.pre-commit-hooks.text = self.checks.${system}.pre-commit.shellHook;
           };
         })
     );


### PR DESCRIPTION
Unfortunately, plain `mkShell` provided by Nixpkgs is not that plain — it pulls the whole C toolchain into the environment by default, and even when that part is changed (e.g., by using `stdenvNoCC`), it still exports lots of not really desired environment variables.  Use the `mkShell` implementation from https://github.com/numtide/devshell instead, which does not pull the C toolchain into the development environment unless configured explicitly, and does not export those undesired environment variables.