### PR TITLE
Avoid extra attributes in `legacyPackages` and NUR packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       flake-utils.lib.eachDefaultSystem (system: let
         inherit (flake-utils.lib) filterPackages flattenTree;
         pkgs = nixpkgs.legacyPackages.${system};
-        legacyPackages = pkgs.callPackage ./pkgs {inherit inputs;};
+        legacyPackages = (pkgs.callPackage ./pkgs {inherit inputs;}).packages;
         packages = filterPackages system (flattenTree legacyPackages);
       in {
         inherit packages legacyPackages;

--- a/nur.nix
+++ b/nur.nix
@@ -17,9 +17,9 @@
     };
 
     lib = import ./lib self.inputs;
-    nurPackages.${system} = pkgs.callPackage ./pkgs {
-      inherit (self) inputs;
-    };
+    nurPackages.${system} =
+      (pkgs.callPackage ./pkgs {inherit (self) inputs;})
+      .packages;
   };
 in
   self

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,7 @@
-{pkgs, ...}: {
-  cosevka = pkgs.callPackage ./cosevka {};
-  terminus-font-custom = pkgs.callPackage ./terminus-font-custom {};
-  virt-manager = pkgs.callPackage ./virt-manager {};
+{callPackage, ...}: {
+  packages = {
+    cosevka = callPackage ./cosevka {};
+    terminus-font-custom = callPackage ./terminus-font-custom {};
+    virt-manager = callPackage ./virt-manager {};
+  };
 }


### PR DESCRIPTION
Although `callPackage` is an easy method to import package sets while passing arbitrary arguments to them, that function internally uses `makeOverridable`, which adds some extra attributes (`override` and `overrideDerivation`) to the returned attribute sets.  These attributes are mostly useless there (especially when the attribute set is actually merged from multiple parts), and filtering them out after the fact is problematic (filtering by `isDerivation` is not good, because it would exclude any functions that might be there, and excluding just some specific attributes by name may break in the future).

Instead of trying to filter the already polluted attribute set, try to keep the set clean by putting the actual set of packages into the nested `packages` attribute, so that it won't be touched by `makeOverridable`.