### PR TITLE
virt-manager-2.2.1: Remove `ipaddress` from dependencies

### DIFF
--- a/pkgs/virt-manager/virt-manager-2.2.1.nix
+++ b/pkgs/virt-manager/virt-manager-2.2.1.nix
@@ -59,7 +59,6 @@ with lib;
 
     propagatedBuildInputs = with python3Packages; [
       pygobject3
-      ipaddress
       libvirt
       libxml2
       requests


### PR DESCRIPTION
The `ipaddress` Python module did not actually exist since Python 3.3 (it is included in core), and was completely removed from Nixpkgs in NixOS/nixpkgs#175518, breaking any old packages which still referred to that module.  Remove `ipaddress` from `propagatedBuildInputs` in `virt-manager-2.2.1` to fix its build with most recent Nixpkgs.