### PR TITLE
cosevka: Fix `postFetch` after NixOS/nixpkgs#173430

### DIFF
--- a/pkgs/cosevka/default.nix
+++ b/pkgs/cosevka/default.nix
@@ -12,12 +12,20 @@ in
     # output, because moving the font files to `$out/share/fonts/truetype` also
     # affects the hash.
 
+    # Note: The `if [ -f "$downloadedFile" ]` part below is needed when Nixpkgs
+    # does not have https://github.com/NixOS/nixpkgs/pull/173430 (i.e., before
+    # NixOS 22.05); it may be removed when any support for those old versions
+    # is dropped.
     postFetch = let
       basename = baseNameOf url;
     in ''
-      renamed="$TMPDIR/${basename}"
-      mv "$downloadedFile" "$renamed"
-      unpackFile "$renamed"
+      if [ -f "$downloadedFile" ]; then
+        renamed="$TMPDIR/${basename}"
+        mv "$downloadedFile" "$renamed"
+        unpackFile "$renamed"
+      else
+        mv $out/*.tt[fc] ./
+      fi
       install -m444 -D -t $out/share/fonts/truetype *.tt[fc]
     '';
 


### PR DESCRIPTION
NixOS/nixpkgs#173430 (included in NixOS >= 22.05) changed the meaning of the `postFetch` argument to `fetchzip` — before that change it replaced the original `postFetch` code completely, but after the change it just appends the code after the default one, like `extraPostFetch` did in the old version.  This change broke the existing code in the `cosevka` package (but it was not noticed immediately, because the package did not actually get rebuilt thanks to the binary cache).

Just using `extraPostFetch` instead of `postFetch` is not possible, because it results in a warning with the new `fetchzip` code (and probably would be removed completely in some future release).  So the chosen solution is to add some compatibility code that checks whether `$downloadedFile` exists (which would be the case for the old implementation of `fetchzip`, but not for the new one).  When the support for NixOS versions before 22.05 gets dropped completely, the compatibility branch in the script could be dropped too.