### PR TITLE
ci: Fix Cachix pollution and `.git` data leak

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -125,8 +125,21 @@ runs:
         echo "::endgroup::"
         echo "::group::Building derivations"
         build_result=0
-        # Use nix-build-uncached from the locked version of nixpkgs
-        nix shell --impure --expr '(builtins.getFlake (toString ./.)).inputs.nixpkgs.legacyPackages.${builtins.currentSystem}.nix-build-uncached' \
+        #
+        # Use `nix-build-uncached` from the locked version of `nixpkgs`.
+        #
+        # WARNING: Do not use `builtins.getFlake (toString ./.)` - while it
+        # seems to work, it does not detect that the current directory is a Git
+        # checkout and copies the whole contents of the directory, including
+        # `.git` and any untracked files, into the Nix store, using an unique
+        # hash every time; then this store item may be pushed into Cachix,
+        # polluting the cache and leaking the contents of `.git` including any
+        # auth tokens that might be there.  The proper `git+file:` URL for the
+        # current flake may be obtained from `nix flake metadata`.
+        #
+        flake_url="$( nix flake metadata --json | jq -r '.url' )"
+        current_system="$( nix eval --raw --impure --expr 'builtins.currentSystem' )"
+        nix shell --expr "(builtins.getFlake \"$flake_url\").inputs.nixpkgs.legacyPackages.\"$current_system\".nix-build-uncached" \
           -c nix-build-uncached $drv_list || build_result=$?
         echo "::endgroup::"
         echo "::group::Saving build logs"


### PR DESCRIPTION
The `.github/actions/nix-build` action used `getFlake (toString ./.)` to get access to the flake with the `inputs` attribute present, so that the locked revision of `nixpkgs` may be obtained from there (this looked easier than parsing `flake.lock` manually, and did not require adding any CI-specific outputs to the flake).

Unfortunately, it turned out that `getFlake` does not check whether the passed path is a Git checkout — it simply copies the whole directory into the Nix store, including the `.git` subdirectory.  Therefore an unique store item was created for every job that used the `nix-build` action, and that store item was then pushed to Cachix, needlessly increasing the space usage.  Even worse, the `.git/config` file exposed the value of `$GITHUB_TOKEN`, which is a security issue (although not a major one, because the default token gets invalidated immediately after the workflow finishes, so the window for possible abuse was limited).

Fix the issue by parsing the `nix flake metadata --json` output to obtain the proper flake URL instead of just using the full path to the current directory.  The flake URL has the `git+file:` type in this case, and the Nix store item gets a stable identifier which changes only when the commit hash actually changes, therefore the Cachix cache is not polluted with store items that can never be reused, and the contents of the `.git` subdirectory is not leaked.