### PR TITLE
Add language pack packages for Firefox and Thunderbird

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,7 +1,9 @@
 {callPackage, ...}: {
-  packages = {
-    cosevka = callPackage ./cosevka {};
-    terminus-font-custom = callPackage ./terminus-font-custom {};
-    virt-manager = callPackage ./virt-manager {};
-  };
+  packages =
+    {
+      cosevka = callPackage ./cosevka {};
+      terminus-font-custom = callPackage ./terminus-font-custom {};
+      virt-manager = callPackage ./virt-manager {};
+    }
+    // (callPackage ./mozilla-langpack/packages.nix {}).packages;
 }

--- a/pkgs/mozilla-langpack/functions.nix
+++ b/pkgs/mozilla-langpack/functions.nix
@@ -1,0 +1,21 @@
+{
+  getAppInfo = {
+    lib,
+    mozSupportedApps,
+    mozPlatforms,
+    mozApp,
+    mozAppName ? mozApp.pname,
+    mozAppVersion ? lib.getVersion mozApp,
+    ...
+  }:
+    mozSupportedApps.${mozAppName}
+    // rec {
+      name = mozAppName;
+      version = mozAppVersion;
+      major = builtins.head (builtins.match "([^.]+)\\..*" version);
+      isESR = (builtins.match ".*esr" version) != null;
+      majorKey = major + lib.optionalString isESR "esr";
+      arch = mozPlatforms.${mozApp.system} or "";
+      langpackBaseName = "${name}${lib.optionalString isESR "-esr"}-langpack";
+    };
+}

--- a/pkgs/mozilla-langpack/langpack.nix
+++ b/pkgs/mozilla-langpack/langpack.nix
@@ -1,0 +1,54 @@
+# Build the language pack for the specified app and language.
+#
+# This package requires lots of parameters; see the `makeMozillaLangpack`
+# function in `./packages.nix` for a more convenient way to use it.
+#
+let
+  functions = import ./functions.nix;
+in
+  {
+    # Custom parameters.
+    mozApp,
+    mozLanguage,
+    mozAppName ? mozApp.pname,
+    mozAppVersion ? lib.getVersion mozApp,
+    mozSupportedApps,
+    mozPlatforms,
+    mozLangpackSources,
+    # Various components from Nixpkgs.
+    lib,
+    callPackage,
+    fetchurl,
+    stdenv,
+  }: let
+    inherit (builtins) elem;
+    inherit (lib) filterAttrs;
+
+    app = functions.getAppInfo {
+      inherit lib mozSupportedApps mozPlatforms mozApp mozAppName mozAppVersion;
+    };
+    langpack = mozLangpackSources.${app.name}.${app.majorKey}.${app.arch}.${mozLanguage};
+    addonId = "langpack-${mozLanguage}@${app.addonIdSuffix}";
+  in
+    stdenv.mkDerivation {
+      name = "${app.name}-langpack-${mozLanguage}-${langpack.version}";
+      src = fetchurl {
+        name = "${app.name}-langpack-${mozLanguage}-${langpack.version}-${app.arch}.xpi";
+        inherit (langpack) url hash;
+      };
+
+      meta =
+        filterAttrs (n: _: elem n ["homepage" "license" "platforms" "badPlatforms"]) mozApp.meta
+        // {
+          description = "${app.fullName} language pack for the '${mozLanguage}' language.";
+        };
+
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+
+      buildCommand = ''
+        dst="$out/share/mozilla/extensions/${app.extensionDir}"
+        mkdir -p "$dst"
+        install -v -m644 "$src" "$dst/${addonId}.xpi"
+      '';
+    }

--- a/pkgs/mozilla-langpack/packages.nix
+++ b/pkgs/mozilla-langpack/packages.nix
@@ -1,0 +1,76 @@
+let
+  functions = import ./functions.nix;
+  presets = import ./presets.nix;
+in
+  {
+    pkgs,
+    lib,
+    callPackage,
+  }: let
+    inherit (lib) mapAttrs' nameValuePair optionalAttrs;
+
+    # Make a language pack package for the specified Mozilla-originated app and
+    # language.
+    #
+    # Required arguments:
+    # - `mozApp`: The app package for which the language pack needs to be made.
+    # - `mozLanguage`: The language name in the format used by Mozilla.
+    #
+    # Optional arguments:
+    # - `mozAppName`: The app name (normally derived from `mozApp`, but can be
+    #   specified explicitly in case the app was renamed, but is actually still
+    #   compatible with language packs for the original app).
+    # - `mozAppVersion`: The app version (normally derived from `mozApp`, but
+    #   can be overridden if a modified app uses an incompatible version
+    #   format).
+    #
+    # Optional arguments for some really special cases:
+    # - `mozSupportedApps`: The set of supported Mozilla apps (currently only
+    #   `firefox` and `thunderbird` are supported by default).
+    # - `mozPlatforms`: The set which provides the mapping from the Nix system
+    #   name to the platform name used by Mozilla products.
+    # - `mozLangpackSources`: The set of known language pack sources; usually
+    #   supplied by the package, but an override may be supplied for some
+    #   really custom cases.
+    #
+    # Any arguments with names not listed above are passed to `callPackage`.
+    #
+    makeMozillaLangpack = args @ {
+      mozApp,
+      mozLanguage,
+      mozAppName ? mozApp.pname,
+      mozAppVersion ? lib.getVersion mozApp,
+      mozSupportedApps ? presets.mozSupportedApps,
+      mozPlatforms ? presets.mozPlatforms,
+      mozLangpackSources ? presets.mozLangpackSources,
+      ...
+    }:
+      callPackage ./langpack.nix (args
+        // {
+          # Arguments with default values need to be passed explicitly.
+          inherit mozAppName mozAppVersion mozSupportedApps mozPlatforms mozLangpackSources;
+        });
+
+    # Make language pack packages for the specified app and all available
+    # languages.
+    langpackPackagesFor = mozApp: let
+      app = functions.getAppInfo (presets // {inherit lib mozApp;});
+      langpacks = presets.mozLangpackSources.${app.name}.${app.majorKey}.${app.arch} or {};
+      packageName = mozLanguage: "${app.langpackBaseName}-${mozLanguage}";
+      package = mozLanguage: makeMozillaLangpack {inherit mozApp mozLanguage;};
+    in
+      lib.mapAttrs' (n: v: nameValuePair (packageName n) (package n)) langpacks;
+  in {
+    packages =
+      {
+        # Always export `makeMozillaLangpack`, even if known Mozilla-originated
+        # apps are not available (maybe someone wants to override the set of
+        # supported Mozilla apps).
+        inherit makeMozillaLangpack;
+      }
+      # Export language pack packages for all available Mozilla-originated
+      # packages from the supported set and all available languages.
+      // optionalAttrs (pkgs ? firefox) (langpackPackagesFor pkgs.firefox)
+      // optionalAttrs (pkgs ? firefox-esr) (langpackPackagesFor pkgs.firefox-esr)
+      // optionalAttrs (pkgs ? thunderbird) (langpackPackagesFor pkgs.thunderbird);
+  }

--- a/pkgs/mozilla-langpack/presets.nix
+++ b/pkgs/mozilla-langpack/presets.nix
@@ -1,0 +1,21 @@
+{
+  mozSupportedApps = {
+    firefox = {
+      fullName = "Firefox";
+      addonIdSuffix = "firefox.mozilla.org";
+      extensionDir = "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}";
+    };
+    thunderbird = {
+      fullName = "Thunderbird";
+      addonIdSuffix = "thunderbird.mozilla.org";
+      extensionDir = "{3550f703-e582-4d05-9a08-453d09bdfdc6}";
+    };
+  };
+
+  mozPlatforms = {
+    i686-linux = "linux-i686";
+    x86_64-linux = "linux-x86_64";
+  };
+
+  mozLangpackSources = builtins.fromJSON (builtins.readFile ./sources.json);
+}

--- a/pkgs/mozilla-langpack/sources.json
+++ b/pkgs/mozilla-langpack/sources.json
@@ -1,0 +1,4613 @@
+{
+  "firefox": {
+    "101": {
+      "linux-i686": {
+        "ach": {
+          "hash": "sha512-nuEw1Olrtz7C7AG9dfqiaHvLYgcn9E4ZnuF9s+UjJU4KDovY0YE/TuvrgOV1uiCzEmd9I6SZSq3GpNT7m7+luA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ach.xpi",
+          "version": "101.0.1"
+        },
+        "af": {
+          "hash": "sha512-yd3rTd1t2HBMF/Xdi/jr24gdiK0bseAXN7cLoO/TN0/aCCkSOvy/v5i3cL5MKBpxT7qy7jDW/O/z6sv6OY352w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/af.xpi",
+          "version": "101.0.1"
+        },
+        "an": {
+          "hash": "sha512-+n1nXVLVR8cWjkAuapxPRoehsd0lHo517Y0LfhcZYOJ2KuQtlNlQ0ZJUZ7YZUUEQHdC2YsOZGYIv8v3SokhhPw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/an.xpi",
+          "version": "101.0.1"
+        },
+        "ar": {
+          "hash": "sha512-3Ip2xH63ywXIxBHacGaCC3ZtW3rxksHuklZHn7Jo8tgpRCEz6Ac7quKUW20YkqjGqkDxwMx5CBnz5O8RzuBMbA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ar.xpi",
+          "version": "101.0.1"
+        },
+        "ast": {
+          "hash": "sha512-l3fFkiJGs9AQZSGRqQqloL6dCTjQQy/p46KBnM8Hx9YF7X6qHY4G8QPe13uUOvs6Fs2ZlQQOdp/Z4yilvVBxyA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ast.xpi",
+          "version": "101.0.1"
+        },
+        "az": {
+          "hash": "sha512-e3q/+lo6uex5wGH63bVJIjPGMgYVA4Z/xZGuJDjSlOp3g4+VXRrduH73llUz8JkKDkrgaCB58ndSBPuVyiZtgg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/az.xpi",
+          "version": "101.0.1"
+        },
+        "be": {
+          "hash": "sha512-TBbaYJmb5Viq4lAE4Sp1zgYGHvyJbtX2EpgbEuxsKTs7ao2ND3MsqbRobBoGcdQ1nhFcS7LmHr5hsthsw00oUQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/be.xpi",
+          "version": "101.0.1"
+        },
+        "bg": {
+          "hash": "sha512-gFlmd5ow1RfzN1XE/umxYHmv1R7awuq9oypk1xiDfSvUcxkwL++U57heY+wbyGpjvjCLfxLBhHtbf/dZ1VaEMg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/bg.xpi",
+          "version": "101.0.1"
+        },
+        "bn": {
+          "hash": "sha512-tJEGQrlYsPW437Nwj5c7mFA5xMw1ky/Gs9HwrSSuLfdUV7HRA7orOYZKZR1KPA8ZMBrClQTbfMfDOcR1c4K1og==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/bn.xpi",
+          "version": "101.0.1"
+        },
+        "br": {
+          "hash": "sha512-32X58M8b2HWsN2tcbG6PLm24haiFc7aqQDI+Cb3Ad5AWT+AdJQl1hFyDpfVM+Dbj93pHYD2GEQsix15NoiMfpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/br.xpi",
+          "version": "101.0.1"
+        },
+        "bs": {
+          "hash": "sha512-evNVOnp3O9XCbhbDiLfNB+CX6Ik32+6Dw/qPMUY/eEWSOmKmVa60uny7BsxrzRKK1snrH+1MdrWUzI8IvgHQBA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/bs.xpi",
+          "version": "101.0.1"
+        },
+        "ca": {
+          "hash": "sha512-lLEKHYARAVIwQzaXba1XaB/aMcB3YRb0tr/I4W0W2PsUlFtHDl716t9LSCqMY+1wXeBZOQIeg3KVE01aFO3SGA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ca.xpi",
+          "version": "101.0.1"
+        },
+        "ca-valencia": {
+          "hash": "sha512-Rpf3TyWLha8FFr2FIRQ4Zx/9U5Ri1Y0+rEnlNcOowKDU//fayX2r9Q9023eqzPnWZNU0ZjMSKIrWUpDBi8DcBQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ca-valencia.xpi",
+          "version": "101.0.1"
+        },
+        "cak": {
+          "hash": "sha512-3tK+k9lG3ozIFTRhLA8XzCCpkD+PR/1poH08ILftL1m2Gp8G1iIwJM+v7s35gD6NJlckgJlVabkbQls0phbFew==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/cak.xpi",
+          "version": "101.0.1"
+        },
+        "cs": {
+          "hash": "sha512-VBYSjEo42m7q8Ux0dU+wnnavXR+NzIsm9VzN0CTihP5NzTp8IN/cFNXI4+mkjAxOgNe+DG5sOPJ4NnvHoCDghA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/cs.xpi",
+          "version": "101.0.1"
+        },
+        "cy": {
+          "hash": "sha512-kuaFEvH39YPeBM9f4qW/CV8UnmkfXKKVQOU8fgVtpFqulz+QUZpYt7n82OP5RKHXGSlOctHZltaDOrUEILOzaw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/cy.xpi",
+          "version": "101.0.1"
+        },
+        "da": {
+          "hash": "sha512-KdKe68t1tb0PGfplmvjIOecweFSll6WbNFvwvPliF92VlsJKqwVtmIs/X5trMsl+EUOyRJ1AX/29Vh8i3AiRsA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/da.xpi",
+          "version": "101.0.1"
+        },
+        "de": {
+          "hash": "sha512-t+N/IN9XwCouISIcnNzbiUVYX/tzhZjCcvczNjCeMfQM3SPDq89rBIt1mogH3q7S1eAFQmJVtdyK3+CdLjuL3Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/de.xpi",
+          "version": "101.0.1"
+        },
+        "dsb": {
+          "hash": "sha512-nHLZQBS/hZrsyimM9yeL5KuWgmMf4zA+z4hjxfyCUY5PxGijG6XIqP3rNicSLtPFSjdiH4qBcmnQ4eIA+QQsLw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/dsb.xpi",
+          "version": "101.0.1"
+        },
+        "el": {
+          "hash": "sha512-HcXCIMv4KUY89iLrfSg5Wm+2hRXpx0rjFrEmSQkB78r4S7jFaCwF8gfvxUU3mD4gWfSZHh359iNvq9p8rcePlg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/el.xpi",
+          "version": "101.0.1"
+        },
+        "en-CA": {
+          "hash": "sha512-wUwMHG3SifL6L/sB1ISM3s8vQFSUCCxpD4nYUklQuMzZQQNAo+cxStzi6NPVE+MVy44DFQl8qvYc9bEHRuwCUA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/en-CA.xpi",
+          "version": "101.0.1"
+        },
+        "en-GB": {
+          "hash": "sha512-F/3dfKOyNk8uKCEktoxyUJC4BkRGdn+GbdRW6bd+G1Vw1BM9N4ObgN77w+OIz4STij/q7Mu9ZbduOKnCpWN3FQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/en-GB.xpi",
+          "version": "101.0.1"
+        },
+        "en-US": {
+          "hash": "sha512-xwlW/eHl/c5tBY7S0reUlTr7Y9Eg3wo2Q8LceXYk7dq7WjNa7LG13ccoTtxlYot/06wBX8zS36ORhwLhPMUzLA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/en-US.xpi",
+          "version": "101.0.1"
+        },
+        "eo": {
+          "hash": "sha512-fJp+ELWq0hLD3o3VeZQQ/gsf+A872qwIxqi2knYn1WpqNfJ4t90yg1EN43U5ppx/g1ZlPsOVnQ7zM5YiLxmlEA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/eo.xpi",
+          "version": "101.0.1"
+        },
+        "es-AR": {
+          "hash": "sha512-0dJyuEthNUCjOF/jySKP3fNxjvHebGOxH3UJYdJ8O5hfwsPJBhg7F1vFyi59j1FRK7rLl8juuwZHoWsN+PoHYg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-AR.xpi",
+          "version": "101.0.1"
+        },
+        "es-CL": {
+          "hash": "sha512-uicZK9Xmlmk3I/R1N1jkpeaz84metVH4BvhMAnOQ06FPB0+i+qMxcjbFvA7F8vNH7ZecWL9GdNlpj2vy1ykcCw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-CL.xpi",
+          "version": "101.0.1"
+        },
+        "es-ES": {
+          "hash": "sha512-OscmHqSvShPAWyGns24YdogFnvhAe8nHMSApMYNcSJ7KsBsW4Um37/uBErsFYSzbKO0cytdI5jT4kQAAIZzkIg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-ES.xpi",
+          "version": "101.0.1"
+        },
+        "es-MX": {
+          "hash": "sha512-ApTn+bn4nCyrCySU2pNp9RdVk0sXaMr5f7j8Ga/gAYGAjJpLgmu7l01GedsZbPRl97jPZjJa/6q6u0r5LvsDbw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-MX.xpi",
+          "version": "101.0.1"
+        },
+        "et": {
+          "hash": "sha512-kRC4Ev/6oA6K2YxooeqHKmDZdJCC5UPwTe51mCQD8WqZrYmjFaHKVdyA8aoh4AtiqKROs3EftGpgDxK8L0PZWg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/et.xpi",
+          "version": "101.0.1"
+        },
+        "eu": {
+          "hash": "sha512-OZtN5rzARiWre3i4+O+Co4sU9X+GSItb0PKZNL3faK7+iWuLgsb2kLmoInq4cydR8ia9Pf8/R3fDp1spKO9AMw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/eu.xpi",
+          "version": "101.0.1"
+        },
+        "fa": {
+          "hash": "sha512-7MqibXhGFBtdT2a0p/8BlmBw+QQTj7JVp/0BcbBccPBHZWCRe06LYRy5BgvCZMWgWN6hJIKl+k4LX3dFoUMqdg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fa.xpi",
+          "version": "101.0.1"
+        },
+        "ff": {
+          "hash": "sha512-FH26UEt0uPnKcZZYl8e8vX4PHbaBLA9ld279pLyb2/skrCT2/ONn6wl3j37vGTsNSyP3Nqjzs/qpG/woB86LTQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ff.xpi",
+          "version": "101.0.1"
+        },
+        "fi": {
+          "hash": "sha512-MBVa3obS8+3WVtf+xASiNCxmszvUdbXyRi/mr1PGyL2hmpw1l89UC8//3QWSdsDxiUMDDkCbLs1hsYWGM4hgBQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fi.xpi",
+          "version": "101.0.1"
+        },
+        "fr": {
+          "hash": "sha512-Ntj/CIjA9G27awtsKp4LWkzEYARxNBz9E0vqShrn1S7VBfPlwtSRR0cneg7UvdiiQe4mdhfkTos5uM13iDsRCQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fr.xpi",
+          "version": "101.0.1"
+        },
+        "fy-NL": {
+          "hash": "sha512-9CICKmEGhglQJ/7npuYwdl/6jiO0TU9hvGvpDhRm4s97NKklqLJfj6YZ187IyEkV+QukaFeLd88GHupkoSq3aw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fy-NL.xpi",
+          "version": "101.0.1"
+        },
+        "ga-IE": {
+          "hash": "sha512-UrQpKPVAmgDuxXYjyVGYFmiEr6xlFYdBmmqybS7iPrIGVVyh0nJiv4N6bkOV/9DxdLhx0OWQHOwBuczDeuQlMw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ga-IE.xpi",
+          "version": "101.0.1"
+        },
+        "gd": {
+          "hash": "sha512-rEz0kf+oROxeeifVDy+8VcdGpCRw7NP/XSjZQGLU+wZTI1xWFz/xF4GnobWyzKvV4/0OPxEBesKTeG9jFxvMQg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gd.xpi",
+          "version": "101.0.1"
+        },
+        "gl": {
+          "hash": "sha512-aqiUW8e75oIENZuUSvFJyUK68mWiehzLBLPRl7saBsn5BfG/jlItnri6cmeLsJtxfWqOm/6Ey+4RnjbbMVykEg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gl.xpi",
+          "version": "101.0.1"
+        },
+        "gn": {
+          "hash": "sha512-FzZ7I7+OPWSNBOgeitzovRMOdBkMz9/jYIVAZKe/iczvGVQ7YMxonOzZaBc4+oH4bRPkFnDaHz4btke+F35duQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gn.xpi",
+          "version": "101.0.1"
+        },
+        "gu-IN": {
+          "hash": "sha512-H/lNNIo0gNeCCXXZxhk2GkTFQzfFYfJGEs3WoKZPHQdq2iV1Don06ZjbGs534zF5muzlXXEFpNJ2XWOZM4aypw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gu-IN.xpi",
+          "version": "101.0.1"
+        },
+        "he": {
+          "hash": "sha512-w5RNn5AG0NbhiaCqF+eF1eQVbIckPKDzc94UyitGBwkvrYKfkiPw2Lu3xe+3ndV1Yc3TNuyBYV/duAMiTppw4w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/he.xpi",
+          "version": "101.0.1"
+        },
+        "hi-IN": {
+          "hash": "sha512-rMhs9R+9zIGhujSS3BEVsZ7j+nZMh1fqNOZLPRea2WCvsS8F7BjB1bnpheQOz/zEJ9AdjmwhpGtHg2FT7COWoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hi-IN.xpi",
+          "version": "101.0.1"
+        },
+        "hr": {
+          "hash": "sha512-zVxU4ZZ4eYqSTazv8YLtFuWcI/EQNCL+IwptbnDyI5UTcZ/mCxuRxgt+998dAeu7qKHs3iqilO9hx46Y8FzEzA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hr.xpi",
+          "version": "101.0.1"
+        },
+        "hsb": {
+          "hash": "sha512-lt0EcBLfhGtBeDNafvH+i2BV8Tf0SuYX0lebmLC7h7LS0pwqGycO3NynBYiwB8c1CPe48cNtXYqYopwBHzMfcQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hsb.xpi",
+          "version": "101.0.1"
+        },
+        "hu": {
+          "hash": "sha512-6WEdY4dGCfmUlxobYAe1rLdakVEiaXu1TA+sRVgFX46cyftbi8CJLNX6iq+wL9O4gyir68qclnwu5poUtR7b+A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hu.xpi",
+          "version": "101.0.1"
+        },
+        "hy-AM": {
+          "hash": "sha512-aoKZV4x4JjVtgjLnJGiXdS0dMowEAdWKDDQUgFxsoYFS9fgDdhIbWrJB5YrCRHESXqaa7H4FvZ4I8+jsO7BI+w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hy-AM.xpi",
+          "version": "101.0.1"
+        },
+        "ia": {
+          "hash": "sha512-HfzTjtdTtPt0pgxzDKn8iHcM3a/LfcyCy0r4bPc2P+RGy09pV7FI4mJX4HskJHn1gC2NM69e7sbxtQivehMZXg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ia.xpi",
+          "version": "101.0.1"
+        },
+        "id": {
+          "hash": "sha512-nWpHpLesZKvdNc/gsfxhwJqbHocTeT/GGkmGf2ELlhAGWh7wIo37p4JFuKA1sCITNM452UfQX0ZOSRFc9GjfGg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/id.xpi",
+          "version": "101.0.1"
+        },
+        "is": {
+          "hash": "sha512-oAnHJC8cPTIDlsQVGhOctk0IcWzGKCf1LaYCgYV/7IE8Il6jWgJO7dk023Yig0ByeWB1qp9olnW1FPoqg1nOWw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/is.xpi",
+          "version": "101.0.1"
+        },
+        "it": {
+          "hash": "sha512-hPjtKiFBPVcl1xqyYzgU11blf60I2yDIphXKlPGnwEDhcKV+oVtj2n4kXpIe7L0N8NxPceLNugejVd9RM8NryA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/it.xpi",
+          "version": "101.0.1"
+        },
+        "ja": {
+          "hash": "sha512-vOGVdgQWzl39/vz8rPU7QT0/ptxvNo4yR68yEgqI3FjBKoKXWzoFNRdncjRI5uUsNqIp5yTzDpeGG5e20PpCtQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ja.xpi",
+          "version": "101.0.1"
+        },
+        "ka": {
+          "hash": "sha512-/5AzE+yNDrwYnNZKTTRxt5ZRwZ7x2oKM9GbuQE+opqwmZK98rROCiqmuSfYX9RtloP++ynYnbDbs98NLLT1ubQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ka.xpi",
+          "version": "101.0.1"
+        },
+        "kab": {
+          "hash": "sha512-FeEBFNwsDe5bvN6CB6y9dZSOm/jwtl4DDC23pdNTx1tA79cP7FlWecergbRh7h7ePbA/IOrtqhDP9jK1hOgW0Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/kab.xpi",
+          "version": "101.0.1"
+        },
+        "kk": {
+          "hash": "sha512-k1O1reWZE/XKkWfN3sN0zl7J9G3tfVuOuDmwzQKayZ0hI+BjdChWzcRYrfgl8GNf/52HgrP6XxHXWIhsnO4JaA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/kk.xpi",
+          "version": "101.0.1"
+        },
+        "km": {
+          "hash": "sha512-igGpXJBKmFUKx123B5fZU4beDbf8Bm/34GQxHZke+uFXgeymYsV7v2LCA7CrowaBModBpkerXiTglmeglUrE1g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/km.xpi",
+          "version": "101.0.1"
+        },
+        "kn": {
+          "hash": "sha512-V3cPtJmHOxQFB5MMUB+t03QWcI7amT9fUpW1ngVglmDAFabW+o0DmCg2c2uBNhKXCKZ7izcQh+4vSOK7xECoDA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/kn.xpi",
+          "version": "101.0.1"
+        },
+        "ko": {
+          "hash": "sha512-Wqj/VFIrarUcdXazTCRavftZ5zhOvEKWy5zNTL0jV8IbxkQoQiYuSjXTyMerwUK0dAzPKOhbEUYSW6jNUqRRBg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ko.xpi",
+          "version": "101.0.1"
+        },
+        "lij": {
+          "hash": "sha512-HwOUk3su90qK0xlPFiGcc8LBHcgRqxwRexl7+/yW0lXwA3/H/WHLqQzev3tL60P/lqNbQQNNs4KxSOmW4F/XdQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/lij.xpi",
+          "version": "101.0.1"
+        },
+        "lt": {
+          "hash": "sha512-vO6lS0XrgDnYJrKOSMusIWLlhAUMRSIeW/RofcMpyeAo/3Oc9CGNl8yspe+fqJqsd/+6JlETGpyTKOlOPnPITQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/lt.xpi",
+          "version": "101.0.1"
+        },
+        "lv": {
+          "hash": "sha512-DrFKrvALJcmPBsWhvnhvg6+bHZ0CfKZV5SR0R3OsS7Qkp3ljxdk4hccM5nGazHCzitk0UISyZMoJkugjuxXV5A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/lv.xpi",
+          "version": "101.0.1"
+        },
+        "mk": {
+          "hash": "sha512-pXLcZ3qcgiovdaitgeOzDkW3wBi6wzjtjwTf2BAhzudLRIb/P+4DD4ic4gLHPnPXW4NI/1W9pLuC3bf43PB+wQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/mk.xpi",
+          "version": "101.0.1"
+        },
+        "mr": {
+          "hash": "sha512-KVMjhoO3SlaCqwCp0VEL5IjcwfmiPxbjOq5drj3zS2OxGPWmsjkb8I1E9lSRftgNGdQImDvGCGJSvWaBl8z4Xg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/mr.xpi",
+          "version": "101.0.1"
+        },
+        "ms": {
+          "hash": "sha512-VAhpep1ULFWd5gmd6n9Yhg8ylB3s6W0EztspPwWQVhew0aOt9+qodaUwN9mUujxZTgIIlQAA8OGsBbf6JW/Q3g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ms.xpi",
+          "version": "101.0.1"
+        },
+        "my": {
+          "hash": "sha512-tmH7HD7zJU6jsz6M1ExmiF7JSuMvqtx0Iw5tk6y+E84nywgG8l8tXy+YumoFocXhhUmf76kOJUELL/lK4m7+Sw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/my.xpi",
+          "version": "101.0.1"
+        },
+        "nb-NO": {
+          "hash": "sha512-6G0e0x7sbIph2av+OZcadMXYI+r6iFYDKVmzfRkGOa3x1wrG2M3ogPRk+7hFIgK/cOknN6MGG6UO3M7FtffzPw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/nb-NO.xpi",
+          "version": "101.0.1"
+        },
+        "ne-NP": {
+          "hash": "sha512-MHXzX9vZYeHCmsj3qfF71qUKsXfMUE11VP3yg0R485cs5sa/F8a7AZhBd4bAc0M0I4AqeDY2qbhYwsG2lJsdlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ne-NP.xpi",
+          "version": "101.0.1"
+        },
+        "nl": {
+          "hash": "sha512-QbNfW5WHCsMzRoaxn4L0lYKhpZksPtEu9CHT+7k+WPq44dQzss/JguWCOlxY060+le2CB7ngPZ40MLN1isBknw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/nl.xpi",
+          "version": "101.0.1"
+        },
+        "nn-NO": {
+          "hash": "sha512-eXF4NToXtLW6Db/BF+08KjjT0JPzBhISUWO4kOZupupNjIdA1iewWdKXAcJ6Xmcw5EA4RLCt1C6UZICf8N7yFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/nn-NO.xpi",
+          "version": "101.0.1"
+        },
+        "oc": {
+          "hash": "sha512-cnAmDFON7naaXYzqz2ka5gIZWtjx3RfokNv1hVlnE+kBhQa7M1yeh+AlHe72fmQ6TjCvU7ojbERtW70W6or5dQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/oc.xpi",
+          "version": "101.0.1"
+        },
+        "pa-IN": {
+          "hash": "sha512-r/M9Y0lvKPhDXOQQ68oY3+z6+noyHYP6g6UagLA7BTXewYeMM0XojzF5HzxogX6IPQbWRqgkKXLnf6Y0KCbvQg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pa-IN.xpi",
+          "version": "101.0.1"
+        },
+        "pl": {
+          "hash": "sha512-I5uwSkHYs4a5ykq4nTBntFJowtgAECLnCjdVMroLbRNmvBGCUW6Wk22bK2dKXaq+o10ZyZFeMyOGDPpzyC8S4Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pl.xpi",
+          "version": "101.0.1"
+        },
+        "pt-BR": {
+          "hash": "sha512-j1PM5YSW9eHdvP63OEmembHrg98DnNFk+V2oShBXtfZR8JgXpqDHfLxdxiJRLFkWqwxVk8wvNO6htqFUFVibEg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pt-BR.xpi",
+          "version": "101.0.1"
+        },
+        "pt-PT": {
+          "hash": "sha512-NATYnIZi/MtC5hF5foX9wb8fY82s2JdDEvAoVI8c5+VPnOck3Zrnt/Na/5XTFT4iTP/khark2HD49vl/wQFHCw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pt-PT.xpi",
+          "version": "101.0.1"
+        },
+        "rm": {
+          "hash": "sha512-TyOXb6kQBOjPeCiGdTWrq2lRpZYOoU2yGmKS6zbS3vNhCPuvohcm6ZdxXM+W3n0qf1nnpjVcGdipEr3giEANcw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/rm.xpi",
+          "version": "101.0.1"
+        },
+        "ro": {
+          "hash": "sha512-Aeth9hddONx2CEkHoPgJVtET7ugrptdhFtdfhQ51Saybq/E+uLRA1uBpGy8JHzPdizC7FkguvglHL451UDRFag==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ro.xpi",
+          "version": "101.0.1"
+        },
+        "ru": {
+          "hash": "sha512-E8qjUEc6T/CI/h8RgCfgz3gZb1v2IZvKSkNyTdYV6CNcE8FOIXBy1HzodCsrrkbI49mp+a2tgNik9yKJWHA7oQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ru.xpi",
+          "version": "101.0.1"
+        },
+        "sco": {
+          "hash": "sha512-GLPDmnQ3Nt7jq/dgpFzqNc3lXUW20p5CX0uqVWg2+93MZTa2xZOHzacOg7cd8Q3cVGTTKNV7cu8M7Um9DXMJ0Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sco.xpi",
+          "version": "101.0.1"
+        },
+        "si": {
+          "hash": "sha512-rxTECYGRUoc5ykXU35+RGBBvIg3Lfa8Qdc5O98sFMNQKy8JWmtqeSK8Z6vttWa4J0P5XvntOcewBThVHolDPNw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/si.xpi",
+          "version": "101.0.1"
+        },
+        "sk": {
+          "hash": "sha512-t9ej9Nyqy/ADipyK8afOAlVkjGojAnlZKesgR4ORZy1/XalFO3wbHcJ5ENzz7UM7PaxqyDc6gs82o3c5C8Wj0Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sk.xpi",
+          "version": "101.0.1"
+        },
+        "sl": {
+          "hash": "sha512-EHR5AM0+3ZYVrq60sKVKUVgiYoXQLQhU0BuU0Xa7R2zQVN9RHIskS1U6ayhBZwBkk+ORkfjbXZcssS7z2RKXRg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sl.xpi",
+          "version": "101.0.1"
+        },
+        "son": {
+          "hash": "sha512-WphxvXDS6p17dKWnixJsUDQz7HL6+typkHaQFaf5G/cdJ2tRCKPGldE+VHJSgFU7NfuCWiCL1Tm4YkKNaAvnNA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/son.xpi",
+          "version": "101.0.1"
+        },
+        "sq": {
+          "hash": "sha512-jFJncZ3H9U+bKzLTMvso80GaWrlc3W4sOrpkaKzENh7MLPnNb9sxPPjfrv/6qfDlBIcH8Q00zMSKBAJrX53cTQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sq.xpi",
+          "version": "101.0.1"
+        },
+        "sr": {
+          "hash": "sha512-MCUglPxmDN+Or6ZUqR6DtWXVbibyRDz6b80UdZA1CC+mzYct7ciZ2iB88ixVi0bGka/euuAy97rPK8BcGHJL1g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sr.xpi",
+          "version": "101.0.1"
+        },
+        "sv-SE": {
+          "hash": "sha512-yRDVE+7mloFFgO/LcTFU0eyKmYxK3EJpdpBCU3UIF3bOT28/56w2lnAT/cU/6mxHGQygDR4J1A/t0YhIE2FoGQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sv-SE.xpi",
+          "version": "101.0.1"
+        },
+        "szl": {
+          "hash": "sha512-r+Ff43PDJSZDVf6NOvIWgfyUf6OMoyUHM3p+BzgA/Qx/e2wl5JN+zOxjCyY1U8fOfD4tfxr596WNuVJdxz98GQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/szl.xpi",
+          "version": "101.0.1"
+        },
+        "ta": {
+          "hash": "sha512-Y1r9or/uPpTkXbH/HtwxdvWIqmBalLagoIjtdHPJop+40jJV/yb9M5gaBizNuvnxQaZEFZ/smWPlVNM6OXBehg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ta.xpi",
+          "version": "101.0.1"
+        },
+        "te": {
+          "hash": "sha512-yk85fYeek/5yr4w2llVxxougBrKH9zq/HcEWTOEPrOx8noPv5+XXx7sxjVgMA6COt3sfg9LnF4vKhOxJdaPUcQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/te.xpi",
+          "version": "101.0.1"
+        },
+        "th": {
+          "hash": "sha512-nhhCqnxVFskVc0Brz8VFrdt/DfSyFzgwoIC9S3xIjCsFVHmY3t/7kTn09481uiGRq2DhJwJ60LXG/Hgcsf/Xtw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/th.xpi",
+          "version": "101.0.1"
+        },
+        "tl": {
+          "hash": "sha512-PnwGbMv9mj+VTQk0AwHwbvJhoVqO5F7XReh3OAPLhABgcKc2lnjxVxlG8z806Loxq15XdSnDQ4mpIzHG67RewA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/tl.xpi",
+          "version": "101.0.1"
+        },
+        "tr": {
+          "hash": "sha512-3mCjYYNek8qXssANZdrWlFRsVSsdvkGfdo7+xtOgGSMz0BMINJN2SovdtdzgfCKJIFw7rQEUYUT5UhZbgPaHwg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/tr.xpi",
+          "version": "101.0.1"
+        },
+        "trs": {
+          "hash": "sha512-DoAf4bPi+bm6U7KfUFiDbH6jbTpeQ1z4K/cLEYWwKkTfCRDNZnTUbRmeUiiceo+J2u4UMg54oVg8ASQ5bJ/ZYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/trs.xpi",
+          "version": "101.0.1"
+        },
+        "uk": {
+          "hash": "sha512-R0kAC159cqHMNFped+XBkdSuuSg+mZ1VIIHSC5Nqt3dtRAnMdzJ1rXSYCoiKv1X5GrCcLoIwkM5m+ZQVzvYSQA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/uk.xpi",
+          "version": "101.0.1"
+        },
+        "ur": {
+          "hash": "sha512-I5uPe1nmaAmdl+RrDzS8lKBqcP/cjocgjRc5mwxJEs9jYR84UxprMI2IVB6kBg4WIiXIAf/mD0PDliVOpvr+Rw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ur.xpi",
+          "version": "101.0.1"
+        },
+        "uz": {
+          "hash": "sha512-dHifXoqydpmxM9D0IZsPAXqrih6ZRFP31iLnL5sNT+N1Q5+s7kL14pqMqHQyQTpyIGbmjrSgwaB/e2xBcmrJuQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/uz.xpi",
+          "version": "101.0.1"
+        },
+        "vi": {
+          "hash": "sha512-QpkYQfOKCyUvCa5EWSgw0KI2T+6nxAGFbwRb7QUKh012SC0vZmj53niFCJmuT8gskjzZFs9u/tpLQca6po/uTQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/vi.xpi",
+          "version": "101.0.1"
+        },
+        "xh": {
+          "hash": "sha512-LN0NypBHOFRBqCCKhGCbF3KAYeS2mOwgZtHNL1RmJAnuRhu0RLPYveYwNIZ8++9EjgT4X0UgS60CLfWOibj3Tw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/xh.xpi",
+          "version": "101.0.1"
+        },
+        "zh-CN": {
+          "hash": "sha512-hIRirhjaYteaphY9yw5TrbSsD+AxqA3R86C5QxAgYFSGgviSGwJDHfVS/YF7vSRrrFZj4JF2LrHsBAMI80/mOQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/zh-CN.xpi",
+          "version": "101.0.1"
+        },
+        "zh-TW": {
+          "hash": "sha512-IvqHJgQhiVgT9bMmnooyDSS0R3utXGEI0LaPgK/qrqLZDTZ8Q2pJ1kNSOgC/+99MVwx9VUTT5vGXehxbBHOztQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/zh-TW.xpi",
+          "version": "101.0.1"
+        }
+      },
+      "linux-x86_64": {
+        "ach": {
+          "hash": "sha512-nuEw1Olrtz7C7AG9dfqiaHvLYgcn9E4ZnuF9s+UjJU4KDovY0YE/TuvrgOV1uiCzEmd9I6SZSq3GpNT7m7+luA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ach.xpi",
+          "version": "101.0.1"
+        },
+        "af": {
+          "hash": "sha512-yd3rTd1t2HBMF/Xdi/jr24gdiK0bseAXN7cLoO/TN0/aCCkSOvy/v5i3cL5MKBpxT7qy7jDW/O/z6sv6OY352w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/af.xpi",
+          "version": "101.0.1"
+        },
+        "an": {
+          "hash": "sha512-+n1nXVLVR8cWjkAuapxPRoehsd0lHo517Y0LfhcZYOJ2KuQtlNlQ0ZJUZ7YZUUEQHdC2YsOZGYIv8v3SokhhPw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/an.xpi",
+          "version": "101.0.1"
+        },
+        "ar": {
+          "hash": "sha512-3Ip2xH63ywXIxBHacGaCC3ZtW3rxksHuklZHn7Jo8tgpRCEz6Ac7quKUW20YkqjGqkDxwMx5CBnz5O8RzuBMbA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ar.xpi",
+          "version": "101.0.1"
+        },
+        "ast": {
+          "hash": "sha512-l3fFkiJGs9AQZSGRqQqloL6dCTjQQy/p46KBnM8Hx9YF7X6qHY4G8QPe13uUOvs6Fs2ZlQQOdp/Z4yilvVBxyA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ast.xpi",
+          "version": "101.0.1"
+        },
+        "az": {
+          "hash": "sha512-e3q/+lo6uex5wGH63bVJIjPGMgYVA4Z/xZGuJDjSlOp3g4+VXRrduH73llUz8JkKDkrgaCB58ndSBPuVyiZtgg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/az.xpi",
+          "version": "101.0.1"
+        },
+        "be": {
+          "hash": "sha512-TBbaYJmb5Viq4lAE4Sp1zgYGHvyJbtX2EpgbEuxsKTs7ao2ND3MsqbRobBoGcdQ1nhFcS7LmHr5hsthsw00oUQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/be.xpi",
+          "version": "101.0.1"
+        },
+        "bg": {
+          "hash": "sha512-gFlmd5ow1RfzN1XE/umxYHmv1R7awuq9oypk1xiDfSvUcxkwL++U57heY+wbyGpjvjCLfxLBhHtbf/dZ1VaEMg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/bg.xpi",
+          "version": "101.0.1"
+        },
+        "bn": {
+          "hash": "sha512-tJEGQrlYsPW437Nwj5c7mFA5xMw1ky/Gs9HwrSSuLfdUV7HRA7orOYZKZR1KPA8ZMBrClQTbfMfDOcR1c4K1og==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/bn.xpi",
+          "version": "101.0.1"
+        },
+        "br": {
+          "hash": "sha512-32X58M8b2HWsN2tcbG6PLm24haiFc7aqQDI+Cb3Ad5AWT+AdJQl1hFyDpfVM+Dbj93pHYD2GEQsix15NoiMfpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/br.xpi",
+          "version": "101.0.1"
+        },
+        "bs": {
+          "hash": "sha512-evNVOnp3O9XCbhbDiLfNB+CX6Ik32+6Dw/qPMUY/eEWSOmKmVa60uny7BsxrzRKK1snrH+1MdrWUzI8IvgHQBA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/bs.xpi",
+          "version": "101.0.1"
+        },
+        "ca": {
+          "hash": "sha512-lLEKHYARAVIwQzaXba1XaB/aMcB3YRb0tr/I4W0W2PsUlFtHDl716t9LSCqMY+1wXeBZOQIeg3KVE01aFO3SGA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ca.xpi",
+          "version": "101.0.1"
+        },
+        "ca-valencia": {
+          "hash": "sha512-Rpf3TyWLha8FFr2FIRQ4Zx/9U5Ri1Y0+rEnlNcOowKDU//fayX2r9Q9023eqzPnWZNU0ZjMSKIrWUpDBi8DcBQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ca-valencia.xpi",
+          "version": "101.0.1"
+        },
+        "cak": {
+          "hash": "sha512-3tK+k9lG3ozIFTRhLA8XzCCpkD+PR/1poH08ILftL1m2Gp8G1iIwJM+v7s35gD6NJlckgJlVabkbQls0phbFew==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/cak.xpi",
+          "version": "101.0.1"
+        },
+        "cs": {
+          "hash": "sha512-VBYSjEo42m7q8Ux0dU+wnnavXR+NzIsm9VzN0CTihP5NzTp8IN/cFNXI4+mkjAxOgNe+DG5sOPJ4NnvHoCDghA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/cs.xpi",
+          "version": "101.0.1"
+        },
+        "cy": {
+          "hash": "sha512-kuaFEvH39YPeBM9f4qW/CV8UnmkfXKKVQOU8fgVtpFqulz+QUZpYt7n82OP5RKHXGSlOctHZltaDOrUEILOzaw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/cy.xpi",
+          "version": "101.0.1"
+        },
+        "da": {
+          "hash": "sha512-KdKe68t1tb0PGfplmvjIOecweFSll6WbNFvwvPliF92VlsJKqwVtmIs/X5trMsl+EUOyRJ1AX/29Vh8i3AiRsA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/da.xpi",
+          "version": "101.0.1"
+        },
+        "de": {
+          "hash": "sha512-t+N/IN9XwCouISIcnNzbiUVYX/tzhZjCcvczNjCeMfQM3SPDq89rBIt1mogH3q7S1eAFQmJVtdyK3+CdLjuL3Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/de.xpi",
+          "version": "101.0.1"
+        },
+        "dsb": {
+          "hash": "sha512-nHLZQBS/hZrsyimM9yeL5KuWgmMf4zA+z4hjxfyCUY5PxGijG6XIqP3rNicSLtPFSjdiH4qBcmnQ4eIA+QQsLw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/dsb.xpi",
+          "version": "101.0.1"
+        },
+        "el": {
+          "hash": "sha512-HcXCIMv4KUY89iLrfSg5Wm+2hRXpx0rjFrEmSQkB78r4S7jFaCwF8gfvxUU3mD4gWfSZHh359iNvq9p8rcePlg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/el.xpi",
+          "version": "101.0.1"
+        },
+        "en-CA": {
+          "hash": "sha512-wUwMHG3SifL6L/sB1ISM3s8vQFSUCCxpD4nYUklQuMzZQQNAo+cxStzi6NPVE+MVy44DFQl8qvYc9bEHRuwCUA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/en-CA.xpi",
+          "version": "101.0.1"
+        },
+        "en-GB": {
+          "hash": "sha512-F/3dfKOyNk8uKCEktoxyUJC4BkRGdn+GbdRW6bd+G1Vw1BM9N4ObgN77w+OIz4STij/q7Mu9ZbduOKnCpWN3FQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/en-GB.xpi",
+          "version": "101.0.1"
+        },
+        "en-US": {
+          "hash": "sha512-xwlW/eHl/c5tBY7S0reUlTr7Y9Eg3wo2Q8LceXYk7dq7WjNa7LG13ccoTtxlYot/06wBX8zS36ORhwLhPMUzLA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/en-US.xpi",
+          "version": "101.0.1"
+        },
+        "eo": {
+          "hash": "sha512-fJp+ELWq0hLD3o3VeZQQ/gsf+A872qwIxqi2knYn1WpqNfJ4t90yg1EN43U5ppx/g1ZlPsOVnQ7zM5YiLxmlEA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/eo.xpi",
+          "version": "101.0.1"
+        },
+        "es-AR": {
+          "hash": "sha512-0dJyuEthNUCjOF/jySKP3fNxjvHebGOxH3UJYdJ8O5hfwsPJBhg7F1vFyi59j1FRK7rLl8juuwZHoWsN+PoHYg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-AR.xpi",
+          "version": "101.0.1"
+        },
+        "es-CL": {
+          "hash": "sha512-uicZK9Xmlmk3I/R1N1jkpeaz84metVH4BvhMAnOQ06FPB0+i+qMxcjbFvA7F8vNH7ZecWL9GdNlpj2vy1ykcCw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-CL.xpi",
+          "version": "101.0.1"
+        },
+        "es-ES": {
+          "hash": "sha512-OscmHqSvShPAWyGns24YdogFnvhAe8nHMSApMYNcSJ7KsBsW4Um37/uBErsFYSzbKO0cytdI5jT4kQAAIZzkIg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-ES.xpi",
+          "version": "101.0.1"
+        },
+        "es-MX": {
+          "hash": "sha512-ApTn+bn4nCyrCySU2pNp9RdVk0sXaMr5f7j8Ga/gAYGAjJpLgmu7l01GedsZbPRl97jPZjJa/6q6u0r5LvsDbw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-MX.xpi",
+          "version": "101.0.1"
+        },
+        "et": {
+          "hash": "sha512-kRC4Ev/6oA6K2YxooeqHKmDZdJCC5UPwTe51mCQD8WqZrYmjFaHKVdyA8aoh4AtiqKROs3EftGpgDxK8L0PZWg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/et.xpi",
+          "version": "101.0.1"
+        },
+        "eu": {
+          "hash": "sha512-OZtN5rzARiWre3i4+O+Co4sU9X+GSItb0PKZNL3faK7+iWuLgsb2kLmoInq4cydR8ia9Pf8/R3fDp1spKO9AMw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/eu.xpi",
+          "version": "101.0.1"
+        },
+        "fa": {
+          "hash": "sha512-7MqibXhGFBtdT2a0p/8BlmBw+QQTj7JVp/0BcbBccPBHZWCRe06LYRy5BgvCZMWgWN6hJIKl+k4LX3dFoUMqdg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fa.xpi",
+          "version": "101.0.1"
+        },
+        "ff": {
+          "hash": "sha512-FH26UEt0uPnKcZZYl8e8vX4PHbaBLA9ld279pLyb2/skrCT2/ONn6wl3j37vGTsNSyP3Nqjzs/qpG/woB86LTQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ff.xpi",
+          "version": "101.0.1"
+        },
+        "fi": {
+          "hash": "sha512-MBVa3obS8+3WVtf+xASiNCxmszvUdbXyRi/mr1PGyL2hmpw1l89UC8//3QWSdsDxiUMDDkCbLs1hsYWGM4hgBQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fi.xpi",
+          "version": "101.0.1"
+        },
+        "fr": {
+          "hash": "sha512-Ntj/CIjA9G27awtsKp4LWkzEYARxNBz9E0vqShrn1S7VBfPlwtSRR0cneg7UvdiiQe4mdhfkTos5uM13iDsRCQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fr.xpi",
+          "version": "101.0.1"
+        },
+        "fy-NL": {
+          "hash": "sha512-9CICKmEGhglQJ/7npuYwdl/6jiO0TU9hvGvpDhRm4s97NKklqLJfj6YZ187IyEkV+QukaFeLd88GHupkoSq3aw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fy-NL.xpi",
+          "version": "101.0.1"
+        },
+        "ga-IE": {
+          "hash": "sha512-UrQpKPVAmgDuxXYjyVGYFmiEr6xlFYdBmmqybS7iPrIGVVyh0nJiv4N6bkOV/9DxdLhx0OWQHOwBuczDeuQlMw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ga-IE.xpi",
+          "version": "101.0.1"
+        },
+        "gd": {
+          "hash": "sha512-rEz0kf+oROxeeifVDy+8VcdGpCRw7NP/XSjZQGLU+wZTI1xWFz/xF4GnobWyzKvV4/0OPxEBesKTeG9jFxvMQg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gd.xpi",
+          "version": "101.0.1"
+        },
+        "gl": {
+          "hash": "sha512-aqiUW8e75oIENZuUSvFJyUK68mWiehzLBLPRl7saBsn5BfG/jlItnri6cmeLsJtxfWqOm/6Ey+4RnjbbMVykEg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gl.xpi",
+          "version": "101.0.1"
+        },
+        "gn": {
+          "hash": "sha512-FzZ7I7+OPWSNBOgeitzovRMOdBkMz9/jYIVAZKe/iczvGVQ7YMxonOzZaBc4+oH4bRPkFnDaHz4btke+F35duQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gn.xpi",
+          "version": "101.0.1"
+        },
+        "gu-IN": {
+          "hash": "sha512-H/lNNIo0gNeCCXXZxhk2GkTFQzfFYfJGEs3WoKZPHQdq2iV1Don06ZjbGs534zF5muzlXXEFpNJ2XWOZM4aypw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gu-IN.xpi",
+          "version": "101.0.1"
+        },
+        "he": {
+          "hash": "sha512-w5RNn5AG0NbhiaCqF+eF1eQVbIckPKDzc94UyitGBwkvrYKfkiPw2Lu3xe+3ndV1Yc3TNuyBYV/duAMiTppw4w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/he.xpi",
+          "version": "101.0.1"
+        },
+        "hi-IN": {
+          "hash": "sha512-rMhs9R+9zIGhujSS3BEVsZ7j+nZMh1fqNOZLPRea2WCvsS8F7BjB1bnpheQOz/zEJ9AdjmwhpGtHg2FT7COWoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hi-IN.xpi",
+          "version": "101.0.1"
+        },
+        "hr": {
+          "hash": "sha512-zVxU4ZZ4eYqSTazv8YLtFuWcI/EQNCL+IwptbnDyI5UTcZ/mCxuRxgt+998dAeu7qKHs3iqilO9hx46Y8FzEzA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hr.xpi",
+          "version": "101.0.1"
+        },
+        "hsb": {
+          "hash": "sha512-lt0EcBLfhGtBeDNafvH+i2BV8Tf0SuYX0lebmLC7h7LS0pwqGycO3NynBYiwB8c1CPe48cNtXYqYopwBHzMfcQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hsb.xpi",
+          "version": "101.0.1"
+        },
+        "hu": {
+          "hash": "sha512-6WEdY4dGCfmUlxobYAe1rLdakVEiaXu1TA+sRVgFX46cyftbi8CJLNX6iq+wL9O4gyir68qclnwu5poUtR7b+A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hu.xpi",
+          "version": "101.0.1"
+        },
+        "hy-AM": {
+          "hash": "sha512-aoKZV4x4JjVtgjLnJGiXdS0dMowEAdWKDDQUgFxsoYFS9fgDdhIbWrJB5YrCRHESXqaa7H4FvZ4I8+jsO7BI+w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hy-AM.xpi",
+          "version": "101.0.1"
+        },
+        "ia": {
+          "hash": "sha512-HfzTjtdTtPt0pgxzDKn8iHcM3a/LfcyCy0r4bPc2P+RGy09pV7FI4mJX4HskJHn1gC2NM69e7sbxtQivehMZXg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ia.xpi",
+          "version": "101.0.1"
+        },
+        "id": {
+          "hash": "sha512-nWpHpLesZKvdNc/gsfxhwJqbHocTeT/GGkmGf2ELlhAGWh7wIo37p4JFuKA1sCITNM452UfQX0ZOSRFc9GjfGg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/id.xpi",
+          "version": "101.0.1"
+        },
+        "is": {
+          "hash": "sha512-oAnHJC8cPTIDlsQVGhOctk0IcWzGKCf1LaYCgYV/7IE8Il6jWgJO7dk023Yig0ByeWB1qp9olnW1FPoqg1nOWw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/is.xpi",
+          "version": "101.0.1"
+        },
+        "it": {
+          "hash": "sha512-hPjtKiFBPVcl1xqyYzgU11blf60I2yDIphXKlPGnwEDhcKV+oVtj2n4kXpIe7L0N8NxPceLNugejVd9RM8NryA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/it.xpi",
+          "version": "101.0.1"
+        },
+        "ja": {
+          "hash": "sha512-vOGVdgQWzl39/vz8rPU7QT0/ptxvNo4yR68yEgqI3FjBKoKXWzoFNRdncjRI5uUsNqIp5yTzDpeGG5e20PpCtQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ja.xpi",
+          "version": "101.0.1"
+        },
+        "ka": {
+          "hash": "sha512-/5AzE+yNDrwYnNZKTTRxt5ZRwZ7x2oKM9GbuQE+opqwmZK98rROCiqmuSfYX9RtloP++ynYnbDbs98NLLT1ubQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ka.xpi",
+          "version": "101.0.1"
+        },
+        "kab": {
+          "hash": "sha512-FeEBFNwsDe5bvN6CB6y9dZSOm/jwtl4DDC23pdNTx1tA79cP7FlWecergbRh7h7ePbA/IOrtqhDP9jK1hOgW0Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/kab.xpi",
+          "version": "101.0.1"
+        },
+        "kk": {
+          "hash": "sha512-k1O1reWZE/XKkWfN3sN0zl7J9G3tfVuOuDmwzQKayZ0hI+BjdChWzcRYrfgl8GNf/52HgrP6XxHXWIhsnO4JaA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/kk.xpi",
+          "version": "101.0.1"
+        },
+        "km": {
+          "hash": "sha512-igGpXJBKmFUKx123B5fZU4beDbf8Bm/34GQxHZke+uFXgeymYsV7v2LCA7CrowaBModBpkerXiTglmeglUrE1g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/km.xpi",
+          "version": "101.0.1"
+        },
+        "kn": {
+          "hash": "sha512-V3cPtJmHOxQFB5MMUB+t03QWcI7amT9fUpW1ngVglmDAFabW+o0DmCg2c2uBNhKXCKZ7izcQh+4vSOK7xECoDA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/kn.xpi",
+          "version": "101.0.1"
+        },
+        "ko": {
+          "hash": "sha512-Wqj/VFIrarUcdXazTCRavftZ5zhOvEKWy5zNTL0jV8IbxkQoQiYuSjXTyMerwUK0dAzPKOhbEUYSW6jNUqRRBg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ko.xpi",
+          "version": "101.0.1"
+        },
+        "lij": {
+          "hash": "sha512-HwOUk3su90qK0xlPFiGcc8LBHcgRqxwRexl7+/yW0lXwA3/H/WHLqQzev3tL60P/lqNbQQNNs4KxSOmW4F/XdQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/lij.xpi",
+          "version": "101.0.1"
+        },
+        "lt": {
+          "hash": "sha512-vO6lS0XrgDnYJrKOSMusIWLlhAUMRSIeW/RofcMpyeAo/3Oc9CGNl8yspe+fqJqsd/+6JlETGpyTKOlOPnPITQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/lt.xpi",
+          "version": "101.0.1"
+        },
+        "lv": {
+          "hash": "sha512-DrFKrvALJcmPBsWhvnhvg6+bHZ0CfKZV5SR0R3OsS7Qkp3ljxdk4hccM5nGazHCzitk0UISyZMoJkugjuxXV5A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/lv.xpi",
+          "version": "101.0.1"
+        },
+        "mk": {
+          "hash": "sha512-pXLcZ3qcgiovdaitgeOzDkW3wBi6wzjtjwTf2BAhzudLRIb/P+4DD4ic4gLHPnPXW4NI/1W9pLuC3bf43PB+wQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/mk.xpi",
+          "version": "101.0.1"
+        },
+        "mr": {
+          "hash": "sha512-KVMjhoO3SlaCqwCp0VEL5IjcwfmiPxbjOq5drj3zS2OxGPWmsjkb8I1E9lSRftgNGdQImDvGCGJSvWaBl8z4Xg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/mr.xpi",
+          "version": "101.0.1"
+        },
+        "ms": {
+          "hash": "sha512-VAhpep1ULFWd5gmd6n9Yhg8ylB3s6W0EztspPwWQVhew0aOt9+qodaUwN9mUujxZTgIIlQAA8OGsBbf6JW/Q3g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ms.xpi",
+          "version": "101.0.1"
+        },
+        "my": {
+          "hash": "sha512-tmH7HD7zJU6jsz6M1ExmiF7JSuMvqtx0Iw5tk6y+E84nywgG8l8tXy+YumoFocXhhUmf76kOJUELL/lK4m7+Sw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/my.xpi",
+          "version": "101.0.1"
+        },
+        "nb-NO": {
+          "hash": "sha512-6G0e0x7sbIph2av+OZcadMXYI+r6iFYDKVmzfRkGOa3x1wrG2M3ogPRk+7hFIgK/cOknN6MGG6UO3M7FtffzPw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/nb-NO.xpi",
+          "version": "101.0.1"
+        },
+        "ne-NP": {
+          "hash": "sha512-MHXzX9vZYeHCmsj3qfF71qUKsXfMUE11VP3yg0R485cs5sa/F8a7AZhBd4bAc0M0I4AqeDY2qbhYwsG2lJsdlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ne-NP.xpi",
+          "version": "101.0.1"
+        },
+        "nl": {
+          "hash": "sha512-QbNfW5WHCsMzRoaxn4L0lYKhpZksPtEu9CHT+7k+WPq44dQzss/JguWCOlxY060+le2CB7ngPZ40MLN1isBknw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/nl.xpi",
+          "version": "101.0.1"
+        },
+        "nn-NO": {
+          "hash": "sha512-eXF4NToXtLW6Db/BF+08KjjT0JPzBhISUWO4kOZupupNjIdA1iewWdKXAcJ6Xmcw5EA4RLCt1C6UZICf8N7yFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/nn-NO.xpi",
+          "version": "101.0.1"
+        },
+        "oc": {
+          "hash": "sha512-cnAmDFON7naaXYzqz2ka5gIZWtjx3RfokNv1hVlnE+kBhQa7M1yeh+AlHe72fmQ6TjCvU7ojbERtW70W6or5dQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/oc.xpi",
+          "version": "101.0.1"
+        },
+        "pa-IN": {
+          "hash": "sha512-r/M9Y0lvKPhDXOQQ68oY3+z6+noyHYP6g6UagLA7BTXewYeMM0XojzF5HzxogX6IPQbWRqgkKXLnf6Y0KCbvQg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pa-IN.xpi",
+          "version": "101.0.1"
+        },
+        "pl": {
+          "hash": "sha512-I5uwSkHYs4a5ykq4nTBntFJowtgAECLnCjdVMroLbRNmvBGCUW6Wk22bK2dKXaq+o10ZyZFeMyOGDPpzyC8S4Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pl.xpi",
+          "version": "101.0.1"
+        },
+        "pt-BR": {
+          "hash": "sha512-j1PM5YSW9eHdvP63OEmembHrg98DnNFk+V2oShBXtfZR8JgXpqDHfLxdxiJRLFkWqwxVk8wvNO6htqFUFVibEg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pt-BR.xpi",
+          "version": "101.0.1"
+        },
+        "pt-PT": {
+          "hash": "sha512-NATYnIZi/MtC5hF5foX9wb8fY82s2JdDEvAoVI8c5+VPnOck3Zrnt/Na/5XTFT4iTP/khark2HD49vl/wQFHCw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pt-PT.xpi",
+          "version": "101.0.1"
+        },
+        "rm": {
+          "hash": "sha512-TyOXb6kQBOjPeCiGdTWrq2lRpZYOoU2yGmKS6zbS3vNhCPuvohcm6ZdxXM+W3n0qf1nnpjVcGdipEr3giEANcw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/rm.xpi",
+          "version": "101.0.1"
+        },
+        "ro": {
+          "hash": "sha512-Aeth9hddONx2CEkHoPgJVtET7ugrptdhFtdfhQ51Saybq/E+uLRA1uBpGy8JHzPdizC7FkguvglHL451UDRFag==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ro.xpi",
+          "version": "101.0.1"
+        },
+        "ru": {
+          "hash": "sha512-E8qjUEc6T/CI/h8RgCfgz3gZb1v2IZvKSkNyTdYV6CNcE8FOIXBy1HzodCsrrkbI49mp+a2tgNik9yKJWHA7oQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ru.xpi",
+          "version": "101.0.1"
+        },
+        "sco": {
+          "hash": "sha512-GLPDmnQ3Nt7jq/dgpFzqNc3lXUW20p5CX0uqVWg2+93MZTa2xZOHzacOg7cd8Q3cVGTTKNV7cu8M7Um9DXMJ0Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sco.xpi",
+          "version": "101.0.1"
+        },
+        "si": {
+          "hash": "sha512-rxTECYGRUoc5ykXU35+RGBBvIg3Lfa8Qdc5O98sFMNQKy8JWmtqeSK8Z6vttWa4J0P5XvntOcewBThVHolDPNw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/si.xpi",
+          "version": "101.0.1"
+        },
+        "sk": {
+          "hash": "sha512-t9ej9Nyqy/ADipyK8afOAlVkjGojAnlZKesgR4ORZy1/XalFO3wbHcJ5ENzz7UM7PaxqyDc6gs82o3c5C8Wj0Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sk.xpi",
+          "version": "101.0.1"
+        },
+        "sl": {
+          "hash": "sha512-EHR5AM0+3ZYVrq60sKVKUVgiYoXQLQhU0BuU0Xa7R2zQVN9RHIskS1U6ayhBZwBkk+ORkfjbXZcssS7z2RKXRg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sl.xpi",
+          "version": "101.0.1"
+        },
+        "son": {
+          "hash": "sha512-WphxvXDS6p17dKWnixJsUDQz7HL6+typkHaQFaf5G/cdJ2tRCKPGldE+VHJSgFU7NfuCWiCL1Tm4YkKNaAvnNA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/son.xpi",
+          "version": "101.0.1"
+        },
+        "sq": {
+          "hash": "sha512-jFJncZ3H9U+bKzLTMvso80GaWrlc3W4sOrpkaKzENh7MLPnNb9sxPPjfrv/6qfDlBIcH8Q00zMSKBAJrX53cTQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sq.xpi",
+          "version": "101.0.1"
+        },
+        "sr": {
+          "hash": "sha512-MCUglPxmDN+Or6ZUqR6DtWXVbibyRDz6b80UdZA1CC+mzYct7ciZ2iB88ixVi0bGka/euuAy97rPK8BcGHJL1g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sr.xpi",
+          "version": "101.0.1"
+        },
+        "sv-SE": {
+          "hash": "sha512-yRDVE+7mloFFgO/LcTFU0eyKmYxK3EJpdpBCU3UIF3bOT28/56w2lnAT/cU/6mxHGQygDR4J1A/t0YhIE2FoGQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sv-SE.xpi",
+          "version": "101.0.1"
+        },
+        "szl": {
+          "hash": "sha512-r+Ff43PDJSZDVf6NOvIWgfyUf6OMoyUHM3p+BzgA/Qx/e2wl5JN+zOxjCyY1U8fOfD4tfxr596WNuVJdxz98GQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/szl.xpi",
+          "version": "101.0.1"
+        },
+        "ta": {
+          "hash": "sha512-Y1r9or/uPpTkXbH/HtwxdvWIqmBalLagoIjtdHPJop+40jJV/yb9M5gaBizNuvnxQaZEFZ/smWPlVNM6OXBehg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ta.xpi",
+          "version": "101.0.1"
+        },
+        "te": {
+          "hash": "sha512-yk85fYeek/5yr4w2llVxxougBrKH9zq/HcEWTOEPrOx8noPv5+XXx7sxjVgMA6COt3sfg9LnF4vKhOxJdaPUcQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/te.xpi",
+          "version": "101.0.1"
+        },
+        "th": {
+          "hash": "sha512-nhhCqnxVFskVc0Brz8VFrdt/DfSyFzgwoIC9S3xIjCsFVHmY3t/7kTn09481uiGRq2DhJwJ60LXG/Hgcsf/Xtw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/th.xpi",
+          "version": "101.0.1"
+        },
+        "tl": {
+          "hash": "sha512-PnwGbMv9mj+VTQk0AwHwbvJhoVqO5F7XReh3OAPLhABgcKc2lnjxVxlG8z806Loxq15XdSnDQ4mpIzHG67RewA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/tl.xpi",
+          "version": "101.0.1"
+        },
+        "tr": {
+          "hash": "sha512-3mCjYYNek8qXssANZdrWlFRsVSsdvkGfdo7+xtOgGSMz0BMINJN2SovdtdzgfCKJIFw7rQEUYUT5UhZbgPaHwg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/tr.xpi",
+          "version": "101.0.1"
+        },
+        "trs": {
+          "hash": "sha512-DoAf4bPi+bm6U7KfUFiDbH6jbTpeQ1z4K/cLEYWwKkTfCRDNZnTUbRmeUiiceo+J2u4UMg54oVg8ASQ5bJ/ZYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/trs.xpi",
+          "version": "101.0.1"
+        },
+        "uk": {
+          "hash": "sha512-R0kAC159cqHMNFped+XBkdSuuSg+mZ1VIIHSC5Nqt3dtRAnMdzJ1rXSYCoiKv1X5GrCcLoIwkM5m+ZQVzvYSQA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/uk.xpi",
+          "version": "101.0.1"
+        },
+        "ur": {
+          "hash": "sha512-I5uPe1nmaAmdl+RrDzS8lKBqcP/cjocgjRc5mwxJEs9jYR84UxprMI2IVB6kBg4WIiXIAf/mD0PDliVOpvr+Rw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ur.xpi",
+          "version": "101.0.1"
+        },
+        "uz": {
+          "hash": "sha512-dHifXoqydpmxM9D0IZsPAXqrih6ZRFP31iLnL5sNT+N1Q5+s7kL14pqMqHQyQTpyIGbmjrSgwaB/e2xBcmrJuQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/uz.xpi",
+          "version": "101.0.1"
+        },
+        "vi": {
+          "hash": "sha512-QpkYQfOKCyUvCa5EWSgw0KI2T+6nxAGFbwRb7QUKh012SC0vZmj53niFCJmuT8gskjzZFs9u/tpLQca6po/uTQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/vi.xpi",
+          "version": "101.0.1"
+        },
+        "xh": {
+          "hash": "sha512-LN0NypBHOFRBqCCKhGCbF3KAYeS2mOwgZtHNL1RmJAnuRhu0RLPYveYwNIZ8++9EjgT4X0UgS60CLfWOibj3Tw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/xh.xpi",
+          "version": "101.0.1"
+        },
+        "zh-CN": {
+          "hash": "sha512-hIRirhjaYteaphY9yw5TrbSsD+AxqA3R86C5QxAgYFSGgviSGwJDHfVS/YF7vSRrrFZj4JF2LrHsBAMI80/mOQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/zh-CN.xpi",
+          "version": "101.0.1"
+        },
+        "zh-TW": {
+          "hash": "sha512-IvqHJgQhiVgT9bMmnooyDSS0R3utXGEI0LaPgK/qrqLZDTZ8Q2pJ1kNSOgC/+99MVwx9VUTT5vGXehxbBHOztQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/zh-TW.xpi",
+          "version": "101.0.1"
+        }
+      }
+    },
+    "102": {
+      "linux-i686": {
+        "ach": {
+          "hash": "sha512-1wMz8tb1N/WgAYehZqA+OhJ+hrJ2G7nA3PUyW0OneKw0z1lqqkcjysQaDoRXFJsgCDo6smLB9uRkWJPZMiUEDA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ach.xpi",
+          "version": "102.0.1"
+        },
+        "af": {
+          "hash": "sha512-PWkQuA9PtwoZklTqd1UIrwj9PJgSYgR6gS94KkQQinmRUP2tN6faBbHHoj9eJ/+GgSST8DzqplGPr55ivo9Zlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/af.xpi",
+          "version": "102.0.1"
+        },
+        "an": {
+          "hash": "sha512-8yEe21AGF2gV/pLirSVepmpdWOJgDARMSKHEtJdlTol+qGk+feWA3nMZAvjtXVLpakH6OkFprDasuKm2BL0UQg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/an.xpi",
+          "version": "102.0.1"
+        },
+        "ar": {
+          "hash": "sha512-XooVTJMZGJgcAWFEPgr89XzY8rNKU8/E2feD2optztbIJ1UEMqhvMsnNWq/sl6tedDp6+0AdpPkzwjT+j19DYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ar.xpi",
+          "version": "102.0.1"
+        },
+        "ast": {
+          "hash": "sha512-PgoABB/375ZoLP9bd2cGWNUHIyu3iMgiGbgzoBRSx5s/W8bwirj6sA/x9JRgF08NUA7bMv7rrf9pac2A9/F76A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ast.xpi",
+          "version": "102.0.1"
+        },
+        "az": {
+          "hash": "sha512-QO7per+zRx1iyijEJG8PlXteCMOYQGj3GazFBIwgO5nHZPMKaLsUs+f5gMg4ilxZ8NpCxO7L6lHuXI51+Dr1rg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/az.xpi",
+          "version": "102.0.1"
+        },
+        "be": {
+          "hash": "sha512-FSmlnQoSbe+pL0RDAZid5hLLxVd25P1jkxXj1wV2fYHuD+saV2ntnaTIHxLLo0CwbjgUiFeaW8uUqh9y9YNFuw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/be.xpi",
+          "version": "102.0.1"
+        },
+        "bg": {
+          "hash": "sha512-3AoQlIeQZ63sTUuHVrr8hTN1kWF10oFB7c7P6sVrgirFphMneL6QL8IxVXlzY3ADSM3OD672RQP/D8Rt9In/cg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/bg.xpi",
+          "version": "102.0.1"
+        },
+        "bn": {
+          "hash": "sha512-4p9uBEaCLrHk1IJs6IkF41eU/f01/JhaZWqOCiC9zNCADuNtzarHLzdhplrK3Ow+dsW0ncLP+4wCgcCTdJkqPg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/bn.xpi",
+          "version": "102.0.1"
+        },
+        "br": {
+          "hash": "sha512-Oo/N7O7vsAYCY021+t05cK4pvsPeElYQ1y9MvAMiFB3dUZhyzY3zob3f4W8LQKgPuiMvx7m9vdBldEYk4EoReA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/br.xpi",
+          "version": "102.0.1"
+        },
+        "bs": {
+          "hash": "sha512-tkgXYF3ztMTRp85hTLN72zjRw9cOpZvHJubV/ailTAkwjjgSxmLAAwbYc+aMNjDZyirQik9j7Qd/rVBCvcCBaQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/bs.xpi",
+          "version": "102.0.1"
+        },
+        "ca": {
+          "hash": "sha512-096VAUzmi9uULul8FOKFkOtAr/C80SbuD9+E5aJESY8cRzSZXgn+2avfJFRDXtWbIxQpeHsXfE6CDu8fhCjneA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ca.xpi",
+          "version": "102.0.1"
+        },
+        "ca-valencia": {
+          "hash": "sha512-t8pre2OUGvNviVlR9ZUnVU3zvZJYxv3oWzdsNlffzVSgG8GHsrQACYJOM/I0WiZgVq5QkiOMMPie3lXx11zhAw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ca-valencia.xpi",
+          "version": "102.0.1"
+        },
+        "cak": {
+          "hash": "sha512-603PnXxiv8C6FmVKqHAYzmbq0fcsuvEBM2XOJI1082T2gJNbuBTvlZ2IzQ+NMEdDaR+5H1nEF4Zo9JmIPPmRUQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/cak.xpi",
+          "version": "102.0.1"
+        },
+        "cs": {
+          "hash": "sha512-KqWTKRjQE+qoXFyFULMFvSbpQQkYJC39DQvemoU2YcBPv1gBhR6vU1qrNVFEozv+X+DOZQ0cIJ2ao9hh506Kvg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/cs.xpi",
+          "version": "102.0.1"
+        },
+        "cy": {
+          "hash": "sha512-XtcBH1L0Vy5uHJEn1ix970RuQXaLPwytGoDv7NuNr63aVEQKezOz0h5goEJrXHhBSjwE4RuQ8EJkvoaTAFwTbA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/cy.xpi",
+          "version": "102.0.1"
+        },
+        "da": {
+          "hash": "sha512-hLuYkETlxNe7SFkK7wNs5f5unqNq/2/E9f4gxee1XZTsVA/iHK7UdMNqFyxgimVghDt2mg3Ns3p9fd1O4muBig==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/da.xpi",
+          "version": "102.0.1"
+        },
+        "de": {
+          "hash": "sha512-yanOY99XoXDO6JSfja2EzstkSZ8D5dDPZCXody1R0OK965h8sXz7sTYyPNkb+CEmIC9PAZFa9WUMuYZkAhUpfg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/de.xpi",
+          "version": "102.0.1"
+        },
+        "dsb": {
+          "hash": "sha512-SwpPgJb1eAq1bdnqpNKi9yRtAqkERkiHgoDJplWNLxanRzEDOvkLdGFyJsek+gpDe9DvI+gT8N+c69TZYovtHQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/dsb.xpi",
+          "version": "102.0.1"
+        },
+        "el": {
+          "hash": "sha512-D7o0jhlUnGSwf2EeHa9fNSyJU7u7oCMM6eVkZjN9pEs5JptNJ1/lSL4Ienkbd/NYWQpTtFpNJyLD2IrqG8bCNg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/el.xpi",
+          "version": "102.0.1"
+        },
+        "en-CA": {
+          "hash": "sha512-Z9L+rAKxkC9Sexs5AlCVZ3jFH5hbJpBQ+TAY0riF0D9NwBg/ymxG9HeBZKNYcS7/VxLUMTuk2kZu/r4sB7KcpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/en-CA.xpi",
+          "version": "102.0.1"
+        },
+        "en-GB": {
+          "hash": "sha512-a/kWCuGWzpbqLDiMKcYUMFAYVR7jglQwRsiRoHFFGJnoFk3tGbl2bODoYc0LVY85bDn8vxPKuBtJkXPt59yWqA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/en-GB.xpi",
+          "version": "102.0.1"
+        },
+        "en-US": {
+          "hash": "sha512-569lWsRSKDA/DrSMEppQeHU+L5XEJXMonJ2qNvyr4cHYxzPGryk/R8i4h8U0QX4P/rIAl6DAf1XSVbGMxbvq5g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/en-US.xpi",
+          "version": "102.0.1"
+        },
+        "eo": {
+          "hash": "sha512-9mAejQrFnMkt9P1gFbIMox8NycwW2GiW1lXcyutB79eijGm+HmXwCnF+6Ccd+MyB3t4x0ExITpun/pC0HmwrZQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/eo.xpi",
+          "version": "102.0.1"
+        },
+        "es-AR": {
+          "hash": "sha512-njwtU8wiF8mH0CKfuRx1VNu/WdS/Jb1nl3P1RXYjib8gBudL5OtFTDaktfdisrk60lFUfKBPLbt3L85VtXXSUg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-AR.xpi",
+          "version": "102.0.1"
+        },
+        "es-CL": {
+          "hash": "sha512-d8NAwXuOggHr8N39T6Y9D4gDR5PQ3WWPTBZUv3fyuubNcozflnnqXeamcjDJ+POLKqv2mJinrbBvF6hyjzy30Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-CL.xpi",
+          "version": "102.0.1"
+        },
+        "es-ES": {
+          "hash": "sha512-XtBcm4Ur1bDU/nH1esbJ7jOmRYI+yiBqt4t/5BldNY/aCoNn/9qnGVYOKdJGKQ8+qACAx3v3Ldj44veRD+mqeg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-ES.xpi",
+          "version": "102.0.1"
+        },
+        "es-MX": {
+          "hash": "sha512-pp22eKGufcryJMbptb7dSIhEVc8QvidpJoBxTr7diP6wOoy6JImdCmxS2n1DjskczViBhr3KsLUfv7xgaafTig==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-MX.xpi",
+          "version": "102.0.1"
+        },
+        "et": {
+          "hash": "sha512-mEJr+trFgdOJ6gSwKpDHFUQFHbPxD7hu7HCYK9yUmsbqJRHVdYvMtZjSi2F2+mOhFhuvQORahp/v8w4/mcaybA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/et.xpi",
+          "version": "102.0.1"
+        },
+        "eu": {
+          "hash": "sha512-oXTAeYLRMp4lVpP/4g9aUAi8iv0s+Tt6E0RPW/iJXWPbtXClp56WiPvfT61puT8+Yo/ZpULdfseaAoWmNuqtWQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/eu.xpi",
+          "version": "102.0.1"
+        },
+        "fa": {
+          "hash": "sha512-t+gOJWuMZIBsMtvAy+Bnrprgqq1OCPNtphygicDUAl6ZvPWQMJZgweNuD6/R1y66R9hUHHZ71lxWl2fVWvjFvg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fa.xpi",
+          "version": "102.0.1"
+        },
+        "ff": {
+          "hash": "sha512-7tPNwtRrRJrBKPSLibM0zWvKyetqDhNA42nRtiJXruLjEJv2OaUaFubFzxV8NMCnGjEJ0Ergw3n9hivqJKDOKQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ff.xpi",
+          "version": "102.0.1"
+        },
+        "fi": {
+          "hash": "sha512-42QTMp57qSQglPPF2WFzViwf6nubnIPU32tdkVjmeMlFQ4O/S5c08mlWUbwuQ/19vrfwQv2b6vSz+u20QGJ1zw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fi.xpi",
+          "version": "102.0.1"
+        },
+        "fr": {
+          "hash": "sha512-wFjkGRk9AHbv8yvB1ZRB+5Q1SN2MJUB0wFJpOafNasDWQiqVQo3HravB5d7tEspCivwi/uaPPZEWJOoPeFSyEw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fr.xpi",
+          "version": "102.0.1"
+        },
+        "fy-NL": {
+          "hash": "sha512-SeKPJXWV4XxuD1cEKWWbPVhI4olMfzhqqMARA0LTla/czEpB601v5u7gEr4KeC4eamsbUmm7J5zGtq2l81cQvw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fy-NL.xpi",
+          "version": "102.0.1"
+        },
+        "ga-IE": {
+          "hash": "sha512-zG3uwCNtY9hMvaHuOHKyyNMHUxcqNe5nQYBqtEa7zL/ReHMYzC2UmVHjv+1SwJCQwa7GxZk2dXThAc/ncCrrEw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ga-IE.xpi",
+          "version": "102.0.1"
+        },
+        "gd": {
+          "hash": "sha512-Ovcn7EHqJzcrraAXZlJQMriwIA1lx0ed3GL/XZhOi+nKCrZebcLe7Eg7xk5JmFIlWZFDdFf+OxgbS7dmM2HuuQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gd.xpi",
+          "version": "102.0.1"
+        },
+        "gl": {
+          "hash": "sha512-eMvGfmwYTHSKNWF/qWDyvqhaTePkqwEwkTYsSfuXjrxHl5QzDB9B3bkGeOcBplh8B/jT4zzhvhRgczzRKZ7nzQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gl.xpi",
+          "version": "102.0.1"
+        },
+        "gn": {
+          "hash": "sha512-/y0tshuSeDMPuLsyoUZptGygh2SmDB7vu352H/v/QnNcYHRSgQU4UxuEvEBUfcQkoTrArAktYWR5T27jNIURlg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gn.xpi",
+          "version": "102.0.1"
+        },
+        "gu-IN": {
+          "hash": "sha512-ljY6m7P+aNCb8KoCQzTKDkaU77VDL4E0AjJAQF4S3xr3EHc8QMCL1+L1fuVbzUKXfl6ySpPFN95wHXqMibOcyQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gu-IN.xpi",
+          "version": "102.0.1"
+        },
+        "he": {
+          "hash": "sha512-IaCbKjssqcSKInnLUxtWDKrECCEIjNq9ut7RsfNM98GKDAIcBCXfHmKAhjox6pdDWAbPtzhZW/X8XHB29sCLCw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/he.xpi",
+          "version": "102.0.1"
+        },
+        "hi-IN": {
+          "hash": "sha512-eYGOdMqyNyZvN2OnJnJgWXlSgFNJnW1YQQ5VYhh/Gcexr/xmTohcaXwzN3jS/OPDuptXwzsgaje2/1hHpaC7yQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hi-IN.xpi",
+          "version": "102.0.1"
+        },
+        "hr": {
+          "hash": "sha512-sLnX4ZghgtPT1QoA6IUIdtF6gJk1fQe+4mE5VXJkspNFXaw7/3W0pvk8YtmG18t31gRKir5z8Fr5tTujm/LqiA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hr.xpi",
+          "version": "102.0.1"
+        },
+        "hsb": {
+          "hash": "sha512-Ktm3HRnpxJt+643peTXhPzSx+3R5fRSIfNBm1XzSorR/Aw5FWBTsLFXKpDNe5AvMJgnR6HyhRModQgEucpwTDQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hsb.xpi",
+          "version": "102.0.1"
+        },
+        "hu": {
+          "hash": "sha512-82CpWC5p9MAUY+OgGqf0K2A6ZALaNOsFNI78PnAMGkc9H9WcSdpr9BDr9ofi4oAMegAHboPqYenI1UYGxuTfYQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hu.xpi",
+          "version": "102.0.1"
+        },
+        "hy-AM": {
+          "hash": "sha512-FgxxkY7Rop5DctgW5vwugUaGO4/T1hV4zG5NBA3iTJTooNa6A69YPNGGhOwXtSWI8J49/cL6rNiqOnrE1jyHVw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hy-AM.xpi",
+          "version": "102.0.1"
+        },
+        "ia": {
+          "hash": "sha512-9X4uBVia6ysLfBUu2cWUSMTyRuVISAAfHLmJ6+EV+9Kl9cx03qZ/vd878crWjvV9FjURjUi1diMEiArzn5qz8w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ia.xpi",
+          "version": "102.0.1"
+        },
+        "id": {
+          "hash": "sha512-w5Dmou3NIFhGmkT0BPgaeenGnHj37MMS9sPuh3uDQsWhG7W+/XM/ky0BLDW68BujpcPOZ7FARbLGVRq0Lirdtg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/id.xpi",
+          "version": "102.0.1"
+        },
+        "is": {
+          "hash": "sha512-/T7wUz36Zw1ukjNEgIRWYuzPaBgyyecruqP15y41qvcu2Og+HJYJWCTn6OnTv+k2Ft4trDohQ76uEbFS1GZw5A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/is.xpi",
+          "version": "102.0.1"
+        },
+        "it": {
+          "hash": "sha512-gHJd4ISo2+5qifYwJXUps7FxpEo8acuziiJ83OkvwLfRcC54N+5Y9cA8xRa9T4EgJznctaQjZ5i/AWeRY7MGpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/it.xpi",
+          "version": "102.0.1"
+        },
+        "ja": {
+          "hash": "sha512-IDyCk+HNfwvu2oyjks365Dte56t2/PK+HN3KxNjWhssb0m6CKDAZ5a37au5K6MfetvZT91qpid/z6kklqnIi/w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ja.xpi",
+          "version": "102.0.1"
+        },
+        "ka": {
+          "hash": "sha512-E5jhk77zZzkKK82XVTYW8GucB+P++ezhzGd8VqgrhfnUxndGzNIVIV0gblPJh5CZm98/hzNGdqKkokWD/y9uSg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ka.xpi",
+          "version": "102.0.1"
+        },
+        "kab": {
+          "hash": "sha512-p9tjEQaySttcC1Rq1zOwn59vzzcddIpCQYgeHlKI9S+WzvbpHuqXrkYYAevD9tYaPgdtmaxYEGSFg2HzGNGKgw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/kab.xpi",
+          "version": "102.0.1"
+        },
+        "kk": {
+          "hash": "sha512-XdNAHxMM6DqKHd13lo6XFxDDt21dftHsRT8te6DqPtBBbEKcHvrdrjMvPXVdHmd0AiQ+APpT5zcFblZOdIT7qQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/kk.xpi",
+          "version": "102.0.1"
+        },
+        "km": {
+          "hash": "sha512-Mn6Iq83qpKGiGI/O0ZZsxailCMLBL+Ey8OPkSvUzniTBLVIlCZW6Cxt2BIJ+Yc1WWj9VsrQfwr1WDifR7k1HVQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/km.xpi",
+          "version": "102.0.1"
+        },
+        "kn": {
+          "hash": "sha512-v7WcUAQLx8ZCb6Zz8uQIPktNTRSr7emrVaVSkB3nWsHzlL15YTFARPjxBhw0sarXTq8qGVsR2SYVsDzS4mo2Mg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/kn.xpi",
+          "version": "102.0.1"
+        },
+        "ko": {
+          "hash": "sha512-MODi9//qZYgfymyhY6eJ4j26/jmWjAeQ+NUIcYk/WqfADR5OtwlhRnuxqTB1PGQ2+OBuam+Ane4I8aoiPa/weg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ko.xpi",
+          "version": "102.0.1"
+        },
+        "lij": {
+          "hash": "sha512-bq07DBLSoYvPJy0B/A9jMNAB6PgrvCzTX8FbQSMM1jKOpgyhDrPdYGf5oCRL3q+jT4hlgH0M6Fyr0l1mAJpofw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/lij.xpi",
+          "version": "102.0.1"
+        },
+        "lt": {
+          "hash": "sha512-GA+O344AllnFopFdKIzOnTldg+Ff/2vCb7xj+aehyZ54YCOJadV8As2unSzqghSXhpVashQ1sbVY7PFqn+e00Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/lt.xpi",
+          "version": "102.0.1"
+        },
+        "lv": {
+          "hash": "sha512-F/14cY64RQjQOAM1rB+mSCfuCOhnfzoNlFrLBgamqjbIAy8zHqrMvp4+p8OwyQJRL874f3/EbWhsBmwUOogGFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/lv.xpi",
+          "version": "102.0.1"
+        },
+        "mk": {
+          "hash": "sha512-MA+rOm3mUzmhTgo2Vwq3iGXxYKCa/m15VgHDXfIYakiEavYlgjPjRFcLQn+pNWIWXMRrutnS0bquFbim894Wlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/mk.xpi",
+          "version": "102.0.1"
+        },
+        "mr": {
+          "hash": "sha512-hRHFwihJC/fmb2ISjH4tjb/2WdWnKEehKGmZNFj1K+Q6wrmBmgDVsD9v4VoF68RR4Rji32vHEEE+IyLB48GRrQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/mr.xpi",
+          "version": "102.0.1"
+        },
+        "ms": {
+          "hash": "sha512-3a1m9tNUrMJ9DhB+1idcDZtmU/BrIX6tcm/uWL4RDUmjP6kPuPYuaRBHWKjs9MZdQPMsFpsaYMiVgjUJ2s+enA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ms.xpi",
+          "version": "102.0.1"
+        },
+        "my": {
+          "hash": "sha512-5noERpeXv1SVHF7hC4eEd32QqEbIxt48y0pXrSwv3j1RintqLsJlSARRSPk2b+RwGh0snfvmFP281COWzh6ROQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/my.xpi",
+          "version": "102.0.1"
+        },
+        "nb-NO": {
+          "hash": "sha512-PGi8yW44Z1tDMaSSnampIsGwvYAy8ikVhklVUIqMnmivNe6pNok3qAsKLwOcFNjCwuNwcTtuW4JQjiDSMZgtHw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/nb-NO.xpi",
+          "version": "102.0.1"
+        },
+        "ne-NP": {
+          "hash": "sha512-+a50NXUOZFmqTDLR5mg8R6GVtC1Sm9SOgGVs4ulqT+tu1dLETNtXGrG0HhCf1mNQ1PdtcMzATiypcEJeUTFgPQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ne-NP.xpi",
+          "version": "102.0.1"
+        },
+        "nl": {
+          "hash": "sha512-cibfgFY81lWTcgr5e+RHUGKP0NOCbco7UQyv/jmohmdQWm+eBAIDZevaUkWitIzyJLl8VyZZirj2LWl9ygAr2g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/nl.xpi",
+          "version": "102.0.1"
+        },
+        "nn-NO": {
+          "hash": "sha512-ALEC1Gyz00/9V1shCCTzQK4/l25tZ1lXDIyCU24DQfIwH2URMjuaWeMYNNR+8g1xWXqzReytCG76paNLMUg7ZA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/nn-NO.xpi",
+          "version": "102.0.1"
+        },
+        "oc": {
+          "hash": "sha512-H3Ju57kgnhufu2nSQ2mnCW4SkhuQXCVj9Z4CIWcyKGe/RnD1s6I+Q8BMXz6Q5mccAZPSpBtkWt22giYC86oqtw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/oc.xpi",
+          "version": "102.0.1"
+        },
+        "pa-IN": {
+          "hash": "sha512-t/LfjhrTorb85MbtPQiryUuFy1Cn0h0r0WMsERHMxMa5ivJkM0S0zkkXEQA4zCb6I1Nf+lAo8w4BiM94Q8AIoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pa-IN.xpi",
+          "version": "102.0.1"
+        },
+        "pl": {
+          "hash": "sha512-zUQpOQcK8d5wPTBNETlVxklc8ISrIXcJRcae6Fg7umi2Y+tYWyPJb+QDJ3loNbSDtd67Y6Kl5QWIEzMjfAo2HA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pl.xpi",
+          "version": "102.0.1"
+        },
+        "pt-BR": {
+          "hash": "sha512-FiwH6/knN5DxpwNLIk0Bfln8ZnXegjJzGmzAY5Lyg6Z93QXPHdBl5SLP7ZzQDwky+pygopRr+vesummHU6OFUA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pt-BR.xpi",
+          "version": "102.0.1"
+        },
+        "pt-PT": {
+          "hash": "sha512-q6vxpJjkfO5GLgYg8PolmNeYB7Z4vf0tZe5buUblnoxhBF/R1AISGnpV5wg7SWk+9ckNHZHEIY5Y5AkfgyKLXg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pt-PT.xpi",
+          "version": "102.0.1"
+        },
+        "rm": {
+          "hash": "sha512-YJ1osmKqD/Lm+8anlcfGCJ+yYS+E3CTxK1LBob52c7CVubKh+3pmo6iLGQRHcjey+H6lEdEPO9TrUHoIUwRVxg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/rm.xpi",
+          "version": "102.0.1"
+        },
+        "ro": {
+          "hash": "sha512-yiEVGGVZMsbwxPxZfqSQ6afuS7lwfsNkwKa1F6mn5pURHpCJgdF3J8JU+s1JszdJSgxahWbqb7j6imlR6pIvlA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ro.xpi",
+          "version": "102.0.1"
+        },
+        "ru": {
+          "hash": "sha512-skRWytxjtkI5L+FIp+//FPH6g1tOoa2iFV40kTwiOxruun5m9Jc/4pI+7ktJzhUT7iarfXyOWKsv/5NlMPo6Vg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ru.xpi",
+          "version": "102.0.1"
+        },
+        "sco": {
+          "hash": "sha512-VNXouIrPp2J0Uv2RsFcaZYF3i2n6yReBYz4cKG+7QdBHFJu/kWS23akc8/rZv8uupJOeszIQr7p1845HU2N2MA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sco.xpi",
+          "version": "102.0.1"
+        },
+        "si": {
+          "hash": "sha512-UsxfskZaA96dn1VbcF69xqCOXbJq5iMQlk1jHzXW9V8T97GGMLq4hCWp4sTQUd7wzJ5fPv3dOrbnpRzJblBPVw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/si.xpi",
+          "version": "102.0.1"
+        },
+        "sk": {
+          "hash": "sha512-lx/hXGgV9Y4uIeAtM8laEata2lksc62iRYoMJWzYybEc+cZgLL/iIz/JDezEYSkfab807ibtANaEe+yrYtBOAA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sk.xpi",
+          "version": "102.0.1"
+        },
+        "sl": {
+          "hash": "sha512-OjeCSogm/nXwcYfsAz9Ah+RLD6VncWlTGVh8MM4W7wmFpEvmumPIEdvp+XX+h/kisbFLdN4qYHPOm8GGHzLSFQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sl.xpi",
+          "version": "102.0.1"
+        },
+        "son": {
+          "hash": "sha512-71HXnGEBNzpDq77ghwGIevm1kppwvxOuPCdsZol031I17Qp9J8Qznbt06piBn22QgQAu4OsL6D2TSb4ZWHdH+Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/son.xpi",
+          "version": "102.0.1"
+        },
+        "sq": {
+          "hash": "sha512-qELnJUw9Hk2/3gezY/l9lPI6PfXDrzqLg5c5FfAp50Dpzc/VgKSG2O8Gk/u1jyi3dEFXdTlGlY2UVLcw9lSyPw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sq.xpi",
+          "version": "102.0.1"
+        },
+        "sr": {
+          "hash": "sha512-klbQ9xR0v5v2u6LfF+ffkOq9kq24NXyHXCDNztd0cWcPKo9+hh8Q2MhRJxQ6lMsI7ycFenysd3HNEWkoigNW2Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sr.xpi",
+          "version": "102.0.1"
+        },
+        "sv-SE": {
+          "hash": "sha512-DyMRWARA022eFZb/KH220BlhDXhCyFoNYlp3RwebSanOWU04woXhMZ64D2nG7kSTuyY2aetOun9+aOhg3QeLGw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sv-SE.xpi",
+          "version": "102.0.1"
+        },
+        "szl": {
+          "hash": "sha512-3DBmZrvVMxdk4o84lup3/KiYq1C54Rh66TUXKOAqpx02pFm3FII0qqTs0bZk13jaNk80xtyug80PedDXYk2IGg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/szl.xpi",
+          "version": "102.0.1"
+        },
+        "ta": {
+          "hash": "sha512-rXBVrxlyQpHDwZDkcK7eqKuULqB1s5pZM30I1VgL1Iev0KUhG2uHIFQ08rYK8bPMdq8/6fS4ymyuIaFEXmmiYQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ta.xpi",
+          "version": "102.0.1"
+        },
+        "te": {
+          "hash": "sha512-u9oWStf26IFFZsLrfwKpzcSd5WEHHXin7uCFWXrrHgSSrEXdWSDGetSaeDV9WIvxClA3PQ4uw5TQnoVpsqIm9g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/te.xpi",
+          "version": "102.0.1"
+        },
+        "th": {
+          "hash": "sha512-InS/D9uTItNCqorKfR8ubga5MAReOy8aUXGYa3ab/KtM5RNVmakKBcDeD1n1b2HWD492pHSD7f+pbD/1R7pcng==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/th.xpi",
+          "version": "102.0.1"
+        },
+        "tl": {
+          "hash": "sha512-Qxn/2c05Fx8+IMSIhnLs/84qAPkZx2ibQu33TpKRQcDndF179xY9O0LYvUfwE+TLexV0AOpfJZz/qsntMLiG3w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/tl.xpi",
+          "version": "102.0.1"
+        },
+        "tr": {
+          "hash": "sha512-hBi45TGZllPGgcDxPCZz1cv0/WVWZTuRv03vxnznuJzthiWKWVlUMvZ0yQrYT0rX7UF9xEv49XjGlVfzyOxQ8g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/tr.xpi",
+          "version": "102.0.1"
+        },
+        "trs": {
+          "hash": "sha512-da4sIHhPCL+y9z7g9Ov4lFlBAWgjrDMBnHIKZ18b/CIjixo3lxS4dx4uC9jcgPMpuZj8XgzxTlm+MahMTveJ9g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/trs.xpi",
+          "version": "102.0.1"
+        },
+        "uk": {
+          "hash": "sha512-2UjAtuF85D8gnTUwCCcIKkk75YWlSQyhtsEUjmJu22hQCHqAW5zLnwE9ik17nOWgFBo2UWVq/HvFlv+lRE6zkg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/uk.xpi",
+          "version": "102.0.1"
+        },
+        "ur": {
+          "hash": "sha512-zWMUfI3KU0Y14Ia+zukaH2GKsU35FoBP0TVfJwe/ko5xAhECNjSPHBK5qcRQj5Cyf2MLXM2ql0rysEFzs1eIgg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ur.xpi",
+          "version": "102.0.1"
+        },
+        "uz": {
+          "hash": "sha512-G8NP1POT1odyO5d0BjVYE/kVsugrPMZHDWmm7VB8LVoaGcTJrFpVPxAHm7rUuhQD0YhADU5v37F9i+YX77WDrQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/uz.xpi",
+          "version": "102.0.1"
+        },
+        "vi": {
+          "hash": "sha512-UdMr7OwirJdpFt3pUC4wvmUw4mLxATSZ6o9hr3DEXS+K62aF3+hYvjFJTKRdzrVRHPjAO+nKNFJL62i3c9UDUA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/vi.xpi",
+          "version": "102.0.1"
+        },
+        "xh": {
+          "hash": "sha512-BguzJ2bM9lEi4+A5V9dmHvvfg6pr9t5cuMZ1BCNGc4AG6U6IdCdCd83NjYanoV4BJQy28PlHrx6NXhjmK4PdbQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/xh.xpi",
+          "version": "102.0.1"
+        },
+        "zh-CN": {
+          "hash": "sha512-9Ai4latfveY/12SgMMprVMOHqrK/0QbrFGgCN4EwoV+oZ+3kfp56+1k0SIpkh3eyHtpJPpqiGJs6A7O0N48CDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/zh-CN.xpi",
+          "version": "102.0.1"
+        },
+        "zh-TW": {
+          "hash": "sha512-/ThJDr+NTOJHnZQ+hAowskb1So/EzIBLOacoY1Xze1WiDIV61HUrcdEmZ4T/9afNGWBIqUR/nmX9wlgMJSz6HQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/zh-TW.xpi",
+          "version": "102.0.1"
+        }
+      },
+      "linux-x86_64": {
+        "ach": {
+          "hash": "sha512-1wMz8tb1N/WgAYehZqA+OhJ+hrJ2G7nA3PUyW0OneKw0z1lqqkcjysQaDoRXFJsgCDo6smLB9uRkWJPZMiUEDA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ach.xpi",
+          "version": "102.0.1"
+        },
+        "af": {
+          "hash": "sha512-PWkQuA9PtwoZklTqd1UIrwj9PJgSYgR6gS94KkQQinmRUP2tN6faBbHHoj9eJ/+GgSST8DzqplGPr55ivo9Zlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/af.xpi",
+          "version": "102.0.1"
+        },
+        "an": {
+          "hash": "sha512-8yEe21AGF2gV/pLirSVepmpdWOJgDARMSKHEtJdlTol+qGk+feWA3nMZAvjtXVLpakH6OkFprDasuKm2BL0UQg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/an.xpi",
+          "version": "102.0.1"
+        },
+        "ar": {
+          "hash": "sha512-XooVTJMZGJgcAWFEPgr89XzY8rNKU8/E2feD2optztbIJ1UEMqhvMsnNWq/sl6tedDp6+0AdpPkzwjT+j19DYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ar.xpi",
+          "version": "102.0.1"
+        },
+        "ast": {
+          "hash": "sha512-PgoABB/375ZoLP9bd2cGWNUHIyu3iMgiGbgzoBRSx5s/W8bwirj6sA/x9JRgF08NUA7bMv7rrf9pac2A9/F76A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ast.xpi",
+          "version": "102.0.1"
+        },
+        "az": {
+          "hash": "sha512-QO7per+zRx1iyijEJG8PlXteCMOYQGj3GazFBIwgO5nHZPMKaLsUs+f5gMg4ilxZ8NpCxO7L6lHuXI51+Dr1rg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/az.xpi",
+          "version": "102.0.1"
+        },
+        "be": {
+          "hash": "sha512-FSmlnQoSbe+pL0RDAZid5hLLxVd25P1jkxXj1wV2fYHuD+saV2ntnaTIHxLLo0CwbjgUiFeaW8uUqh9y9YNFuw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/be.xpi",
+          "version": "102.0.1"
+        },
+        "bg": {
+          "hash": "sha512-3AoQlIeQZ63sTUuHVrr8hTN1kWF10oFB7c7P6sVrgirFphMneL6QL8IxVXlzY3ADSM3OD672RQP/D8Rt9In/cg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/bg.xpi",
+          "version": "102.0.1"
+        },
+        "bn": {
+          "hash": "sha512-4p9uBEaCLrHk1IJs6IkF41eU/f01/JhaZWqOCiC9zNCADuNtzarHLzdhplrK3Ow+dsW0ncLP+4wCgcCTdJkqPg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/bn.xpi",
+          "version": "102.0.1"
+        },
+        "br": {
+          "hash": "sha512-Oo/N7O7vsAYCY021+t05cK4pvsPeElYQ1y9MvAMiFB3dUZhyzY3zob3f4W8LQKgPuiMvx7m9vdBldEYk4EoReA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/br.xpi",
+          "version": "102.0.1"
+        },
+        "bs": {
+          "hash": "sha512-tkgXYF3ztMTRp85hTLN72zjRw9cOpZvHJubV/ailTAkwjjgSxmLAAwbYc+aMNjDZyirQik9j7Qd/rVBCvcCBaQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/bs.xpi",
+          "version": "102.0.1"
+        },
+        "ca": {
+          "hash": "sha512-096VAUzmi9uULul8FOKFkOtAr/C80SbuD9+E5aJESY8cRzSZXgn+2avfJFRDXtWbIxQpeHsXfE6CDu8fhCjneA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ca.xpi",
+          "version": "102.0.1"
+        },
+        "ca-valencia": {
+          "hash": "sha512-t8pre2OUGvNviVlR9ZUnVU3zvZJYxv3oWzdsNlffzVSgG8GHsrQACYJOM/I0WiZgVq5QkiOMMPie3lXx11zhAw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ca-valencia.xpi",
+          "version": "102.0.1"
+        },
+        "cak": {
+          "hash": "sha512-603PnXxiv8C6FmVKqHAYzmbq0fcsuvEBM2XOJI1082T2gJNbuBTvlZ2IzQ+NMEdDaR+5H1nEF4Zo9JmIPPmRUQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/cak.xpi",
+          "version": "102.0.1"
+        },
+        "cs": {
+          "hash": "sha512-KqWTKRjQE+qoXFyFULMFvSbpQQkYJC39DQvemoU2YcBPv1gBhR6vU1qrNVFEozv+X+DOZQ0cIJ2ao9hh506Kvg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/cs.xpi",
+          "version": "102.0.1"
+        },
+        "cy": {
+          "hash": "sha512-XtcBH1L0Vy5uHJEn1ix970RuQXaLPwytGoDv7NuNr63aVEQKezOz0h5goEJrXHhBSjwE4RuQ8EJkvoaTAFwTbA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/cy.xpi",
+          "version": "102.0.1"
+        },
+        "da": {
+          "hash": "sha512-hLuYkETlxNe7SFkK7wNs5f5unqNq/2/E9f4gxee1XZTsVA/iHK7UdMNqFyxgimVghDt2mg3Ns3p9fd1O4muBig==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/da.xpi",
+          "version": "102.0.1"
+        },
+        "de": {
+          "hash": "sha512-yanOY99XoXDO6JSfja2EzstkSZ8D5dDPZCXody1R0OK965h8sXz7sTYyPNkb+CEmIC9PAZFa9WUMuYZkAhUpfg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/de.xpi",
+          "version": "102.0.1"
+        },
+        "dsb": {
+          "hash": "sha512-SwpPgJb1eAq1bdnqpNKi9yRtAqkERkiHgoDJplWNLxanRzEDOvkLdGFyJsek+gpDe9DvI+gT8N+c69TZYovtHQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/dsb.xpi",
+          "version": "102.0.1"
+        },
+        "el": {
+          "hash": "sha512-D7o0jhlUnGSwf2EeHa9fNSyJU7u7oCMM6eVkZjN9pEs5JptNJ1/lSL4Ienkbd/NYWQpTtFpNJyLD2IrqG8bCNg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/el.xpi",
+          "version": "102.0.1"
+        },
+        "en-CA": {
+          "hash": "sha512-Z9L+rAKxkC9Sexs5AlCVZ3jFH5hbJpBQ+TAY0riF0D9NwBg/ymxG9HeBZKNYcS7/VxLUMTuk2kZu/r4sB7KcpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/en-CA.xpi",
+          "version": "102.0.1"
+        },
+        "en-GB": {
+          "hash": "sha512-a/kWCuGWzpbqLDiMKcYUMFAYVR7jglQwRsiRoHFFGJnoFk3tGbl2bODoYc0LVY85bDn8vxPKuBtJkXPt59yWqA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/en-GB.xpi",
+          "version": "102.0.1"
+        },
+        "en-US": {
+          "hash": "sha512-569lWsRSKDA/DrSMEppQeHU+L5XEJXMonJ2qNvyr4cHYxzPGryk/R8i4h8U0QX4P/rIAl6DAf1XSVbGMxbvq5g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/en-US.xpi",
+          "version": "102.0.1"
+        },
+        "eo": {
+          "hash": "sha512-9mAejQrFnMkt9P1gFbIMox8NycwW2GiW1lXcyutB79eijGm+HmXwCnF+6Ccd+MyB3t4x0ExITpun/pC0HmwrZQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/eo.xpi",
+          "version": "102.0.1"
+        },
+        "es-AR": {
+          "hash": "sha512-njwtU8wiF8mH0CKfuRx1VNu/WdS/Jb1nl3P1RXYjib8gBudL5OtFTDaktfdisrk60lFUfKBPLbt3L85VtXXSUg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-AR.xpi",
+          "version": "102.0.1"
+        },
+        "es-CL": {
+          "hash": "sha512-d8NAwXuOggHr8N39T6Y9D4gDR5PQ3WWPTBZUv3fyuubNcozflnnqXeamcjDJ+POLKqv2mJinrbBvF6hyjzy30Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-CL.xpi",
+          "version": "102.0.1"
+        },
+        "es-ES": {
+          "hash": "sha512-XtBcm4Ur1bDU/nH1esbJ7jOmRYI+yiBqt4t/5BldNY/aCoNn/9qnGVYOKdJGKQ8+qACAx3v3Ldj44veRD+mqeg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-ES.xpi",
+          "version": "102.0.1"
+        },
+        "es-MX": {
+          "hash": "sha512-pp22eKGufcryJMbptb7dSIhEVc8QvidpJoBxTr7diP6wOoy6JImdCmxS2n1DjskczViBhr3KsLUfv7xgaafTig==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-MX.xpi",
+          "version": "102.0.1"
+        },
+        "et": {
+          "hash": "sha512-mEJr+trFgdOJ6gSwKpDHFUQFHbPxD7hu7HCYK9yUmsbqJRHVdYvMtZjSi2F2+mOhFhuvQORahp/v8w4/mcaybA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/et.xpi",
+          "version": "102.0.1"
+        },
+        "eu": {
+          "hash": "sha512-oXTAeYLRMp4lVpP/4g9aUAi8iv0s+Tt6E0RPW/iJXWPbtXClp56WiPvfT61puT8+Yo/ZpULdfseaAoWmNuqtWQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/eu.xpi",
+          "version": "102.0.1"
+        },
+        "fa": {
+          "hash": "sha512-t+gOJWuMZIBsMtvAy+Bnrprgqq1OCPNtphygicDUAl6ZvPWQMJZgweNuD6/R1y66R9hUHHZ71lxWl2fVWvjFvg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fa.xpi",
+          "version": "102.0.1"
+        },
+        "ff": {
+          "hash": "sha512-7tPNwtRrRJrBKPSLibM0zWvKyetqDhNA42nRtiJXruLjEJv2OaUaFubFzxV8NMCnGjEJ0Ergw3n9hivqJKDOKQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ff.xpi",
+          "version": "102.0.1"
+        },
+        "fi": {
+          "hash": "sha512-42QTMp57qSQglPPF2WFzViwf6nubnIPU32tdkVjmeMlFQ4O/S5c08mlWUbwuQ/19vrfwQv2b6vSz+u20QGJ1zw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fi.xpi",
+          "version": "102.0.1"
+        },
+        "fr": {
+          "hash": "sha512-wFjkGRk9AHbv8yvB1ZRB+5Q1SN2MJUB0wFJpOafNasDWQiqVQo3HravB5d7tEspCivwi/uaPPZEWJOoPeFSyEw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fr.xpi",
+          "version": "102.0.1"
+        },
+        "fy-NL": {
+          "hash": "sha512-SeKPJXWV4XxuD1cEKWWbPVhI4olMfzhqqMARA0LTla/czEpB601v5u7gEr4KeC4eamsbUmm7J5zGtq2l81cQvw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fy-NL.xpi",
+          "version": "102.0.1"
+        },
+        "ga-IE": {
+          "hash": "sha512-zG3uwCNtY9hMvaHuOHKyyNMHUxcqNe5nQYBqtEa7zL/ReHMYzC2UmVHjv+1SwJCQwa7GxZk2dXThAc/ncCrrEw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ga-IE.xpi",
+          "version": "102.0.1"
+        },
+        "gd": {
+          "hash": "sha512-Ovcn7EHqJzcrraAXZlJQMriwIA1lx0ed3GL/XZhOi+nKCrZebcLe7Eg7xk5JmFIlWZFDdFf+OxgbS7dmM2HuuQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gd.xpi",
+          "version": "102.0.1"
+        },
+        "gl": {
+          "hash": "sha512-eMvGfmwYTHSKNWF/qWDyvqhaTePkqwEwkTYsSfuXjrxHl5QzDB9B3bkGeOcBplh8B/jT4zzhvhRgczzRKZ7nzQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gl.xpi",
+          "version": "102.0.1"
+        },
+        "gn": {
+          "hash": "sha512-/y0tshuSeDMPuLsyoUZptGygh2SmDB7vu352H/v/QnNcYHRSgQU4UxuEvEBUfcQkoTrArAktYWR5T27jNIURlg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gn.xpi",
+          "version": "102.0.1"
+        },
+        "gu-IN": {
+          "hash": "sha512-ljY6m7P+aNCb8KoCQzTKDkaU77VDL4E0AjJAQF4S3xr3EHc8QMCL1+L1fuVbzUKXfl6ySpPFN95wHXqMibOcyQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gu-IN.xpi",
+          "version": "102.0.1"
+        },
+        "he": {
+          "hash": "sha512-IaCbKjssqcSKInnLUxtWDKrECCEIjNq9ut7RsfNM98GKDAIcBCXfHmKAhjox6pdDWAbPtzhZW/X8XHB29sCLCw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/he.xpi",
+          "version": "102.0.1"
+        },
+        "hi-IN": {
+          "hash": "sha512-eYGOdMqyNyZvN2OnJnJgWXlSgFNJnW1YQQ5VYhh/Gcexr/xmTohcaXwzN3jS/OPDuptXwzsgaje2/1hHpaC7yQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hi-IN.xpi",
+          "version": "102.0.1"
+        },
+        "hr": {
+          "hash": "sha512-sLnX4ZghgtPT1QoA6IUIdtF6gJk1fQe+4mE5VXJkspNFXaw7/3W0pvk8YtmG18t31gRKir5z8Fr5tTujm/LqiA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hr.xpi",
+          "version": "102.0.1"
+        },
+        "hsb": {
+          "hash": "sha512-Ktm3HRnpxJt+643peTXhPzSx+3R5fRSIfNBm1XzSorR/Aw5FWBTsLFXKpDNe5AvMJgnR6HyhRModQgEucpwTDQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hsb.xpi",
+          "version": "102.0.1"
+        },
+        "hu": {
+          "hash": "sha512-82CpWC5p9MAUY+OgGqf0K2A6ZALaNOsFNI78PnAMGkc9H9WcSdpr9BDr9ofi4oAMegAHboPqYenI1UYGxuTfYQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hu.xpi",
+          "version": "102.0.1"
+        },
+        "hy-AM": {
+          "hash": "sha512-FgxxkY7Rop5DctgW5vwugUaGO4/T1hV4zG5NBA3iTJTooNa6A69YPNGGhOwXtSWI8J49/cL6rNiqOnrE1jyHVw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hy-AM.xpi",
+          "version": "102.0.1"
+        },
+        "ia": {
+          "hash": "sha512-9X4uBVia6ysLfBUu2cWUSMTyRuVISAAfHLmJ6+EV+9Kl9cx03qZ/vd878crWjvV9FjURjUi1diMEiArzn5qz8w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ia.xpi",
+          "version": "102.0.1"
+        },
+        "id": {
+          "hash": "sha512-w5Dmou3NIFhGmkT0BPgaeenGnHj37MMS9sPuh3uDQsWhG7W+/XM/ky0BLDW68BujpcPOZ7FARbLGVRq0Lirdtg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/id.xpi",
+          "version": "102.0.1"
+        },
+        "is": {
+          "hash": "sha512-/T7wUz36Zw1ukjNEgIRWYuzPaBgyyecruqP15y41qvcu2Og+HJYJWCTn6OnTv+k2Ft4trDohQ76uEbFS1GZw5A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/is.xpi",
+          "version": "102.0.1"
+        },
+        "it": {
+          "hash": "sha512-gHJd4ISo2+5qifYwJXUps7FxpEo8acuziiJ83OkvwLfRcC54N+5Y9cA8xRa9T4EgJznctaQjZ5i/AWeRY7MGpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/it.xpi",
+          "version": "102.0.1"
+        },
+        "ja": {
+          "hash": "sha512-IDyCk+HNfwvu2oyjks365Dte56t2/PK+HN3KxNjWhssb0m6CKDAZ5a37au5K6MfetvZT91qpid/z6kklqnIi/w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ja.xpi",
+          "version": "102.0.1"
+        },
+        "ka": {
+          "hash": "sha512-E5jhk77zZzkKK82XVTYW8GucB+P++ezhzGd8VqgrhfnUxndGzNIVIV0gblPJh5CZm98/hzNGdqKkokWD/y9uSg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ka.xpi",
+          "version": "102.0.1"
+        },
+        "kab": {
+          "hash": "sha512-p9tjEQaySttcC1Rq1zOwn59vzzcddIpCQYgeHlKI9S+WzvbpHuqXrkYYAevD9tYaPgdtmaxYEGSFg2HzGNGKgw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/kab.xpi",
+          "version": "102.0.1"
+        },
+        "kk": {
+          "hash": "sha512-XdNAHxMM6DqKHd13lo6XFxDDt21dftHsRT8te6DqPtBBbEKcHvrdrjMvPXVdHmd0AiQ+APpT5zcFblZOdIT7qQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/kk.xpi",
+          "version": "102.0.1"
+        },
+        "km": {
+          "hash": "sha512-Mn6Iq83qpKGiGI/O0ZZsxailCMLBL+Ey8OPkSvUzniTBLVIlCZW6Cxt2BIJ+Yc1WWj9VsrQfwr1WDifR7k1HVQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/km.xpi",
+          "version": "102.0.1"
+        },
+        "kn": {
+          "hash": "sha512-v7WcUAQLx8ZCb6Zz8uQIPktNTRSr7emrVaVSkB3nWsHzlL15YTFARPjxBhw0sarXTq8qGVsR2SYVsDzS4mo2Mg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/kn.xpi",
+          "version": "102.0.1"
+        },
+        "ko": {
+          "hash": "sha512-MODi9//qZYgfymyhY6eJ4j26/jmWjAeQ+NUIcYk/WqfADR5OtwlhRnuxqTB1PGQ2+OBuam+Ane4I8aoiPa/weg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ko.xpi",
+          "version": "102.0.1"
+        },
+        "lij": {
+          "hash": "sha512-bq07DBLSoYvPJy0B/A9jMNAB6PgrvCzTX8FbQSMM1jKOpgyhDrPdYGf5oCRL3q+jT4hlgH0M6Fyr0l1mAJpofw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/lij.xpi",
+          "version": "102.0.1"
+        },
+        "lt": {
+          "hash": "sha512-GA+O344AllnFopFdKIzOnTldg+Ff/2vCb7xj+aehyZ54YCOJadV8As2unSzqghSXhpVashQ1sbVY7PFqn+e00Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/lt.xpi",
+          "version": "102.0.1"
+        },
+        "lv": {
+          "hash": "sha512-F/14cY64RQjQOAM1rB+mSCfuCOhnfzoNlFrLBgamqjbIAy8zHqrMvp4+p8OwyQJRL874f3/EbWhsBmwUOogGFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/lv.xpi",
+          "version": "102.0.1"
+        },
+        "mk": {
+          "hash": "sha512-MA+rOm3mUzmhTgo2Vwq3iGXxYKCa/m15VgHDXfIYakiEavYlgjPjRFcLQn+pNWIWXMRrutnS0bquFbim894Wlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/mk.xpi",
+          "version": "102.0.1"
+        },
+        "mr": {
+          "hash": "sha512-hRHFwihJC/fmb2ISjH4tjb/2WdWnKEehKGmZNFj1K+Q6wrmBmgDVsD9v4VoF68RR4Rji32vHEEE+IyLB48GRrQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/mr.xpi",
+          "version": "102.0.1"
+        },
+        "ms": {
+          "hash": "sha512-3a1m9tNUrMJ9DhB+1idcDZtmU/BrIX6tcm/uWL4RDUmjP6kPuPYuaRBHWKjs9MZdQPMsFpsaYMiVgjUJ2s+enA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ms.xpi",
+          "version": "102.0.1"
+        },
+        "my": {
+          "hash": "sha512-5noERpeXv1SVHF7hC4eEd32QqEbIxt48y0pXrSwv3j1RintqLsJlSARRSPk2b+RwGh0snfvmFP281COWzh6ROQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/my.xpi",
+          "version": "102.0.1"
+        },
+        "nb-NO": {
+          "hash": "sha512-PGi8yW44Z1tDMaSSnampIsGwvYAy8ikVhklVUIqMnmivNe6pNok3qAsKLwOcFNjCwuNwcTtuW4JQjiDSMZgtHw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/nb-NO.xpi",
+          "version": "102.0.1"
+        },
+        "ne-NP": {
+          "hash": "sha512-+a50NXUOZFmqTDLR5mg8R6GVtC1Sm9SOgGVs4ulqT+tu1dLETNtXGrG0HhCf1mNQ1PdtcMzATiypcEJeUTFgPQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ne-NP.xpi",
+          "version": "102.0.1"
+        },
+        "nl": {
+          "hash": "sha512-cibfgFY81lWTcgr5e+RHUGKP0NOCbco7UQyv/jmohmdQWm+eBAIDZevaUkWitIzyJLl8VyZZirj2LWl9ygAr2g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/nl.xpi",
+          "version": "102.0.1"
+        },
+        "nn-NO": {
+          "hash": "sha512-ALEC1Gyz00/9V1shCCTzQK4/l25tZ1lXDIyCU24DQfIwH2URMjuaWeMYNNR+8g1xWXqzReytCG76paNLMUg7ZA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/nn-NO.xpi",
+          "version": "102.0.1"
+        },
+        "oc": {
+          "hash": "sha512-H3Ju57kgnhufu2nSQ2mnCW4SkhuQXCVj9Z4CIWcyKGe/RnD1s6I+Q8BMXz6Q5mccAZPSpBtkWt22giYC86oqtw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/oc.xpi",
+          "version": "102.0.1"
+        },
+        "pa-IN": {
+          "hash": "sha512-t/LfjhrTorb85MbtPQiryUuFy1Cn0h0r0WMsERHMxMa5ivJkM0S0zkkXEQA4zCb6I1Nf+lAo8w4BiM94Q8AIoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pa-IN.xpi",
+          "version": "102.0.1"
+        },
+        "pl": {
+          "hash": "sha512-zUQpOQcK8d5wPTBNETlVxklc8ISrIXcJRcae6Fg7umi2Y+tYWyPJb+QDJ3loNbSDtd67Y6Kl5QWIEzMjfAo2HA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pl.xpi",
+          "version": "102.0.1"
+        },
+        "pt-BR": {
+          "hash": "sha512-FiwH6/knN5DxpwNLIk0Bfln8ZnXegjJzGmzAY5Lyg6Z93QXPHdBl5SLP7ZzQDwky+pygopRr+vesummHU6OFUA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pt-BR.xpi",
+          "version": "102.0.1"
+        },
+        "pt-PT": {
+          "hash": "sha512-q6vxpJjkfO5GLgYg8PolmNeYB7Z4vf0tZe5buUblnoxhBF/R1AISGnpV5wg7SWk+9ckNHZHEIY5Y5AkfgyKLXg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pt-PT.xpi",
+          "version": "102.0.1"
+        },
+        "rm": {
+          "hash": "sha512-YJ1osmKqD/Lm+8anlcfGCJ+yYS+E3CTxK1LBob52c7CVubKh+3pmo6iLGQRHcjey+H6lEdEPO9TrUHoIUwRVxg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/rm.xpi",
+          "version": "102.0.1"
+        },
+        "ro": {
+          "hash": "sha512-yiEVGGVZMsbwxPxZfqSQ6afuS7lwfsNkwKa1F6mn5pURHpCJgdF3J8JU+s1JszdJSgxahWbqb7j6imlR6pIvlA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ro.xpi",
+          "version": "102.0.1"
+        },
+        "ru": {
+          "hash": "sha512-skRWytxjtkI5L+FIp+//FPH6g1tOoa2iFV40kTwiOxruun5m9Jc/4pI+7ktJzhUT7iarfXyOWKsv/5NlMPo6Vg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ru.xpi",
+          "version": "102.0.1"
+        },
+        "sco": {
+          "hash": "sha512-VNXouIrPp2J0Uv2RsFcaZYF3i2n6yReBYz4cKG+7QdBHFJu/kWS23akc8/rZv8uupJOeszIQr7p1845HU2N2MA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sco.xpi",
+          "version": "102.0.1"
+        },
+        "si": {
+          "hash": "sha512-UsxfskZaA96dn1VbcF69xqCOXbJq5iMQlk1jHzXW9V8T97GGMLq4hCWp4sTQUd7wzJ5fPv3dOrbnpRzJblBPVw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/si.xpi",
+          "version": "102.0.1"
+        },
+        "sk": {
+          "hash": "sha512-lx/hXGgV9Y4uIeAtM8laEata2lksc62iRYoMJWzYybEc+cZgLL/iIz/JDezEYSkfab807ibtANaEe+yrYtBOAA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sk.xpi",
+          "version": "102.0.1"
+        },
+        "sl": {
+          "hash": "sha512-OjeCSogm/nXwcYfsAz9Ah+RLD6VncWlTGVh8MM4W7wmFpEvmumPIEdvp+XX+h/kisbFLdN4qYHPOm8GGHzLSFQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sl.xpi",
+          "version": "102.0.1"
+        },
+        "son": {
+          "hash": "sha512-71HXnGEBNzpDq77ghwGIevm1kppwvxOuPCdsZol031I17Qp9J8Qznbt06piBn22QgQAu4OsL6D2TSb4ZWHdH+Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/son.xpi",
+          "version": "102.0.1"
+        },
+        "sq": {
+          "hash": "sha512-qELnJUw9Hk2/3gezY/l9lPI6PfXDrzqLg5c5FfAp50Dpzc/VgKSG2O8Gk/u1jyi3dEFXdTlGlY2UVLcw9lSyPw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sq.xpi",
+          "version": "102.0.1"
+        },
+        "sr": {
+          "hash": "sha512-klbQ9xR0v5v2u6LfF+ffkOq9kq24NXyHXCDNztd0cWcPKo9+hh8Q2MhRJxQ6lMsI7ycFenysd3HNEWkoigNW2Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sr.xpi",
+          "version": "102.0.1"
+        },
+        "sv-SE": {
+          "hash": "sha512-DyMRWARA022eFZb/KH220BlhDXhCyFoNYlp3RwebSanOWU04woXhMZ64D2nG7kSTuyY2aetOun9+aOhg3QeLGw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sv-SE.xpi",
+          "version": "102.0.1"
+        },
+        "szl": {
+          "hash": "sha512-3DBmZrvVMxdk4o84lup3/KiYq1C54Rh66TUXKOAqpx02pFm3FII0qqTs0bZk13jaNk80xtyug80PedDXYk2IGg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/szl.xpi",
+          "version": "102.0.1"
+        },
+        "ta": {
+          "hash": "sha512-rXBVrxlyQpHDwZDkcK7eqKuULqB1s5pZM30I1VgL1Iev0KUhG2uHIFQ08rYK8bPMdq8/6fS4ymyuIaFEXmmiYQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ta.xpi",
+          "version": "102.0.1"
+        },
+        "te": {
+          "hash": "sha512-u9oWStf26IFFZsLrfwKpzcSd5WEHHXin7uCFWXrrHgSSrEXdWSDGetSaeDV9WIvxClA3PQ4uw5TQnoVpsqIm9g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/te.xpi",
+          "version": "102.0.1"
+        },
+        "th": {
+          "hash": "sha512-InS/D9uTItNCqorKfR8ubga5MAReOy8aUXGYa3ab/KtM5RNVmakKBcDeD1n1b2HWD492pHSD7f+pbD/1R7pcng==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/th.xpi",
+          "version": "102.0.1"
+        },
+        "tl": {
+          "hash": "sha512-Qxn/2c05Fx8+IMSIhnLs/84qAPkZx2ibQu33TpKRQcDndF179xY9O0LYvUfwE+TLexV0AOpfJZz/qsntMLiG3w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/tl.xpi",
+          "version": "102.0.1"
+        },
+        "tr": {
+          "hash": "sha512-hBi45TGZllPGgcDxPCZz1cv0/WVWZTuRv03vxnznuJzthiWKWVlUMvZ0yQrYT0rX7UF9xEv49XjGlVfzyOxQ8g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/tr.xpi",
+          "version": "102.0.1"
+        },
+        "trs": {
+          "hash": "sha512-da4sIHhPCL+y9z7g9Ov4lFlBAWgjrDMBnHIKZ18b/CIjixo3lxS4dx4uC9jcgPMpuZj8XgzxTlm+MahMTveJ9g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/trs.xpi",
+          "version": "102.0.1"
+        },
+        "uk": {
+          "hash": "sha512-2UjAtuF85D8gnTUwCCcIKkk75YWlSQyhtsEUjmJu22hQCHqAW5zLnwE9ik17nOWgFBo2UWVq/HvFlv+lRE6zkg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/uk.xpi",
+          "version": "102.0.1"
+        },
+        "ur": {
+          "hash": "sha512-zWMUfI3KU0Y14Ia+zukaH2GKsU35FoBP0TVfJwe/ko5xAhECNjSPHBK5qcRQj5Cyf2MLXM2ql0rysEFzs1eIgg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ur.xpi",
+          "version": "102.0.1"
+        },
+        "uz": {
+          "hash": "sha512-G8NP1POT1odyO5d0BjVYE/kVsugrPMZHDWmm7VB8LVoaGcTJrFpVPxAHm7rUuhQD0YhADU5v37F9i+YX77WDrQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/uz.xpi",
+          "version": "102.0.1"
+        },
+        "vi": {
+          "hash": "sha512-UdMr7OwirJdpFt3pUC4wvmUw4mLxATSZ6o9hr3DEXS+K62aF3+hYvjFJTKRdzrVRHPjAO+nKNFJL62i3c9UDUA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/vi.xpi",
+          "version": "102.0.1"
+        },
+        "xh": {
+          "hash": "sha512-BguzJ2bM9lEi4+A5V9dmHvvfg6pr9t5cuMZ1BCNGc4AG6U6IdCdCd83NjYanoV4BJQy28PlHrx6NXhjmK4PdbQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/xh.xpi",
+          "version": "102.0.1"
+        },
+        "zh-CN": {
+          "hash": "sha512-9Ai4latfveY/12SgMMprVMOHqrK/0QbrFGgCN4EwoV+oZ+3kfp56+1k0SIpkh3eyHtpJPpqiGJs6A7O0N48CDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/zh-CN.xpi",
+          "version": "102.0.1"
+        },
+        "zh-TW": {
+          "hash": "sha512-/ThJDr+NTOJHnZQ+hAowskb1So/EzIBLOacoY1Xze1WiDIV61HUrcdEmZ4T/9afNGWBIqUR/nmX9wlgMJSz6HQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/zh-TW.xpi",
+          "version": "102.0.1"
+        }
+      }
+    },
+    "102esr": {
+      "linux-i686": {
+        "ach": {
+          "hash": "sha512-3wATvOIJu2S+tEY1SFBhmsbewCcD547F7NyJNR8D90g/QPpf4cXY0uksiGeTAoqLb7vhl96rbRs1XN7zFd7UFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ach.xpi",
+          "version": "102.0esr"
+        },
+        "af": {
+          "hash": "sha512-MgJh7J1Fk0uA1bn5mRtYw7aiPWiGNN9A0q2ma7+d9yUKH2PP5I/i0jfRiNiyWd9L4XYZ6BdAk+2XXaPYkjjz4w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/af.xpi",
+          "version": "102.0esr"
+        },
+        "an": {
+          "hash": "sha512-ZseopH79BTapaZVsYK3k630z3CDUYf/1Nk9Cdn57LIvLJwRMUKzlivekljtBLHNX0aW+cdY4DzjuejE6tPpZuQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/an.xpi",
+          "version": "102.0esr"
+        },
+        "ar": {
+          "hash": "sha512-lJCUym0A5GAZGLkSynaZib3CT+UDW5i+kpcrE1JoJRcXi/uGeYGcebW9FuacSq/nzczvTY21cKBRalm2Aop3Cg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ar.xpi",
+          "version": "102.0esr"
+        },
+        "ast": {
+          "hash": "sha512-6puduq7OhEJY45Vmy/l/M5f6yMQ7ecZROw19GpTdQHG5gIzP2IeOVVVS9xVfP8FvzSFWtcvehE8jewOxZ4G6cQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ast.xpi",
+          "version": "102.0esr"
+        },
+        "az": {
+          "hash": "sha512-BFrqNgGQa76LNm6AwnkIRYa58HUpQwpWABQc0PdDRtpTdC70ayZH4qQ0wCdmHwkoYDkmC5b6obGzvOYuK21Cxw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/az.xpi",
+          "version": "102.0esr"
+        },
+        "be": {
+          "hash": "sha512-VuRH0wgPn42GytaTp9D5P/DyNTVrmUfmo4zQ4WpRSoSaG/Y0ceSgAA3FymAGF/7b9nspVTu5/k+6parShLGssw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/be.xpi",
+          "version": "102.0esr"
+        },
+        "bg": {
+          "hash": "sha512-LV8RGdS4eOQQMXIDNq3i+Xusyl6jNwkMDoAGRRsBP/Bv1KI8vKyaY/HFyPdbf8UcZs/hIvKqTTKS1iD9nCB8Dg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/bg.xpi",
+          "version": "102.0esr"
+        },
+        "bn": {
+          "hash": "sha512-4Vfyiiis3Qp4ojx5ucfwX1G0uSFiGSFH+LPv6TNEiZsvmEAYHpiyyGtZRxKMDj/sSd9KndCfpz3TGAXJkeKBrA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/bn.xpi",
+          "version": "102.0esr"
+        },
+        "br": {
+          "hash": "sha512-vpIV2ihvMTrFQ5qvCRGNBn+ReEXagckRz997gnJ9iWS3PXOfLWTZIDcYvBrSRuZC2T00ncqeksv2F1uSTZUM9Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/br.xpi",
+          "version": "102.0esr"
+        },
+        "bs": {
+          "hash": "sha512-vIZOp9NcdgxE6hvVL9YEAtyxovd4eUFEchDbQK73AjLpMdkZ8RXw11ixhOxPlbj0HpX61FmPLx/av105/3JFWA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/bs.xpi",
+          "version": "102.0esr"
+        },
+        "ca": {
+          "hash": "sha512-nW3PwUDxx4zUeTigyJdfobU899lJ5PUo5G3RNxQ4hvw4AFHYHAADesDNjIIEeF333Vh2hziQt0oP+PvB6qV/IA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ca.xpi",
+          "version": "102.0esr"
+        },
+        "ca-valencia": {
+          "hash": "sha512-BRvDMejvtcFs10PYpk+TIhe85RdL9hx114iG059eaBmi6bsIiQFCi9Y5bnUZt9W1BFIX1CPyEiOsd0XjvU874g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ca-valencia.xpi",
+          "version": "102.0esr"
+        },
+        "cak": {
+          "hash": "sha512-th1k+GNo5T2HmytqBCScL74s6HKbE6ZU7UXnFYgcCJSh73Dzj2rzuFK+P/9yK/iSym91QiNg0e7MdvoLC9sWyQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/cak.xpi",
+          "version": "102.0esr"
+        },
+        "cs": {
+          "hash": "sha512-tYYVRA2YKVm5NntPDD7nSWEvJcRSQWOv+XZ+tumIXzZhija5mL8PY0hzja7284LLY8JqdNVTGNSyic564zzorg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/cs.xpi",
+          "version": "102.0esr"
+        },
+        "cy": {
+          "hash": "sha512-l8casFMSidNugAXfyn2zrLulM68mv6HGXoeuUVFilqPsN/+QOK8c7jzy4E7f/CGr/rKKr62kpfE1RndXvSxkZw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/cy.xpi",
+          "version": "102.0esr"
+        },
+        "da": {
+          "hash": "sha512-JbZ9LDcHnnRprDN/OfYSc7HH90B1dR09dtVD9FxeMkRWgck+y/UovqrhTz+wMu+mrotUuftzzNpsT4a9SpHGeg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/da.xpi",
+          "version": "102.0esr"
+        },
+        "de": {
+          "hash": "sha512-LKBCuem0pv8i2I4HjO0jE6KBJVyqanj4F0fHTqkP4DpSE73TZ2Jeu5IFZB1s7gE2hhgNooS3yMn6EOiegyVqWw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/de.xpi",
+          "version": "102.0esr"
+        },
+        "dsb": {
+          "hash": "sha512-OnfeqFBiIBuTO6WOR0wzV/PuUA3KWznakrx1W3ILzeiWmVGdDfpse3AO77u0r/ZmYZ/HSZHBKjOHGiS7U6lVhQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/dsb.xpi",
+          "version": "102.0esr"
+        },
+        "el": {
+          "hash": "sha512-eQIfkBzBunBV1lsG2daTVjZRFfFK1wAjlp/DYVQf5tB22E96IigGNHwk7iyFP3usKdH06LoJc+JSlgrE5sTICw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/el.xpi",
+          "version": "102.0esr"
+        },
+        "en-CA": {
+          "hash": "sha512-D2Hn+bC7jJgN1V46Rdmbzm7Pkcpj6WRtgsHnSr2p4xWK6MNuw1Xl+Im0oGFK+BFEQayo7JCPyCIetVAZQ+9x6Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/en-CA.xpi",
+          "version": "102.0esr"
+        },
+        "en-GB": {
+          "hash": "sha512-U6c4Allq4J/lTq8EulMC/Lv5/gK4lNqKALSWF/LM9yI3/mR5zB1rVJIW6tImDiUjD3YrNHJXZiBLRnd6rmvteg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/en-GB.xpi",
+          "version": "102.0esr"
+        },
+        "en-US": {
+          "hash": "sha512-/AMmRl8AMwhmb99jaXleM3Oy+wFLMOQGyuhL1ficQ6o+W8aC58mO1TIpXhEfZ/J3nulCbrEk7fC8JcrNlWIKSg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/en-US.xpi",
+          "version": "102.0esr"
+        },
+        "eo": {
+          "hash": "sha512-LflFLkQKU69g1Qih8cNkXVlcZ792oBoPJ+Nw0EatXzv3jBJfdUTbD/WU2Uosw7U3JpJb3Is9c5cBEAxZ7r20+A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/eo.xpi",
+          "version": "102.0esr"
+        },
+        "es-AR": {
+          "hash": "sha512-g7pkhIvDfrg/YULXxoW1Ml6ifDIEt2rh+XBmOM8R2vcXwYrZeX3cqfkpFAt83ypJ0h4/2T1E8G86WVQSBuh6Yg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/es-AR.xpi",
+          "version": "102.0esr"
+        },
+        "es-CL": {
+          "hash": "sha512-FWeVSLc0O5kIJaDGXUP1bu9H2E4x59hq3Ff1tXZpeITN8/RJhe26izSQTwPPvYqYXt/ox3BB3Hi+7xxhThCxvA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/es-CL.xpi",
+          "version": "102.0esr"
+        },
+        "es-ES": {
+          "hash": "sha512-GN6m+d9twmSOu/KxZ3wlRZzJjByQaQE7/ZL1/A1imiGvAg7hwqHUTOeI7APnNaBOI1tfxjxpvn6rZRAALQg3sg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/es-ES.xpi",
+          "version": "102.0esr"
+        },
+        "es-MX": {
+          "hash": "sha512-AZi7COgt+NB0uFnA3H+WTREJw+Xfc6N4KL27b3PPjagRmwNiQxd2Gc6DTYolUfN9gcRLvVi6Fv/iuhdB0X0zZQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/es-MX.xpi",
+          "version": "102.0esr"
+        },
+        "et": {
+          "hash": "sha512-3/y97pXmmqKmlTYZuz2cyOuuOMTYKieIDKWJnjMwFUuvKr1/QR+5zJgnDwqfcXfXt3ismSKpolFOQzuriPS2Uw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/et.xpi",
+          "version": "102.0esr"
+        },
+        "eu": {
+          "hash": "sha512-NDV3UoPBK7TY90Evx09J3Rls4UxadJ46V9tIOM3Xnvgo6O2L/Ug7W8mfSd/nAQQcugWAgmfqz62p1iWWunkZnQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/eu.xpi",
+          "version": "102.0esr"
+        },
+        "fa": {
+          "hash": "sha512-0c+qaf+GLy91PWJbcqsqdO//cOwDXAOkumk8sMGIwyoRXm2/9dLl0Ek1hIIPMqB4JVW+X93OSOgtg+ow/q+5Lg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/fa.xpi",
+          "version": "102.0esr"
+        },
+        "ff": {
+          "hash": "sha512-DxmadwF5ua0J0hDoPpwXWa8IpHOEZumlbUG7oKcRuFu1awLbZgS579cquGO/O3DiozX0uO3y0YAz+wG1hr0YBQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ff.xpi",
+          "version": "102.0esr"
+        },
+        "fi": {
+          "hash": "sha512-qK+dKIZXTgaTNZpQjwM3lYxFOFea0fyE1igQgS4UqHnp1s4G5bQUeB7PzheezzKyjEr//I8dz5w4I30/YdMZJw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/fi.xpi",
+          "version": "102.0esr"
+        },
+        "fr": {
+          "hash": "sha512-+3HvdX3IO/lH13+tTK9kgZaQg/Y90J/YgxRUKHiOy68r3jLKMjPC4b+6j6+dLa6oc71M1ge/dLieNoIjQz3aNA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/fr.xpi",
+          "version": "102.0esr"
+        },
+        "fy-NL": {
+          "hash": "sha512-Ok98n3U2REY87im2d4JZjN1/oK0mMrbxjUxo2ETas/Lfq+9v9D/vsDRt2hg0v0BcXMYv2iIOf8RLx38pa6PxoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/fy-NL.xpi",
+          "version": "102.0esr"
+        },
+        "ga-IE": {
+          "hash": "sha512-3Y1DwafYhtcXbM7AQBAc6hhehWTbEOhmjm2oFRDBNYERno5nGYg8dVoMkbo3zShR4ksGla8yY6pxx1CXrCOilg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ga-IE.xpi",
+          "version": "102.0esr"
+        },
+        "gd": {
+          "hash": "sha512-Qsko/4lzjNFqGQL4Vs+AP4k0uZmgSA0oRs4bkCcbrZXPPtpvOsqrs6u276Z5fRuCCfYzK/KwN/huSqXfJxDEQA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/gd.xpi",
+          "version": "102.0esr"
+        },
+        "gl": {
+          "hash": "sha512-mo7ohStFu9Ygu7bifzEd7jHBb7qrHtpyEBDDBrsqCIakM55Q5b/S2fDyfmqjs9TwoCxVzSweVpImq7+Z5Trx+g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/gl.xpi",
+          "version": "102.0esr"
+        },
+        "gn": {
+          "hash": "sha512-3nf/wNHMBARAve8zVB8aEP94q1PltJbMOkRUjzx3LsNzodS+uLEdXqnMfIIZq5mgZTboTbIkKc8+UFJA5z97+g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/gn.xpi",
+          "version": "102.0esr"
+        },
+        "gu-IN": {
+          "hash": "sha512-YYhN10gixWq4yJvG51k09CydQFzPKzjcXPSgtDXoSI2mIf7FAvyVqfvgCO+pj7qYO1B27uSl8EPEae/NlXgQlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/gu-IN.xpi",
+          "version": "102.0esr"
+        },
+        "he": {
+          "hash": "sha512-TLrAjvZB4vkt5zTZTmlgH26FwMNdqa48ft5+8IQgi6JZ8L5Ot6+Yo5lc0u36SiTcTsJTjgEtkQI5f77vLfL4WA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/he.xpi",
+          "version": "102.0esr"
+        },
+        "hi-IN": {
+          "hash": "sha512-cdAJWsS0fJtZJ4h4kJWfFvwb51wC/B0szc4WqJB1lKkAFGOt+FcWX960VIPfCjFBejw1wP7E2SOeHT9khZ2mxw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/hi-IN.xpi",
+          "version": "102.0esr"
+        },
+        "hr": {
+          "hash": "sha512-zLln1UJpX/AUObogdNEkKOjVps22m5HT9lMfLlsZchfL9sGAXwuFIBNUtuVrrOl2kltHS6nXPOzKqLsNGJWuFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/hr.xpi",
+          "version": "102.0esr"
+        },
+        "hsb": {
+          "hash": "sha512-3EA0ySBjRfHuLTFwaxGgQc60jumeaibZmKfAM6p6p/tA+5U9peTVNPcmSOUHuc98lZDE/NRlFycw1jHsz1b+3Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/hsb.xpi",
+          "version": "102.0esr"
+        },
+        "hu": {
+          "hash": "sha512-Ua+VDHRErb30NkJlSaMoPzbB3I4UCMhnY9UBMMkRETilQWhDX4OlMx9xEZX1xX3oO/OIn9PGW1LrQO4m5OSrEg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/hu.xpi",
+          "version": "102.0esr"
+        },
+        "hy-AM": {
+          "hash": "sha512-5pgE5pTxdQj3oJP238BHpQJd/n1jK56QL+DaTMmx8grC175OHOegKe2gduqKXnYLo2ZCKYpII0nhzvDLxY/S9Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/hy-AM.xpi",
+          "version": "102.0esr"
+        },
+        "ia": {
+          "hash": "sha512-bEcW5HTxRdZANYhpOdi/oXjw2mjY4dOd3MfOqjgpq7DeKwUhs9xxsG+yoNR9tYNSvmVbFm0UH+gHIXOtCKgvkQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ia.xpi",
+          "version": "102.0esr"
+        },
+        "id": {
+          "hash": "sha512-paNP8n2vUFLRwYamoahXh2hgfww+LH7yqO54VDezhwwAUcJX+uKaLE6a6q73Bob1G8YLd/W3kTTFwhTjPGZsHA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/id.xpi",
+          "version": "102.0esr"
+        },
+        "is": {
+          "hash": "sha512-BcgWnFj99FPGDB/xO6VvtXKXQ5k4+3l46EDmrBM8ziaRc5yTGVqOkWwKZ+tiHFcrBpDjNH3yJHIsxpCyLvVm9w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/is.xpi",
+          "version": "102.0esr"
+        },
+        "it": {
+          "hash": "sha512-zNGEi+ttutxjgj7sU/f5MgXKAFuG/6MY4VBDlsKo3UIO0aCjug8lp567ZXBo21SDUYXml22IH/Np52QUSZpejw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/it.xpi",
+          "version": "102.0esr"
+        },
+        "ja": {
+          "hash": "sha512-sc8+NKgbh59r9fEUQSpuh6J7W+Ln9ryESxt9iLr6ZbJBauki2jtT0vpZ9QmwJ8PR3wTN4tSVpZPNtCbSr/NNmw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ja.xpi",
+          "version": "102.0esr"
+        },
+        "ka": {
+          "hash": "sha512-MVKi8A4Fx9u076+L5lSK5mK8uKGSPE1mjK6fTOERifIeO8LyLJ/vosi0lb7fEXBHPjQADP0R0D8x9cwxWyi0xw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ka.xpi",
+          "version": "102.0esr"
+        },
+        "kab": {
+          "hash": "sha512-IDosnumv0SAKp9hVNXHHOct5+EOgiRjoJko/V+hIIdangETp/OMM8JHUYq/gm5UkFnOhWgfMW1YIo4GVKhhKRg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/kab.xpi",
+          "version": "102.0esr"
+        },
+        "kk": {
+          "hash": "sha512-rZ5AXsUVOE39UTrpiaQ4Uy3vLYn7FZ04cgzIXfqaY/4zpYKOLDvb90ZuZZn4gDrPStTo/srhVU8HE9L93xpbaQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/kk.xpi",
+          "version": "102.0esr"
+        },
+        "km": {
+          "hash": "sha512-tSSAVYEBr5725LpyPJ5E+qAF3wsIv9Nhqk5s+xnBX+9zlOc/RNsh+BZUH/Eg+hZgp0XjHnKBs+ztcG+s6fiepg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/km.xpi",
+          "version": "102.0esr"
+        },
+        "kn": {
+          "hash": "sha512-9Opies9WGDj1zS/ehj7MoA6eV6dVWY9al2mS6ljOso8HWRMzaiyFRVMauGbhEhxUfBDzskK38yKLeyZ2Qaz9Ng==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/kn.xpi",
+          "version": "102.0esr"
+        },
+        "ko": {
+          "hash": "sha512-6aJ2UeyDX2AuAZjkjMjYQanweKIMmctt7P/nEF83rEAA6cvHEsDIW95l0fk7NzWfUDmIh8YJ34rHL4K4mGHZhA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ko.xpi",
+          "version": "102.0esr"
+        },
+        "lij": {
+          "hash": "sha512-ihhrglEZxhSgtRdBRmLJbGdrHbEhBTV3Dd4fbnTaDhRy7x8FKMgyHPYBX05KqHOOiuFWZAwq9l876V6j7mIvxg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/lij.xpi",
+          "version": "102.0esr"
+        },
+        "lt": {
+          "hash": "sha512-iupMQAJLVhzuMkDl8+PzZ/fBCfYnaDEBoNrsATrlKn57cPA2cewuIhSRgBR4eTOoFGu2bKH+Xgin/78bCZ/RBA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/lt.xpi",
+          "version": "102.0esr"
+        },
+        "lv": {
+          "hash": "sha512-gYzh+MvjDXhtg9+mPKJgNeaGs/Af3jiEkBFo3dALH1ElpQCQHuVBIakHI5YrqH8Mhj2bDa2WatcIe9asf9xq0w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/lv.xpi",
+          "version": "102.0esr"
+        },
+        "mk": {
+          "hash": "sha512-5BJ0wLavJ7l3CV4CKkaHWL9fnXeGmEpxASm8JTvPa+us18G811K/A4bl6VpYlIoB5J7idGPy37Ph3cFaBuWxgQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/mk.xpi",
+          "version": "102.0esr"
+        },
+        "mr": {
+          "hash": "sha512-qYwPLLEE3sVVou5MkFknn3rA7T0BnHGBEuOGleE+hgS9xVx3P3JRpH+Deb0KgDx17Z5d89HbSHYL9Amrk5nCig==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/mr.xpi",
+          "version": "102.0esr"
+        },
+        "ms": {
+          "hash": "sha512-DnaAouWKaFk510DBE4OWmuZ/l9T93T5+B3rBpBtdzu2Uz/2NNk9YTuHlOQN0YlQtgFh/cimHWEeKHwyDHVOkcg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ms.xpi",
+          "version": "102.0esr"
+        },
+        "my": {
+          "hash": "sha512-xc3OkdJB9x2rLuPMme3VZTRfDVzgWp+IfNEb/pwZhexwN7XII1Ixh/J8fdmUy0U9Z9wfNDgiWIg+4HQiA6AGDQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/my.xpi",
+          "version": "102.0esr"
+        },
+        "nb-NO": {
+          "hash": "sha512-sB1iKc3XBqAuWvnFMVXWE+qB6hqUdge/E3JRnId2Qc/7omx7M0OdH3xljKO6MTqjiuA+HSnfiF1PZ8bkxeDUmA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/nb-NO.xpi",
+          "version": "102.0esr"
+        },
+        "ne-NP": {
+          "hash": "sha512-bP52OXk+t9NBxbkKAtzkQi1kZbmH1dB7USKDos9/GHPA1PsooGgosS1R2blLbxi///YG8Z9NeRpRY7tzfMGw9w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ne-NP.xpi",
+          "version": "102.0esr"
+        },
+        "nl": {
+          "hash": "sha512-TvM3LU9viV1T51Ug+6YuwdLHP3nqOjfTWXZ6fwZdTTUD3t5+plUt5FmgJQJqfkj6B4GeK5pSbmmymK1duYvJXg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/nl.xpi",
+          "version": "102.0esr"
+        },
+        "nn-NO": {
+          "hash": "sha512-U7mDfreVP9iEAUn/c1a5lM5yeqhdUCJsq7/Ucv9rz13brV/+iG5HPRtnYhrOXZRMdoSh8vUY1NhGmLoWXDgYlA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/nn-NO.xpi",
+          "version": "102.0esr"
+        },
+        "oc": {
+          "hash": "sha512-JEkjw0AcKGVxWDQs7jkXqjuCwpLyM0DF5JFwGqjZQ1KDZJ2/QII9pEnrDkCV88t7zi6sqgg/J0ip32n74aaWRA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/oc.xpi",
+          "version": "102.0esr"
+        },
+        "pa-IN": {
+          "hash": "sha512-/FZHOzyMdlYz8S328TFU/Gi1tQYeVjhjB+WyjmzeGTK2mmnRIMJxWntUfVD6BkMUeIYoqQr+G+vxKrZZ8rYgIA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/pa-IN.xpi",
+          "version": "102.0esr"
+        },
+        "pl": {
+          "hash": "sha512-HyV383JxkIA273NSOphI6C8oAYg9XKWQM7phrwl82YNJz6TilKy2hHtTOap7vxYa/yDRDd/x5vVsZQPTwjgLNg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/pl.xpi",
+          "version": "102.0esr"
+        },
+        "pt-BR": {
+          "hash": "sha512-ZlsXGZkeEtfY/0hB1JdaP4BPkk+nuBshVYreUsU+x6Qn5D81jENaA8Ur7XE7WUzrDk12/SJZQtdjxBkk0wPniQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/pt-BR.xpi",
+          "version": "102.0esr"
+        },
+        "pt-PT": {
+          "hash": "sha512-sOsSjyk3LJLDUFFFu56rdlyhy1wSuXf9pHmzKmAIbx8UXEzd5eu5aH4ckM7451flhPJvyY2zLAS4v0bZ6RkSDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/pt-PT.xpi",
+          "version": "102.0esr"
+        },
+        "rm": {
+          "hash": "sha512-/6lCmu4VE/RqlAeLBdM78zQAoNymOtyqHKUAG7628KKvZAoRf/3nyObZ3w1orjtFP6LYgYPZtkxRWwuWNqUkcQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/rm.xpi",
+          "version": "102.0esr"
+        },
+        "ro": {
+          "hash": "sha512-BFqn2bk7D6miZh3rUF+D59+VSgo+6bRRAGgBO/8aNJX80LIQ1B8GxPPj4TqN2KzD4vvwNKSmeLcBFNtB9Z91Bg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ro.xpi",
+          "version": "102.0esr"
+        },
+        "ru": {
+          "hash": "sha512-QYwxrLa0RWEh7FyZsYPkg2TOVpUczDWUiRpMTevB7RBPqlTXIKJcVHUyQxDuwG+Lbw2EBR8a612o1YUfO97vHw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ru.xpi",
+          "version": "102.0esr"
+        },
+        "sco": {
+          "hash": "sha512-jpYMq0seMxmDxLPClX50POpAoUOkbiq7dC9+HZFGUC2UXFWVD2/NYGMHRRpmAJyWoYasyuHu3I2iZe6PzW5UAQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/sco.xpi",
+          "version": "102.0esr"
+        },
+        "si": {
+          "hash": "sha512-955Sl3mhji/3OBYQdDFX6hJYvF5hoaDGFnjAOpHUpStybZUyc/s4hMiW4ta0dku1BpYCcvXPF1M9GS9bVK+Msw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/si.xpi",
+          "version": "102.0esr"
+        },
+        "sk": {
+          "hash": "sha512-v9Mk32IJ6yLGspJMkKX4g0YIuqmZQ6Vdlp7m/lJ2GIlvg0coHISXR5buBwUcTQRPjs2gydX5RUrK9WoXsomqfA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/sk.xpi",
+          "version": "102.0esr"
+        },
+        "sl": {
+          "hash": "sha512-wGFOJ1S7+9WLVK57XAfbSk+8QJJRtEg/0WXhcczo05A5VCNfTj+TDNpQ2jqFWr4eIVEc4LO94hV9/phWhhXYTA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/sl.xpi",
+          "version": "102.0esr"
+        },
+        "son": {
+          "hash": "sha512-q/s8P56Vo+UIS1NukdHp9q6WeFfVG8m1SOihii76MwAGepCWb7tO5RoRnuZMJ+jt/mo30uxrXNOnDbHFjuzV5w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/son.xpi",
+          "version": "102.0esr"
+        },
+        "sq": {
+          "hash": "sha512-vC0sEU6Dy9IhRqtxsH0ZnreK0CsGWZgwPwj6rXAA2Xf+FryDN6Y2IIHSDMGOcFlNQEqhpGrYrBngz23IK5PClg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/sq.xpi",
+          "version": "102.0esr"
+        },
+        "sr": {
+          "hash": "sha512-x1Ap49uxv1BW4CVhZa6AtTGjoYoA/fxEJskR38Gy1BG3QbzzejJY5RuWsKsmUpzhj5+2UWrsb9uP3mNIAI/VZw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/sr.xpi",
+          "version": "102.0esr"
+        },
+        "sv-SE": {
+          "hash": "sha512-5FcvQgmVsFq8NL/6It0DPqZdsLguXw+lOzl/EDad6/R7+ehas7i2cxFs2PxKW9lO/+biXp+UYn5RrpHjCDgNxQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/sv-SE.xpi",
+          "version": "102.0esr"
+        },
+        "szl": {
+          "hash": "sha512-5zrti9DC+8BOske4wmug7st5UvDJdeyJ0DbwQHYhVtqKU6q6sUv1PJuIHx9dhRd5TvPdV8VIqGg2zqs5q/dQfA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/szl.xpi",
+          "version": "102.0esr"
+        },
+        "ta": {
+          "hash": "sha512-KaQOmKLNnJ4XZdGfjWHtoYjpasEMDyLePU2gH/lCBwl1VjZ7O3xjSEEO/qnAk51CNBrJ3xTUbpDipoE4oB0jNw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ta.xpi",
+          "version": "102.0esr"
+        },
+        "te": {
+          "hash": "sha512-0bp4Pd4Vlwql464UOWwKjLleSeqA1t+M/R/cMN6sk3dsHgy5jFJ4RgwsfbDqtUNWXD5ygUesGmj+hAgbWhiMUw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/te.xpi",
+          "version": "102.0esr"
+        },
+        "th": {
+          "hash": "sha512-Qxze3UKnlWw6k/HMhAVzz7g8EwH/HJlMNOYnM/ScOxNuxKu/wHDWoq35v8TjPv+zuFkYDFi7klhMB59s5lekQQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/th.xpi",
+          "version": "102.0esr"
+        },
+        "tl": {
+          "hash": "sha512-NHiEPPFc7DblS7z1+FRK3N1N7TOOlmGgbsQBJUfLzDjNRi2kV2FSeg50fv/lykxfqFFQ2KOljQpd8CqFhuRSzg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/tl.xpi",
+          "version": "102.0esr"
+        },
+        "tr": {
+          "hash": "sha512-Ix+atA2ciZk+CRF1EbQY4H0uRZK40V599Qo9Fml+7Ruz3Jjq7uItmL+1/KkgteIOfkar0Su9ZTOxLBMRKaO6+w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/tr.xpi",
+          "version": "102.0esr"
+        },
+        "trs": {
+          "hash": "sha512-QM/WItwZXFAdRdNsuzvf6h2roKGJ+r9b/7ZJ3R2Tgm3DnSr88IOoKrU4gX5meBpF9aSlnFooXMLPbPMNr8cvNQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/trs.xpi",
+          "version": "102.0esr"
+        },
+        "uk": {
+          "hash": "sha512-Z9xOYXDfX+LLzprl2zuSqABhD8x43z+0MZkEtF6fU0RZvpbHxvUiUwUHwnQfArYT67a9uK2p0UobJWBNj4M0ug==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/uk.xpi",
+          "version": "102.0esr"
+        },
+        "ur": {
+          "hash": "sha512-9o7jvOMhAoCihHwWbcPZKDF5l5bYz7y8oaa0h0hLJbjU75KfXkEpvBd9W8W2TjaG3ALg9PdQfg5CFBi1w3aggQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/ur.xpi",
+          "version": "102.0esr"
+        },
+        "uz": {
+          "hash": "sha512-5BWapKS8uMMnrQQiNpJ24i5cuHA+4TubjbZn6KMOrcUsU+QKI4bN/aOn2pRCQxxa049WMlJt0yzI3tWOd492aA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/uz.xpi",
+          "version": "102.0esr"
+        },
+        "vi": {
+          "hash": "sha512-gnyQkt2vfDEpcVHwdBT16jGCsxuQxZmh4b2w//EGJ0C6d+W9bem4R2Qv7rRMSrccxLyuaB4op97RCxhbpdgjsw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/vi.xpi",
+          "version": "102.0esr"
+        },
+        "xh": {
+          "hash": "sha512-gnmsHzhypqF62xVAgYYHA2gVFkUAKfNML3Ryi/6SeB95LNykWztoN9h63LmU2XLC/+LF7XhmHg9u8xlnEMqRlQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/xh.xpi",
+          "version": "102.0esr"
+        },
+        "zh-CN": {
+          "hash": "sha512-L+lugei7T7/xdgsmJAdicmeoBpLNxNKZ2nfX4dSrAwhZOuZ2461wIIYhfAvN/t2skngr8T39sRPLvkcdV8O84w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/zh-CN.xpi",
+          "version": "102.0esr"
+        },
+        "zh-TW": {
+          "hash": "sha512-dUdto3jVtlRjaMBisMiI7jr0xrVr4onkS1epB79Vo7/ZJKn2lOyvX0gr96gDwr6euIm4F2esyU30xvX6avjCjw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-i686/xpi/zh-TW.xpi",
+          "version": "102.0esr"
+        }
+      },
+      "linux-x86_64": {
+        "ach": {
+          "hash": "sha512-3wATvOIJu2S+tEY1SFBhmsbewCcD547F7NyJNR8D90g/QPpf4cXY0uksiGeTAoqLb7vhl96rbRs1XN7zFd7UFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ach.xpi",
+          "version": "102.0esr"
+        },
+        "af": {
+          "hash": "sha512-MgJh7J1Fk0uA1bn5mRtYw7aiPWiGNN9A0q2ma7+d9yUKH2PP5I/i0jfRiNiyWd9L4XYZ6BdAk+2XXaPYkjjz4w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/af.xpi",
+          "version": "102.0esr"
+        },
+        "an": {
+          "hash": "sha512-ZseopH79BTapaZVsYK3k630z3CDUYf/1Nk9Cdn57LIvLJwRMUKzlivekljtBLHNX0aW+cdY4DzjuejE6tPpZuQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/an.xpi",
+          "version": "102.0esr"
+        },
+        "ar": {
+          "hash": "sha512-lJCUym0A5GAZGLkSynaZib3CT+UDW5i+kpcrE1JoJRcXi/uGeYGcebW9FuacSq/nzczvTY21cKBRalm2Aop3Cg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ar.xpi",
+          "version": "102.0esr"
+        },
+        "ast": {
+          "hash": "sha512-6puduq7OhEJY45Vmy/l/M5f6yMQ7ecZROw19GpTdQHG5gIzP2IeOVVVS9xVfP8FvzSFWtcvehE8jewOxZ4G6cQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ast.xpi",
+          "version": "102.0esr"
+        },
+        "az": {
+          "hash": "sha512-BFrqNgGQa76LNm6AwnkIRYa58HUpQwpWABQc0PdDRtpTdC70ayZH4qQ0wCdmHwkoYDkmC5b6obGzvOYuK21Cxw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/az.xpi",
+          "version": "102.0esr"
+        },
+        "be": {
+          "hash": "sha512-VuRH0wgPn42GytaTp9D5P/DyNTVrmUfmo4zQ4WpRSoSaG/Y0ceSgAA3FymAGF/7b9nspVTu5/k+6parShLGssw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/be.xpi",
+          "version": "102.0esr"
+        },
+        "bg": {
+          "hash": "sha512-LV8RGdS4eOQQMXIDNq3i+Xusyl6jNwkMDoAGRRsBP/Bv1KI8vKyaY/HFyPdbf8UcZs/hIvKqTTKS1iD9nCB8Dg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/bg.xpi",
+          "version": "102.0esr"
+        },
+        "bn": {
+          "hash": "sha512-4Vfyiiis3Qp4ojx5ucfwX1G0uSFiGSFH+LPv6TNEiZsvmEAYHpiyyGtZRxKMDj/sSd9KndCfpz3TGAXJkeKBrA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/bn.xpi",
+          "version": "102.0esr"
+        },
+        "br": {
+          "hash": "sha512-vpIV2ihvMTrFQ5qvCRGNBn+ReEXagckRz997gnJ9iWS3PXOfLWTZIDcYvBrSRuZC2T00ncqeksv2F1uSTZUM9Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/br.xpi",
+          "version": "102.0esr"
+        },
+        "bs": {
+          "hash": "sha512-vIZOp9NcdgxE6hvVL9YEAtyxovd4eUFEchDbQK73AjLpMdkZ8RXw11ixhOxPlbj0HpX61FmPLx/av105/3JFWA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/bs.xpi",
+          "version": "102.0esr"
+        },
+        "ca": {
+          "hash": "sha512-nW3PwUDxx4zUeTigyJdfobU899lJ5PUo5G3RNxQ4hvw4AFHYHAADesDNjIIEeF333Vh2hziQt0oP+PvB6qV/IA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ca.xpi",
+          "version": "102.0esr"
+        },
+        "ca-valencia": {
+          "hash": "sha512-BRvDMejvtcFs10PYpk+TIhe85RdL9hx114iG059eaBmi6bsIiQFCi9Y5bnUZt9W1BFIX1CPyEiOsd0XjvU874g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ca-valencia.xpi",
+          "version": "102.0esr"
+        },
+        "cak": {
+          "hash": "sha512-th1k+GNo5T2HmytqBCScL74s6HKbE6ZU7UXnFYgcCJSh73Dzj2rzuFK+P/9yK/iSym91QiNg0e7MdvoLC9sWyQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/cak.xpi",
+          "version": "102.0esr"
+        },
+        "cs": {
+          "hash": "sha512-tYYVRA2YKVm5NntPDD7nSWEvJcRSQWOv+XZ+tumIXzZhija5mL8PY0hzja7284LLY8JqdNVTGNSyic564zzorg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/cs.xpi",
+          "version": "102.0esr"
+        },
+        "cy": {
+          "hash": "sha512-l8casFMSidNugAXfyn2zrLulM68mv6HGXoeuUVFilqPsN/+QOK8c7jzy4E7f/CGr/rKKr62kpfE1RndXvSxkZw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/cy.xpi",
+          "version": "102.0esr"
+        },
+        "da": {
+          "hash": "sha512-JbZ9LDcHnnRprDN/OfYSc7HH90B1dR09dtVD9FxeMkRWgck+y/UovqrhTz+wMu+mrotUuftzzNpsT4a9SpHGeg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/da.xpi",
+          "version": "102.0esr"
+        },
+        "de": {
+          "hash": "sha512-LKBCuem0pv8i2I4HjO0jE6KBJVyqanj4F0fHTqkP4DpSE73TZ2Jeu5IFZB1s7gE2hhgNooS3yMn6EOiegyVqWw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/de.xpi",
+          "version": "102.0esr"
+        },
+        "dsb": {
+          "hash": "sha512-OnfeqFBiIBuTO6WOR0wzV/PuUA3KWznakrx1W3ILzeiWmVGdDfpse3AO77u0r/ZmYZ/HSZHBKjOHGiS7U6lVhQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/dsb.xpi",
+          "version": "102.0esr"
+        },
+        "el": {
+          "hash": "sha512-eQIfkBzBunBV1lsG2daTVjZRFfFK1wAjlp/DYVQf5tB22E96IigGNHwk7iyFP3usKdH06LoJc+JSlgrE5sTICw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/el.xpi",
+          "version": "102.0esr"
+        },
+        "en-CA": {
+          "hash": "sha512-D2Hn+bC7jJgN1V46Rdmbzm7Pkcpj6WRtgsHnSr2p4xWK6MNuw1Xl+Im0oGFK+BFEQayo7JCPyCIetVAZQ+9x6Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/en-CA.xpi",
+          "version": "102.0esr"
+        },
+        "en-GB": {
+          "hash": "sha512-U6c4Allq4J/lTq8EulMC/Lv5/gK4lNqKALSWF/LM9yI3/mR5zB1rVJIW6tImDiUjD3YrNHJXZiBLRnd6rmvteg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/en-GB.xpi",
+          "version": "102.0esr"
+        },
+        "en-US": {
+          "hash": "sha512-/AMmRl8AMwhmb99jaXleM3Oy+wFLMOQGyuhL1ficQ6o+W8aC58mO1TIpXhEfZ/J3nulCbrEk7fC8JcrNlWIKSg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/en-US.xpi",
+          "version": "102.0esr"
+        },
+        "eo": {
+          "hash": "sha512-LflFLkQKU69g1Qih8cNkXVlcZ792oBoPJ+Nw0EatXzv3jBJfdUTbD/WU2Uosw7U3JpJb3Is9c5cBEAxZ7r20+A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/eo.xpi",
+          "version": "102.0esr"
+        },
+        "es-AR": {
+          "hash": "sha512-g7pkhIvDfrg/YULXxoW1Ml6ifDIEt2rh+XBmOM8R2vcXwYrZeX3cqfkpFAt83ypJ0h4/2T1E8G86WVQSBuh6Yg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/es-AR.xpi",
+          "version": "102.0esr"
+        },
+        "es-CL": {
+          "hash": "sha512-FWeVSLc0O5kIJaDGXUP1bu9H2E4x59hq3Ff1tXZpeITN8/RJhe26izSQTwPPvYqYXt/ox3BB3Hi+7xxhThCxvA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/es-CL.xpi",
+          "version": "102.0esr"
+        },
+        "es-ES": {
+          "hash": "sha512-GN6m+d9twmSOu/KxZ3wlRZzJjByQaQE7/ZL1/A1imiGvAg7hwqHUTOeI7APnNaBOI1tfxjxpvn6rZRAALQg3sg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/es-ES.xpi",
+          "version": "102.0esr"
+        },
+        "es-MX": {
+          "hash": "sha512-AZi7COgt+NB0uFnA3H+WTREJw+Xfc6N4KL27b3PPjagRmwNiQxd2Gc6DTYolUfN9gcRLvVi6Fv/iuhdB0X0zZQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/es-MX.xpi",
+          "version": "102.0esr"
+        },
+        "et": {
+          "hash": "sha512-3/y97pXmmqKmlTYZuz2cyOuuOMTYKieIDKWJnjMwFUuvKr1/QR+5zJgnDwqfcXfXt3ismSKpolFOQzuriPS2Uw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/et.xpi",
+          "version": "102.0esr"
+        },
+        "eu": {
+          "hash": "sha512-NDV3UoPBK7TY90Evx09J3Rls4UxadJ46V9tIOM3Xnvgo6O2L/Ug7W8mfSd/nAQQcugWAgmfqz62p1iWWunkZnQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/eu.xpi",
+          "version": "102.0esr"
+        },
+        "fa": {
+          "hash": "sha512-0c+qaf+GLy91PWJbcqsqdO//cOwDXAOkumk8sMGIwyoRXm2/9dLl0Ek1hIIPMqB4JVW+X93OSOgtg+ow/q+5Lg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/fa.xpi",
+          "version": "102.0esr"
+        },
+        "ff": {
+          "hash": "sha512-DxmadwF5ua0J0hDoPpwXWa8IpHOEZumlbUG7oKcRuFu1awLbZgS579cquGO/O3DiozX0uO3y0YAz+wG1hr0YBQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ff.xpi",
+          "version": "102.0esr"
+        },
+        "fi": {
+          "hash": "sha512-qK+dKIZXTgaTNZpQjwM3lYxFOFea0fyE1igQgS4UqHnp1s4G5bQUeB7PzheezzKyjEr//I8dz5w4I30/YdMZJw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/fi.xpi",
+          "version": "102.0esr"
+        },
+        "fr": {
+          "hash": "sha512-+3HvdX3IO/lH13+tTK9kgZaQg/Y90J/YgxRUKHiOy68r3jLKMjPC4b+6j6+dLa6oc71M1ge/dLieNoIjQz3aNA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/fr.xpi",
+          "version": "102.0esr"
+        },
+        "fy-NL": {
+          "hash": "sha512-Ok98n3U2REY87im2d4JZjN1/oK0mMrbxjUxo2ETas/Lfq+9v9D/vsDRt2hg0v0BcXMYv2iIOf8RLx38pa6PxoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/fy-NL.xpi",
+          "version": "102.0esr"
+        },
+        "ga-IE": {
+          "hash": "sha512-3Y1DwafYhtcXbM7AQBAc6hhehWTbEOhmjm2oFRDBNYERno5nGYg8dVoMkbo3zShR4ksGla8yY6pxx1CXrCOilg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ga-IE.xpi",
+          "version": "102.0esr"
+        },
+        "gd": {
+          "hash": "sha512-Qsko/4lzjNFqGQL4Vs+AP4k0uZmgSA0oRs4bkCcbrZXPPtpvOsqrs6u276Z5fRuCCfYzK/KwN/huSqXfJxDEQA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/gd.xpi",
+          "version": "102.0esr"
+        },
+        "gl": {
+          "hash": "sha512-mo7ohStFu9Ygu7bifzEd7jHBb7qrHtpyEBDDBrsqCIakM55Q5b/S2fDyfmqjs9TwoCxVzSweVpImq7+Z5Trx+g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/gl.xpi",
+          "version": "102.0esr"
+        },
+        "gn": {
+          "hash": "sha512-3nf/wNHMBARAve8zVB8aEP94q1PltJbMOkRUjzx3LsNzodS+uLEdXqnMfIIZq5mgZTboTbIkKc8+UFJA5z97+g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/gn.xpi",
+          "version": "102.0esr"
+        },
+        "gu-IN": {
+          "hash": "sha512-YYhN10gixWq4yJvG51k09CydQFzPKzjcXPSgtDXoSI2mIf7FAvyVqfvgCO+pj7qYO1B27uSl8EPEae/NlXgQlw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/gu-IN.xpi",
+          "version": "102.0esr"
+        },
+        "he": {
+          "hash": "sha512-TLrAjvZB4vkt5zTZTmlgH26FwMNdqa48ft5+8IQgi6JZ8L5Ot6+Yo5lc0u36SiTcTsJTjgEtkQI5f77vLfL4WA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/he.xpi",
+          "version": "102.0esr"
+        },
+        "hi-IN": {
+          "hash": "sha512-cdAJWsS0fJtZJ4h4kJWfFvwb51wC/B0szc4WqJB1lKkAFGOt+FcWX960VIPfCjFBejw1wP7E2SOeHT9khZ2mxw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/hi-IN.xpi",
+          "version": "102.0esr"
+        },
+        "hr": {
+          "hash": "sha512-zLln1UJpX/AUObogdNEkKOjVps22m5HT9lMfLlsZchfL9sGAXwuFIBNUtuVrrOl2kltHS6nXPOzKqLsNGJWuFA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/hr.xpi",
+          "version": "102.0esr"
+        },
+        "hsb": {
+          "hash": "sha512-3EA0ySBjRfHuLTFwaxGgQc60jumeaibZmKfAM6p6p/tA+5U9peTVNPcmSOUHuc98lZDE/NRlFycw1jHsz1b+3Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/hsb.xpi",
+          "version": "102.0esr"
+        },
+        "hu": {
+          "hash": "sha512-Ua+VDHRErb30NkJlSaMoPzbB3I4UCMhnY9UBMMkRETilQWhDX4OlMx9xEZX1xX3oO/OIn9PGW1LrQO4m5OSrEg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/hu.xpi",
+          "version": "102.0esr"
+        },
+        "hy-AM": {
+          "hash": "sha512-5pgE5pTxdQj3oJP238BHpQJd/n1jK56QL+DaTMmx8grC175OHOegKe2gduqKXnYLo2ZCKYpII0nhzvDLxY/S9Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/hy-AM.xpi",
+          "version": "102.0esr"
+        },
+        "ia": {
+          "hash": "sha512-bEcW5HTxRdZANYhpOdi/oXjw2mjY4dOd3MfOqjgpq7DeKwUhs9xxsG+yoNR9tYNSvmVbFm0UH+gHIXOtCKgvkQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ia.xpi",
+          "version": "102.0esr"
+        },
+        "id": {
+          "hash": "sha512-paNP8n2vUFLRwYamoahXh2hgfww+LH7yqO54VDezhwwAUcJX+uKaLE6a6q73Bob1G8YLd/W3kTTFwhTjPGZsHA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/id.xpi",
+          "version": "102.0esr"
+        },
+        "is": {
+          "hash": "sha512-BcgWnFj99FPGDB/xO6VvtXKXQ5k4+3l46EDmrBM8ziaRc5yTGVqOkWwKZ+tiHFcrBpDjNH3yJHIsxpCyLvVm9w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/is.xpi",
+          "version": "102.0esr"
+        },
+        "it": {
+          "hash": "sha512-zNGEi+ttutxjgj7sU/f5MgXKAFuG/6MY4VBDlsKo3UIO0aCjug8lp567ZXBo21SDUYXml22IH/Np52QUSZpejw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/it.xpi",
+          "version": "102.0esr"
+        },
+        "ja": {
+          "hash": "sha512-sc8+NKgbh59r9fEUQSpuh6J7W+Ln9ryESxt9iLr6ZbJBauki2jtT0vpZ9QmwJ8PR3wTN4tSVpZPNtCbSr/NNmw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ja.xpi",
+          "version": "102.0esr"
+        },
+        "ka": {
+          "hash": "sha512-MVKi8A4Fx9u076+L5lSK5mK8uKGSPE1mjK6fTOERifIeO8LyLJ/vosi0lb7fEXBHPjQADP0R0D8x9cwxWyi0xw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ka.xpi",
+          "version": "102.0esr"
+        },
+        "kab": {
+          "hash": "sha512-IDosnumv0SAKp9hVNXHHOct5+EOgiRjoJko/V+hIIdangETp/OMM8JHUYq/gm5UkFnOhWgfMW1YIo4GVKhhKRg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/kab.xpi",
+          "version": "102.0esr"
+        },
+        "kk": {
+          "hash": "sha512-rZ5AXsUVOE39UTrpiaQ4Uy3vLYn7FZ04cgzIXfqaY/4zpYKOLDvb90ZuZZn4gDrPStTo/srhVU8HE9L93xpbaQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/kk.xpi",
+          "version": "102.0esr"
+        },
+        "km": {
+          "hash": "sha512-tSSAVYEBr5725LpyPJ5E+qAF3wsIv9Nhqk5s+xnBX+9zlOc/RNsh+BZUH/Eg+hZgp0XjHnKBs+ztcG+s6fiepg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/km.xpi",
+          "version": "102.0esr"
+        },
+        "kn": {
+          "hash": "sha512-9Opies9WGDj1zS/ehj7MoA6eV6dVWY9al2mS6ljOso8HWRMzaiyFRVMauGbhEhxUfBDzskK38yKLeyZ2Qaz9Ng==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/kn.xpi",
+          "version": "102.0esr"
+        },
+        "ko": {
+          "hash": "sha512-6aJ2UeyDX2AuAZjkjMjYQanweKIMmctt7P/nEF83rEAA6cvHEsDIW95l0fk7NzWfUDmIh8YJ34rHL4K4mGHZhA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ko.xpi",
+          "version": "102.0esr"
+        },
+        "lij": {
+          "hash": "sha512-ihhrglEZxhSgtRdBRmLJbGdrHbEhBTV3Dd4fbnTaDhRy7x8FKMgyHPYBX05KqHOOiuFWZAwq9l876V6j7mIvxg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/lij.xpi",
+          "version": "102.0esr"
+        },
+        "lt": {
+          "hash": "sha512-iupMQAJLVhzuMkDl8+PzZ/fBCfYnaDEBoNrsATrlKn57cPA2cewuIhSRgBR4eTOoFGu2bKH+Xgin/78bCZ/RBA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/lt.xpi",
+          "version": "102.0esr"
+        },
+        "lv": {
+          "hash": "sha512-gYzh+MvjDXhtg9+mPKJgNeaGs/Af3jiEkBFo3dALH1ElpQCQHuVBIakHI5YrqH8Mhj2bDa2WatcIe9asf9xq0w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/lv.xpi",
+          "version": "102.0esr"
+        },
+        "mk": {
+          "hash": "sha512-5BJ0wLavJ7l3CV4CKkaHWL9fnXeGmEpxASm8JTvPa+us18G811K/A4bl6VpYlIoB5J7idGPy37Ph3cFaBuWxgQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/mk.xpi",
+          "version": "102.0esr"
+        },
+        "mr": {
+          "hash": "sha512-qYwPLLEE3sVVou5MkFknn3rA7T0BnHGBEuOGleE+hgS9xVx3P3JRpH+Deb0KgDx17Z5d89HbSHYL9Amrk5nCig==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/mr.xpi",
+          "version": "102.0esr"
+        },
+        "ms": {
+          "hash": "sha512-DnaAouWKaFk510DBE4OWmuZ/l9T93T5+B3rBpBtdzu2Uz/2NNk9YTuHlOQN0YlQtgFh/cimHWEeKHwyDHVOkcg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ms.xpi",
+          "version": "102.0esr"
+        },
+        "my": {
+          "hash": "sha512-xc3OkdJB9x2rLuPMme3VZTRfDVzgWp+IfNEb/pwZhexwN7XII1Ixh/J8fdmUy0U9Z9wfNDgiWIg+4HQiA6AGDQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/my.xpi",
+          "version": "102.0esr"
+        },
+        "nb-NO": {
+          "hash": "sha512-sB1iKc3XBqAuWvnFMVXWE+qB6hqUdge/E3JRnId2Qc/7omx7M0OdH3xljKO6MTqjiuA+HSnfiF1PZ8bkxeDUmA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/nb-NO.xpi",
+          "version": "102.0esr"
+        },
+        "ne-NP": {
+          "hash": "sha512-bP52OXk+t9NBxbkKAtzkQi1kZbmH1dB7USKDos9/GHPA1PsooGgosS1R2blLbxi///YG8Z9NeRpRY7tzfMGw9w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ne-NP.xpi",
+          "version": "102.0esr"
+        },
+        "nl": {
+          "hash": "sha512-TvM3LU9viV1T51Ug+6YuwdLHP3nqOjfTWXZ6fwZdTTUD3t5+plUt5FmgJQJqfkj6B4GeK5pSbmmymK1duYvJXg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/nl.xpi",
+          "version": "102.0esr"
+        },
+        "nn-NO": {
+          "hash": "sha512-U7mDfreVP9iEAUn/c1a5lM5yeqhdUCJsq7/Ucv9rz13brV/+iG5HPRtnYhrOXZRMdoSh8vUY1NhGmLoWXDgYlA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/nn-NO.xpi",
+          "version": "102.0esr"
+        },
+        "oc": {
+          "hash": "sha512-JEkjw0AcKGVxWDQs7jkXqjuCwpLyM0DF5JFwGqjZQ1KDZJ2/QII9pEnrDkCV88t7zi6sqgg/J0ip32n74aaWRA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/oc.xpi",
+          "version": "102.0esr"
+        },
+        "pa-IN": {
+          "hash": "sha512-/FZHOzyMdlYz8S328TFU/Gi1tQYeVjhjB+WyjmzeGTK2mmnRIMJxWntUfVD6BkMUeIYoqQr+G+vxKrZZ8rYgIA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/pa-IN.xpi",
+          "version": "102.0esr"
+        },
+        "pl": {
+          "hash": "sha512-HyV383JxkIA273NSOphI6C8oAYg9XKWQM7phrwl82YNJz6TilKy2hHtTOap7vxYa/yDRDd/x5vVsZQPTwjgLNg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/pl.xpi",
+          "version": "102.0esr"
+        },
+        "pt-BR": {
+          "hash": "sha512-ZlsXGZkeEtfY/0hB1JdaP4BPkk+nuBshVYreUsU+x6Qn5D81jENaA8Ur7XE7WUzrDk12/SJZQtdjxBkk0wPniQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/pt-BR.xpi",
+          "version": "102.0esr"
+        },
+        "pt-PT": {
+          "hash": "sha512-sOsSjyk3LJLDUFFFu56rdlyhy1wSuXf9pHmzKmAIbx8UXEzd5eu5aH4ckM7451flhPJvyY2zLAS4v0bZ6RkSDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/pt-PT.xpi",
+          "version": "102.0esr"
+        },
+        "rm": {
+          "hash": "sha512-/6lCmu4VE/RqlAeLBdM78zQAoNymOtyqHKUAG7628KKvZAoRf/3nyObZ3w1orjtFP6LYgYPZtkxRWwuWNqUkcQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/rm.xpi",
+          "version": "102.0esr"
+        },
+        "ro": {
+          "hash": "sha512-BFqn2bk7D6miZh3rUF+D59+VSgo+6bRRAGgBO/8aNJX80LIQ1B8GxPPj4TqN2KzD4vvwNKSmeLcBFNtB9Z91Bg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ro.xpi",
+          "version": "102.0esr"
+        },
+        "ru": {
+          "hash": "sha512-QYwxrLa0RWEh7FyZsYPkg2TOVpUczDWUiRpMTevB7RBPqlTXIKJcVHUyQxDuwG+Lbw2EBR8a612o1YUfO97vHw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ru.xpi",
+          "version": "102.0esr"
+        },
+        "sco": {
+          "hash": "sha512-jpYMq0seMxmDxLPClX50POpAoUOkbiq7dC9+HZFGUC2UXFWVD2/NYGMHRRpmAJyWoYasyuHu3I2iZe6PzW5UAQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/sco.xpi",
+          "version": "102.0esr"
+        },
+        "si": {
+          "hash": "sha512-955Sl3mhji/3OBYQdDFX6hJYvF5hoaDGFnjAOpHUpStybZUyc/s4hMiW4ta0dku1BpYCcvXPF1M9GS9bVK+Msw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/si.xpi",
+          "version": "102.0esr"
+        },
+        "sk": {
+          "hash": "sha512-v9Mk32IJ6yLGspJMkKX4g0YIuqmZQ6Vdlp7m/lJ2GIlvg0coHISXR5buBwUcTQRPjs2gydX5RUrK9WoXsomqfA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/sk.xpi",
+          "version": "102.0esr"
+        },
+        "sl": {
+          "hash": "sha512-wGFOJ1S7+9WLVK57XAfbSk+8QJJRtEg/0WXhcczo05A5VCNfTj+TDNpQ2jqFWr4eIVEc4LO94hV9/phWhhXYTA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/sl.xpi",
+          "version": "102.0esr"
+        },
+        "son": {
+          "hash": "sha512-q/s8P56Vo+UIS1NukdHp9q6WeFfVG8m1SOihii76MwAGepCWb7tO5RoRnuZMJ+jt/mo30uxrXNOnDbHFjuzV5w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/son.xpi",
+          "version": "102.0esr"
+        },
+        "sq": {
+          "hash": "sha512-vC0sEU6Dy9IhRqtxsH0ZnreK0CsGWZgwPwj6rXAA2Xf+FryDN6Y2IIHSDMGOcFlNQEqhpGrYrBngz23IK5PClg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/sq.xpi",
+          "version": "102.0esr"
+        },
+        "sr": {
+          "hash": "sha512-x1Ap49uxv1BW4CVhZa6AtTGjoYoA/fxEJskR38Gy1BG3QbzzejJY5RuWsKsmUpzhj5+2UWrsb9uP3mNIAI/VZw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/sr.xpi",
+          "version": "102.0esr"
+        },
+        "sv-SE": {
+          "hash": "sha512-5FcvQgmVsFq8NL/6It0DPqZdsLguXw+lOzl/EDad6/R7+ehas7i2cxFs2PxKW9lO/+biXp+UYn5RrpHjCDgNxQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/sv-SE.xpi",
+          "version": "102.0esr"
+        },
+        "szl": {
+          "hash": "sha512-5zrti9DC+8BOske4wmug7st5UvDJdeyJ0DbwQHYhVtqKU6q6sUv1PJuIHx9dhRd5TvPdV8VIqGg2zqs5q/dQfA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/szl.xpi",
+          "version": "102.0esr"
+        },
+        "ta": {
+          "hash": "sha512-KaQOmKLNnJ4XZdGfjWHtoYjpasEMDyLePU2gH/lCBwl1VjZ7O3xjSEEO/qnAk51CNBrJ3xTUbpDipoE4oB0jNw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ta.xpi",
+          "version": "102.0esr"
+        },
+        "te": {
+          "hash": "sha512-0bp4Pd4Vlwql464UOWwKjLleSeqA1t+M/R/cMN6sk3dsHgy5jFJ4RgwsfbDqtUNWXD5ygUesGmj+hAgbWhiMUw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/te.xpi",
+          "version": "102.0esr"
+        },
+        "th": {
+          "hash": "sha512-Qxze3UKnlWw6k/HMhAVzz7g8EwH/HJlMNOYnM/ScOxNuxKu/wHDWoq35v8TjPv+zuFkYDFi7klhMB59s5lekQQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/th.xpi",
+          "version": "102.0esr"
+        },
+        "tl": {
+          "hash": "sha512-NHiEPPFc7DblS7z1+FRK3N1N7TOOlmGgbsQBJUfLzDjNRi2kV2FSeg50fv/lykxfqFFQ2KOljQpd8CqFhuRSzg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/tl.xpi",
+          "version": "102.0esr"
+        },
+        "tr": {
+          "hash": "sha512-Ix+atA2ciZk+CRF1EbQY4H0uRZK40V599Qo9Fml+7Ruz3Jjq7uItmL+1/KkgteIOfkar0Su9ZTOxLBMRKaO6+w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/tr.xpi",
+          "version": "102.0esr"
+        },
+        "trs": {
+          "hash": "sha512-QM/WItwZXFAdRdNsuzvf6h2roKGJ+r9b/7ZJ3R2Tgm3DnSr88IOoKrU4gX5meBpF9aSlnFooXMLPbPMNr8cvNQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/trs.xpi",
+          "version": "102.0esr"
+        },
+        "uk": {
+          "hash": "sha512-Z9xOYXDfX+LLzprl2zuSqABhD8x43z+0MZkEtF6fU0RZvpbHxvUiUwUHwnQfArYT67a9uK2p0UobJWBNj4M0ug==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/uk.xpi",
+          "version": "102.0esr"
+        },
+        "ur": {
+          "hash": "sha512-9o7jvOMhAoCihHwWbcPZKDF5l5bYz7y8oaa0h0hLJbjU75KfXkEpvBd9W8W2TjaG3ALg9PdQfg5CFBi1w3aggQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/ur.xpi",
+          "version": "102.0esr"
+        },
+        "uz": {
+          "hash": "sha512-5BWapKS8uMMnrQQiNpJ24i5cuHA+4TubjbZn6KMOrcUsU+QKI4bN/aOn2pRCQxxa049WMlJt0yzI3tWOd492aA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/uz.xpi",
+          "version": "102.0esr"
+        },
+        "vi": {
+          "hash": "sha512-gnyQkt2vfDEpcVHwdBT16jGCsxuQxZmh4b2w//EGJ0C6d+W9bem4R2Qv7rRMSrccxLyuaB4op97RCxhbpdgjsw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/vi.xpi",
+          "version": "102.0esr"
+        },
+        "xh": {
+          "hash": "sha512-gnmsHzhypqF62xVAgYYHA2gVFkUAKfNML3Ryi/6SeB95LNykWztoN9h63LmU2XLC/+LF7XhmHg9u8xlnEMqRlQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/xh.xpi",
+          "version": "102.0esr"
+        },
+        "zh-CN": {
+          "hash": "sha512-L+lugei7T7/xdgsmJAdicmeoBpLNxNKZ2nfX4dSrAwhZOuZ2461wIIYhfAvN/t2skngr8T39sRPLvkcdV8O84w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/zh-CN.xpi",
+          "version": "102.0esr"
+        },
+        "zh-TW": {
+          "hash": "sha512-dUdto3jVtlRjaMBisMiI7jr0xrVr4onkS1epB79Vo7/ZJKn2lOyvX0gr96gDwr6euIm4F2esyU30xvX6avjCjw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/102.0esr/linux-x86_64/xpi/zh-TW.xpi",
+          "version": "102.0esr"
+        }
+      }
+    },
+    "91esr": {
+      "linux-i686": {
+        "ach": {
+          "hash": "sha512-UV6EJNptFQVIDxVFHFY2O/ckcfpNDkez5DtMrCYbCIuCqFrS8yNO37hJm+q/OS4GNrIn0NfMcoXlRLHivc3zlQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ach.xpi",
+          "version": "91.11.0esr"
+        },
+        "af": {
+          "hash": "sha512-BLzGi4YafJsuGPxP394CR/9Rh58E6NupwpmODNk8oVb4z1b7Y95jvPksVsktqbfgN57QhH0lH6reILnh35aNYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/af.xpi",
+          "version": "91.11.0esr"
+        },
+        "an": {
+          "hash": "sha512-f49W0zNLvss74veApgME3wYxOm19vQ/Dry5tWwyT/nh8Nvek5iNkiT9ToDgV14RQBiY7EADbVtgX/ti+WQOz/Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/an.xpi",
+          "version": "91.11.0esr"
+        },
+        "ar": {
+          "hash": "sha512-94JGx5McNi7n8Qj4/sudlOcgfT7i8On+W6/5ww3xJP4YvD3eDAuDPYT1lpINQ54CKWvLn6CK03mYZYUHgMsf/A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ar.xpi",
+          "version": "91.11.0esr"
+        },
+        "ast": {
+          "hash": "sha512-ULtez3nBdtX8AN8wUMrUAwRTioG9zCI1rdbiZgormmufk9PdCsmaYI6fSz351RvEvBsCpQ4bwU+mYcGJabAauQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ast.xpi",
+          "version": "91.11.0esr"
+        },
+        "az": {
+          "hash": "sha512-wxfcqfoOJKo69EbD2pQR1Pk4QCQN6Up7wkXbmKoFTSK93CBB0MCzAZF/e3C9Ue6dmon51V/77gP5zBGJuntq1A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/az.xpi",
+          "version": "91.11.0esr"
+        },
+        "be": {
+          "hash": "sha512-r8SI4EPzluBRHCVaPwmW+FJ8Ma0Zbq27S+Ht/7Lk0idEoBjAlnh3ABAsM64cGcHzVm79LvNez0ezP/Y1JK7S9w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/be.xpi",
+          "version": "91.11.0esr"
+        },
+        "bg": {
+          "hash": "sha512-Pt6NlaDrCFnAyBWZXg5Q6AAE8xtONJkit4EQ4wDH40mOjyqnL3evdoBUzF9k9Jo4hzF8PRknKT5Z0P3ey8w0XQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/bg.xpi",
+          "version": "91.11.0esr"
+        },
+        "bn": {
+          "hash": "sha512-UKe8O+iPPcxEdQcI9ZTcPESSi7oKvobjW25zCctBfbDtkS6ij4MhH5fNKvxbTj4i0yHdCt6yZhU8vfc767dLeA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/bn.xpi",
+          "version": "91.11.0esr"
+        },
+        "br": {
+          "hash": "sha512-QdOJPx91Msc+XYzQ+AoNNLW2t2fG7E54qw7m6oM266ppoTt1oUVScSrOTLQAOhJrIg7ZHq4paJeXFef/yv9+HA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/br.xpi",
+          "version": "91.11.0esr"
+        },
+        "bs": {
+          "hash": "sha512-2CvN3yDgQWtBSRvF56KSAueljmWPb6ZgR2oszvrSV5gWnObgbRRYrp3JBljbLF79VqL8rQ4VnfK8UWzFMX7X3w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/bs.xpi",
+          "version": "91.11.0esr"
+        },
+        "ca": {
+          "hash": "sha512-jr8i6v5GcWZbjGuHMrdc0wo1Dv2PDKhe6J8xPyUza3CdRhr9vyWXPwRQZgdXbsN4lHmV1n+9aRFyNEYApYlaqQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ca.xpi",
+          "version": "91.11.0esr"
+        },
+        "ca-valencia": {
+          "hash": "sha512-fhuSeL+aH4brhi04kyK7I47iqANqKkqPB+vWmIuGHV+zK8tgmFHv3dgaWyd1qExnaRPcN2HPoAbfUkbT7hKqIA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ca-valencia.xpi",
+          "version": "91.11.0esr"
+        },
+        "cak": {
+          "hash": "sha512-Dgocidgf8KqwSpjOyO8x80tyxHFovF+f3SNPDCHIvRWFF4D6sMIGu+Bq5D0vzx7KiPcofXqwUtWP87IMqWIdeg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/cak.xpi",
+          "version": "91.11.0esr"
+        },
+        "cs": {
+          "hash": "sha512-I9D/+/I68WCXFc86niMfGHkxtOowFLW4CxMyQkJJoIw6MyzMABfAVlV+PlZBtewbCr1s0JPy+PGLFP6l+duRzQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/cs.xpi",
+          "version": "91.11.0esr"
+        },
+        "cy": {
+          "hash": "sha512-zKpoeFcrOZJPibm+fqNRDh4l9d/Ok1g1S79tkZrpShzH1XhSDmTCczC6hLN+i9aYFVt7Z0xfT7WP0ADcFKI9Rw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/cy.xpi",
+          "version": "91.11.0esr"
+        },
+        "da": {
+          "hash": "sha512-fLyB2fDeKrzHzQi+91wA0pFo5SKgsdhSoISCUE/PH7q+MRfk0dfj/Yq4J5XOKEpgYzamr2GfAN+58CUXa7o3Xg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/da.xpi",
+          "version": "91.11.0esr"
+        },
+        "de": {
+          "hash": "sha512-/m1FB4/dTBUX5S7jtWPBIsxrHZbamWaGbIESj7cmS/7HcgwYTQU7LLHt2vIQI4Z6l3XGdqHILyT8k9DScWR8SQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/de.xpi",
+          "version": "91.11.0esr"
+        },
+        "dsb": {
+          "hash": "sha512-E/KZit146PjKX1s3eKlV9GZugjB3h3FpEinB29h1CljZvuqYzKVIxxQNFDY7nM355o8ImRTID8aXkV7IAqqmMg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/dsb.xpi",
+          "version": "91.11.0esr"
+        },
+        "el": {
+          "hash": "sha512-lO2J52kBcZGUYMEw/gU6MbVPErttpR/EdjWmwF8d5jENmdRKuIe4neQPoSyC+tkLPJZyPLQXspHsgurPwBVKLg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/el.xpi",
+          "version": "91.11.0esr"
+        },
+        "en-CA": {
+          "hash": "sha512-NcvBzq518rAfJSabvIQbTfk+IC+xnJgwv4A57RDrLeywhadZUn4cIaTj0j00PLNPAI7UlxzWGsi/RsUWqFaNCA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/en-CA.xpi",
+          "version": "91.11.0esr"
+        },
+        "en-GB": {
+          "hash": "sha512-lnMgfyRh9rfqfcr6b0pBf1fWuFgOm8CyORnG3c8kkEHYKRILGJYPtbB8Dw34+G3a2WbU63jHkIRRj8IZJMuwDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/en-GB.xpi",
+          "version": "91.11.0esr"
+        },
+        "en-US": {
+          "hash": "sha512-ORrlrbpmKMGUiRwxj0AP4fw3/LUD6smF+ohTIH4DSdy0d84PkKhoQ+8f0BybcBLR+GkA1okFLbZlQ+gJw+vE3w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/en-US.xpi",
+          "version": "91.11.0esr"
+        },
+        "eo": {
+          "hash": "sha512-hLcYuRiXOEIUs5CAuZp+aBXOFPDinr2Wy1AqAxbCbWOIWKG6kqBbAavaGIDH8aIi1qZg2ay+XEgdgpCYQJPN9Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/eo.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-AR": {
+          "hash": "sha512-+U45lF6ibVHUkgGnT3gA0d/B7l/Ag+a9QkN7zzqmaPKqQR/kzOco3K5cOivNaZna9LpZ+rfMS6ElxUx+LmsfBw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-AR.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-CL": {
+          "hash": "sha512-GDl/22384NIUhPxxvCHoCMtCE4AAHWzoZ6ZsL3TqcfBBfPKgEa56ZNdBeKM5I4tckQtkJUF464JZj9zZPm1ccA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-CL.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-ES": {
+          "hash": "sha512-xSlyakBEHiLCl2S0tmLoKDabJCe9BS5wcaAtOK2l0Ce3T07tjWRnh8XyIUH50G8PaJpK5P7xW17d0HG8Rk6WWw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-ES.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-MX": {
+          "hash": "sha512-zaoWYM32ekRtlNSOEWunKl5h2GuTodxNu7/zfq+UHoL56Fy5DiAE6JGVXzY4mVNHOitpxbT/QIO1KLHbAu3PyA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-MX.xpi",
+          "version": "91.11.0esr"
+        },
+        "et": {
+          "hash": "sha512-nhzyYLmQBIYtPrF6SNIPvuh7gnYPaboJqqIW8/inPIFmnxTmVyt6YJZdBQLSCXXP9cko9d36laaTvomikbDUKw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/et.xpi",
+          "version": "91.11.0esr"
+        },
+        "eu": {
+          "hash": "sha512-usB8aJLfYiPFZBaT8k2MmCJmjbceZ6z0TCWaUhNejxfsqD2XhJ407CT/4GcspLa7KYT1vmo/31cS1+odjxTPzA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/eu.xpi",
+          "version": "91.11.0esr"
+        },
+        "fa": {
+          "hash": "sha512-fdawOVw1HrAsjYuOs8uld4Z/P291kPQxU0yv8msVb1xBYRTMarY4NG2QFImhDCcBbPXHMzKV3pY7Z3+cJCrjFQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fa.xpi",
+          "version": "91.11.0esr"
+        },
+        "ff": {
+          "hash": "sha512-XGJ59kaFLoZXFR7RthoUJD9VtqmCoUSRT5/nkU6g7iHMcuUwus2p5rtwiwRVyHCDqSCLDWvV5/TyzOSiTwTcMQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ff.xpi",
+          "version": "91.11.0esr"
+        },
+        "fi": {
+          "hash": "sha512-2c1t1XPFiCvMP4K3t+a1Su8EpH2VjDVN/JwE3nrOOPBIWVk92IWj/s1LX4GhVYIyWbr0r5I/6zHHa3OkxkTW5Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fi.xpi",
+          "version": "91.11.0esr"
+        },
+        "fr": {
+          "hash": "sha512-FKFhdAPPX3oOFG7zBacAZcXSAkQUMNoqLbi7JiB8q4Sm57uHOHhH4Nm0A9myp5eoc5+fppXuwMnP9kjBdZ5i6Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fr.xpi",
+          "version": "91.11.0esr"
+        },
+        "fy-NL": {
+          "hash": "sha512-rNyGzgwgaRod8erqF0vOdfKIa0UgZMZgH09+WT66C4jPnCOi5L0pM1sKD8Yr+4dPTMTEOSi+hSiXOdLzYa3ctQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fy-NL.xpi",
+          "version": "91.11.0esr"
+        },
+        "ga-IE": {
+          "hash": "sha512-PrpkCjVQ0mlVA/djl10eOOg6H6SfhXZJj35yWceYxLA0MZ/sHlXnBaulqGSclHm1mQHjLUtPvI9zHhEcMlFMzQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ga-IE.xpi",
+          "version": "91.11.0esr"
+        },
+        "gd": {
+          "hash": "sha512-YYwUXGpPGiQy74XlcmnZFQaj/18sJGRjKhjB4W/9w94bPCMjAC4j4Bl/twG3QI1JBa0ZBQQyOeG9iN4vXd0Fyw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gd.xpi",
+          "version": "91.11.0esr"
+        },
+        "gl": {
+          "hash": "sha512-DX5NcJsBqNkB+Wwl/VESKHSF9kj6FBiFQh4mVqgeQLcfhzcSQ5AhesGdkCwi5g8cqm8z6jzb5DUgjxm0P0+R5w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gl.xpi",
+          "version": "91.11.0esr"
+        },
+        "gn": {
+          "hash": "sha512-CrRKbWcy8FCFXFs9e59uX5IxaVEYcDDJUZLTXiF2LciRumhDCjMsHT/+IBYJYIrwhJv87QH0+es7euvDRZwrNw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gn.xpi",
+          "version": "91.11.0esr"
+        },
+        "gu-IN": {
+          "hash": "sha512-8+p9QmOx1Bj7i9wZ0LT8gAjU547ya5S7fU0k8ktkD5QQy3NFaQzzR57XlUt+AckK0BZ1mBIN+6hr6Xg+z5lHgw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gu-IN.xpi",
+          "version": "91.11.0esr"
+        },
+        "he": {
+          "hash": "sha512-VPVsppwYyDAT9gQTmx4/U8Mxv3a5r6UGiDdQWceqh4MnkireXm6vJSCFnE/Q+K27j7Y2En7nr/ehg2a7hmeW0w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/he.xpi",
+          "version": "91.11.0esr"
+        },
+        "hi-IN": {
+          "hash": "sha512-2wzPeBMx7KaCe4j9jvs3qupZKUS3sr7pVg/Q1+RHyjK7kQoMmX7WHFVBV4U4t1SZxXtm4loZykSbXmwZVhSh9g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hi-IN.xpi",
+          "version": "91.11.0esr"
+        },
+        "hr": {
+          "hash": "sha512-8gc7m9/pEKbRSqVY5897jB9hEJk4uKlaMTgPCMRhjwzrssoUD2kyF5GWXcuXm9SuonFvCpLRF/B45hXOd9ouJA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hr.xpi",
+          "version": "91.11.0esr"
+        },
+        "hsb": {
+          "hash": "sha512-JdzryecYb4D44HNwxr6/UFybZ4DBalPb3n0V3HNBA6xXw/GC9dFUL/2qqm1vPJaGDegRRsY07WiqIloHzcATAg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hsb.xpi",
+          "version": "91.11.0esr"
+        },
+        "hu": {
+          "hash": "sha512-Qer9YcD1yjZjqtzG1X8bty5kPFNPMlZkP9CGvpV+lKzuWTL7wQyD2rZb/tmC5BCYrMscqAZ13aiHybsj5DyOuA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hu.xpi",
+          "version": "91.11.0esr"
+        },
+        "hy-AM": {
+          "hash": "sha512-Aa035IVCc47fgtBwPvsVJ62NLj1CvxC8XLE5qrIqc8r0MmoMiK0b5IjhtMy16yZoZVh5SsmQwdExUj+edXFUJA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hy-AM.xpi",
+          "version": "91.11.0esr"
+        },
+        "ia": {
+          "hash": "sha512-OxogOR76N3b88N8uMtd4KfugN/EeYasVPSrsk/FyPJptWqSFIdNV9C008g/hkUiXal30IbHBaR0dlyzcMUtLUg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ia.xpi",
+          "version": "91.11.0esr"
+        },
+        "id": {
+          "hash": "sha512-n7UKOL6P2JS7MheZuMM7FCv5y7EePNBhGGDvl0yYes3Vez2kBwGspvPTacbU9TTa32nX5OvAHEyH1UuztreICw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/id.xpi",
+          "version": "91.11.0esr"
+        },
+        "is": {
+          "hash": "sha512-57NuiYfXsCgoRVK/NKvswDnoO0avP7fJVEcbIo2r+EPuEqWNgk+NFg/XQkWJnQfiRh44oJScj6IWNbk3UPss8g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/is.xpi",
+          "version": "91.11.0esr"
+        },
+        "it": {
+          "hash": "sha512-Ytl7MCEHLYZC4NPqsdMv0Ec8IVemPoZ5YTLWzHIExpbL6qP61JuQnLagaARd6G3iU+QWBLjLA39a+1QbjJOTAQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/it.xpi",
+          "version": "91.11.0esr"
+        },
+        "ja": {
+          "hash": "sha512-v1PK3QAWiRUMqMvsuHLPwiyf0CbtNGO7JZXyw7nWZ4p2gpBhCLxZcllNxD7glTWICUplKY2kGsO66AOpDskgrA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ja.xpi",
+          "version": "91.11.0esr"
+        },
+        "ka": {
+          "hash": "sha512-C52pfkRqUvwdDDfqQCUXanxuobU/dlISd8+90cQZ8oQPH5i/vTM8AzhZKgIRix7MtEp6dxbzqNF1ggfWsV8k2A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ka.xpi",
+          "version": "91.11.0esr"
+        },
+        "kab": {
+          "hash": "sha512-v7DoY70F+wyrScPMewWA//ri9Bkt0s+xhSRw9eDeQld7l1UZGWdDUPKz+G5Tl2Oi00WLvrQKGFLYZuWya7qoiA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/kab.xpi",
+          "version": "91.11.0esr"
+        },
+        "kk": {
+          "hash": "sha512-9Jd+FDpOTouR6423KrGsQ3hxztEoLkcAZX11Jn1FWc9oSvrDIPyx/MyLVBj55lI+CIeZWEk7tMlpk4qUrxwXag==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/kk.xpi",
+          "version": "91.11.0esr"
+        },
+        "km": {
+          "hash": "sha512-UvKQ1ASbzjKs5kozwDKoBlILKekn/ov5LV+iJsXSHeDSmLAKJuBbulObr6LXAq8dvrcyhFxFZfdaF+Q74ZXjsA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/km.xpi",
+          "version": "91.11.0esr"
+        },
+        "kn": {
+          "hash": "sha512-ZAs6D9HJiF7ijjLN97ce6mk9XgHmfgkQs/Sf9QaxWTgn1M2YysFIGhfaMNs3RZkRTPmBvRC4jbjaNRjubR3HlA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/kn.xpi",
+          "version": "91.11.0esr"
+        },
+        "ko": {
+          "hash": "sha512-oxGM12zwwvl6kViugzUknQQt3jEJPfV6Hg5BdTbLkxFRDuV37CsSXhF8Uqaho9Betiud5H3Td4bpQq1ZDnG7mw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ko.xpi",
+          "version": "91.11.0esr"
+        },
+        "lij": {
+          "hash": "sha512-nGHU9ZZFgMIeSjYEkvq7C2ABuU1/Yo0cvIqOd5EuXP4MNZO/HPEh5VGW/u5i9aO35KzdR/17EqUcKyRT4jt9xQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/lij.xpi",
+          "version": "91.11.0esr"
+        },
+        "lt": {
+          "hash": "sha512-cPTizsOTQJYqws3hMl7KeHkpjR5XM7ySKGweIJK1sXYBsjzY1knVgJ0PK/VjbLT6JNw7j+g/vjoWlIE3Q1xkIQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/lt.xpi",
+          "version": "91.11.0esr"
+        },
+        "lv": {
+          "hash": "sha512-PjkQU1UrPSCLeYo5mbCSbjVorFtxiCrcOpZPEO8E5guOqMZkOE0wjsprBonM022i6ttEzlVotSqdz/LyXddoOA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/lv.xpi",
+          "version": "91.11.0esr"
+        },
+        "mk": {
+          "hash": "sha512-uEI6kPkmEsUIlaSSteqrbmzh1mZmdaxomq48vyhWQ6ATI3nblXkaWVKN7QKku168HS3kSrssPiQD77QfJLfKhw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/mk.xpi",
+          "version": "91.11.0esr"
+        },
+        "mr": {
+          "hash": "sha512-NuSfd7GeKwzqJDw7kgGhK7+1pj6C+1z5JoZ6cWusRASbj8/Kyuc4BNDMO77aIw50dgjKHJyRFc9gzmlx5n7JKQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/mr.xpi",
+          "version": "91.11.0esr"
+        },
+        "ms": {
+          "hash": "sha512-ZaQrukzvxklI7NT2rqhheKLTXXArvSnz6adTqtbuTEc4dEWvC9yOVYogWTV+J/bvMPMJGnBhZjmdk07h/xW+gg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ms.xpi",
+          "version": "91.11.0esr"
+        },
+        "my": {
+          "hash": "sha512-J5sXSpMNnDx/lFlD8zI3HbDGSGl8iyt0PwkZklAJTeFcw+1NGDdF1R7T8Hh2p/36Kj2DtMV5F1fZRINvBwR+rw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/my.xpi",
+          "version": "91.11.0esr"
+        },
+        "nb-NO": {
+          "hash": "sha512-9Ps9OR3CqeofXANUEU417kPEvYGQ164fDNx4V31lI0HPAaNgNDVfYV5V06gJqvKFHXePrZtr0mt6nEjbPgUhog==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/nb-NO.xpi",
+          "version": "91.11.0esr"
+        },
+        "ne-NP": {
+          "hash": "sha512-jaQzMpw/svWQEASDu5h6hyDUH7BUNeyvcU9Flob00ZjlQbDDRKMT7o0mvlPVSMHKpITXrSKaS5D5zFHA6Lshrg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ne-NP.xpi",
+          "version": "91.11.0esr"
+        },
+        "nl": {
+          "hash": "sha512-XWXxAHYuMlF2lF5PmidbcB75gBDT1hMtulOV8JVPpyPppM8YZGLzDZQo2Int24pxW68HDqcPf70+12phib/D+Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/nl.xpi",
+          "version": "91.11.0esr"
+        },
+        "nn-NO": {
+          "hash": "sha512-4HBsfHf7mAGgI2Z6pbrL7BpzUWSWYaXXsqCyYMIH5cWTYxPU8ZJxnJXnmDKHNoQUuaONzhat65JJfzmRH9Qelg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/nn-NO.xpi",
+          "version": "91.11.0esr"
+        },
+        "oc": {
+          "hash": "sha512-qIJpoqELzTVFRtULFjG5irzpcvN2c3gGtSYKT0yw9kpJz5uKInK2eqZlz5m46Iwr0is4RqMp+zpT47y1/SnP0w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/oc.xpi",
+          "version": "91.11.0esr"
+        },
+        "pa-IN": {
+          "hash": "sha512-WBf3NDJYzV7vx2Muo2Om/wx82c67wMhQofnMgi1PWrK4OhnujYEbGvYSx1lN6z6NJ1i62qOoJfnA8/JL5UuG9A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pa-IN.xpi",
+          "version": "91.11.0esr"
+        },
+        "pl": {
+          "hash": "sha512-0zuQ2Rq4lgjp9xEdcmptMv6Vgxrggwamd61/XeWeq5n9j0I6Vm/BdZCzsldrKdzTMoB1EzApiz06Li48JNsdoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pl.xpi",
+          "version": "91.11.0esr"
+        },
+        "pt-BR": {
+          "hash": "sha512-ke7mRVO+XwK+ovpm5m2CeUQLAiJOLv48a4lekUT4mnkQpgZ9bdMgOGuSe7+Q/pmUK+xkfiO0WtzvUL6ZQu6SpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pt-BR.xpi",
+          "version": "91.11.0esr"
+        },
+        "pt-PT": {
+          "hash": "sha512-qRUx5NNaCqMcQ6CTM6ArKTTxqT7GQTwR5W+MwPvvl0e6qzmpYuQjb22bUbSCqHBBOZUfw8WH56memD+6VAucqA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pt-PT.xpi",
+          "version": "91.11.0esr"
+        },
+        "rm": {
+          "hash": "sha512-d+jMQC61PaaV45rC5t08Wj3G0heaHeyEV1sdNvIhPhcnJoOIYeXp34l8oyniErT/dJ25VzjqU20lvO6AGVBPCg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/rm.xpi",
+          "version": "91.11.0esr"
+        },
+        "ro": {
+          "hash": "sha512-caMegR7q/ZhWzBjtljt0lSYQdNXlrHorthxFoGyqg7ao8g+fVmR0uiFBEWcYouCOpqbn6qicskAZHXSAEF300w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ro.xpi",
+          "version": "91.11.0esr"
+        },
+        "ru": {
+          "hash": "sha512-pHOVKn/D6XGaicl0O3xJkQch1mipVYI6V9mZTsvOr6ThFs614RzBES8zPnWs3Kh/l1zd2riCTjhIRlBBRFqFgg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ru.xpi",
+          "version": "91.11.0esr"
+        },
+        "sco": {
+          "hash": "sha512-jnXjz3aLhInVVxiVhf7mjgm5+rfW1AMCOt6bmsPKUfCGwjvf54TAGZ5HrtIiq/+Wrz5naV/xof3yUyB7XM5JkQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sco.xpi",
+          "version": "91.11.0esr"
+        },
+        "si": {
+          "hash": "sha512-1oTnKo9GGBfx2DrUIhejlgnbYYjFb+bcROz708eg1H71P6APDzjCqK7xNPzaHCxi0jvIFtRKXBtb1FoN3cWX2w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/si.xpi",
+          "version": "91.11.0esr"
+        },
+        "sk": {
+          "hash": "sha512-ZPCDMylV+HWMhGB0pD99ANkFONq+Hl2a/pIE0RxjduSx3jPN4F50i/IeYNQPedZjHq6POXY5uqcmIBpXk7Bgjw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sk.xpi",
+          "version": "91.11.0esr"
+        },
+        "sl": {
+          "hash": "sha512-ij3hLLneA7b91oJFbCh+aTpeqKzFUpXYI+yuCBmS4eCpu9Ereqfmz4aACBmENnUA2FQmTND/P/JCKdyMGFK39g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sl.xpi",
+          "version": "91.11.0esr"
+        },
+        "son": {
+          "hash": "sha512-XJjPQ+9+Log6emtH5l3LqjhLqbZYSTIneGXy+IQ+KGJKd2wHTVFC457IyDjGl6V3ds1Xfma1+eI3S4idAOX7jg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/son.xpi",
+          "version": "91.11.0esr"
+        },
+        "sq": {
+          "hash": "sha512-VWA5j9+UELrqTJr3u/B9tiQCOgiHurolG9or1ngNdpGCExfyGyocISsGpjE+oigAFeeGL1A7B54AhjWzxuoaGg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sq.xpi",
+          "version": "91.11.0esr"
+        },
+        "sr": {
+          "hash": "sha512-9fxFJ288PLWRnq2wsjacWHG2MXTSJcJjQqnaDLwncid2bd2PUO9XBlvBFEXgGFVdMRgM47gMGJ1iqkaF4DWIpw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sr.xpi",
+          "version": "91.11.0esr"
+        },
+        "sv-SE": {
+          "hash": "sha512-OJ8EK79SYfu0P1kBGrd2gDakVBwo4VxDkQ+dGoKPyASHglz9lLbPYti+KRX1w9fK7PAkhCATtKAeEfD8fS0OKg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sv-SE.xpi",
+          "version": "91.11.0esr"
+        },
+        "szl": {
+          "hash": "sha512-rOPDKqy9WllR+YxGKyXdYiCPTe18POcafgq0uST7VtombQG9ik5WE3IPHKXm0EjkMtdgrFYGrNXrcyeHDuG68w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/szl.xpi",
+          "version": "91.11.0esr"
+        },
+        "ta": {
+          "hash": "sha512-kI5CW7B+PDMe9UltqPhVCPFu8228Rq91tExzNJFlJAOryjF1HuaigOAR7UNNlugw/RZxCOXCkCPjxyLObuTEjw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ta.xpi",
+          "version": "91.11.0esr"
+        },
+        "te": {
+          "hash": "sha512-kNDt5A5+Le1ntmg/NtITZCTabBOXE0d8uu3owtXEcPzDzJ7k0lQxlfZYIEYDfFSxMIFbl+BbVUS7ykfuL1vykA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/te.xpi",
+          "version": "91.11.0esr"
+        },
+        "th": {
+          "hash": "sha512-24gEYPrOH/0ntop6hZ1pz5VZeELNMaXS+bxpCTEUQayGH0K54cTv5vb8STjVmgsIABX8iYVzvVHKS0oRiK+wHg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/th.xpi",
+          "version": "91.11.0esr"
+        },
+        "tl": {
+          "hash": "sha512-onsjwThqW6YUhlBD+nKkRyhQeOGIow6uNxISJQybWzYVuZbN7u8lzkN1MGEOByXVRKQhSoUNWTTs80nVqcAA4g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/tl.xpi",
+          "version": "91.11.0esr"
+        },
+        "tr": {
+          "hash": "sha512-lmlWRvgoeAwYjOP4qtChpz6eMkpDB7qnlya3E1ogkQpXF7iNG8cE79aElbBRPlwNUZzA+rs57/5hCJ1qlO6sDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/tr.xpi",
+          "version": "91.11.0esr"
+        },
+        "trs": {
+          "hash": "sha512-EPYqiH32MK37bSbxJwAO++sNO3GDrYhsKMDpCabXi/hlDV6tOE0x2io7lmU/FUE99QDC/G/IQGsCe71tyKT4Lw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/trs.xpi",
+          "version": "91.11.0esr"
+        },
+        "uk": {
+          "hash": "sha512-3oO1rQDC7y77vuCwsMDVbVXJeUhNW5nqJz5Ggd09O8VF3K+GsU6bxv38hZY6x5xYtZbEmLlGle9Aii0vCWyWIQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/uk.xpi",
+          "version": "91.11.0esr"
+        },
+        "ur": {
+          "hash": "sha512-YJDxbzK0Sr1kBLebp157FP5DdCSFLZMqOfrCbiieYy5gBHS1PjmRjjc8WNiZSQ18X6ykI6JoqhJFeIXjI5S1sQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ur.xpi",
+          "version": "91.11.0esr"
+        },
+        "uz": {
+          "hash": "sha512-ISmfN85/73lmp3Tq6U2YICDIkAVpScxE7YI+rJ7Um3J1Q13gbmPeL6fNey+xziF9+Vwbpmkn+wRRja6HN/YcYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/uz.xpi",
+          "version": "91.11.0esr"
+        },
+        "vi": {
+          "hash": "sha512-HC/qjULmgiTJWkNoKwgLpe1kb3ZQlT2w7DuTMtWMmVmK8ArigxqsKhg3n/EbihAn2QhGcFy7h4FaWTDzA8h3TA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/vi.xpi",
+          "version": "91.11.0esr"
+        },
+        "xh": {
+          "hash": "sha512-snkL2RSIKnFO+DVVWsONsnpoGDjSj1ObAE7QkYGjPo1yDv9Upz7sUSbjjIjndffjtf8NPeXrwo9rsZFerkarXA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/xh.xpi",
+          "version": "91.11.0esr"
+        },
+        "zh-CN": {
+          "hash": "sha512-dYLq+uiNHlAkKXBq2IjBbWz46s9SYyrmNEImvmCYuIvvKxW8uKwNZMtW9eVHIzyrwrqn/480plwww3QNkmMX8Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/zh-CN.xpi",
+          "version": "91.11.0esr"
+        },
+        "zh-TW": {
+          "hash": "sha512-LChooIbS5pPNFX5ovZWUJ3OBIhyUzlbJyzGLyjguaWHaoq/AE4YydnazhOr50oJH6nlFuWjKpmvI1GwOwAzmDQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/zh-TW.xpi",
+          "version": "91.11.0esr"
+        }
+      },
+      "linux-x86_64": {
+        "ach": {
+          "hash": "sha512-UV6EJNptFQVIDxVFHFY2O/ckcfpNDkez5DtMrCYbCIuCqFrS8yNO37hJm+q/OS4GNrIn0NfMcoXlRLHivc3zlQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ach.xpi",
+          "version": "91.11.0esr"
+        },
+        "af": {
+          "hash": "sha512-BLzGi4YafJsuGPxP394CR/9Rh58E6NupwpmODNk8oVb4z1b7Y95jvPksVsktqbfgN57QhH0lH6reILnh35aNYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/af.xpi",
+          "version": "91.11.0esr"
+        },
+        "an": {
+          "hash": "sha512-f49W0zNLvss74veApgME3wYxOm19vQ/Dry5tWwyT/nh8Nvek5iNkiT9ToDgV14RQBiY7EADbVtgX/ti+WQOz/Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/an.xpi",
+          "version": "91.11.0esr"
+        },
+        "ar": {
+          "hash": "sha512-94JGx5McNi7n8Qj4/sudlOcgfT7i8On+W6/5ww3xJP4YvD3eDAuDPYT1lpINQ54CKWvLn6CK03mYZYUHgMsf/A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ar.xpi",
+          "version": "91.11.0esr"
+        },
+        "ast": {
+          "hash": "sha512-ULtez3nBdtX8AN8wUMrUAwRTioG9zCI1rdbiZgormmufk9PdCsmaYI6fSz351RvEvBsCpQ4bwU+mYcGJabAauQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ast.xpi",
+          "version": "91.11.0esr"
+        },
+        "az": {
+          "hash": "sha512-wxfcqfoOJKo69EbD2pQR1Pk4QCQN6Up7wkXbmKoFTSK93CBB0MCzAZF/e3C9Ue6dmon51V/77gP5zBGJuntq1A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/az.xpi",
+          "version": "91.11.0esr"
+        },
+        "be": {
+          "hash": "sha512-r8SI4EPzluBRHCVaPwmW+FJ8Ma0Zbq27S+Ht/7Lk0idEoBjAlnh3ABAsM64cGcHzVm79LvNez0ezP/Y1JK7S9w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/be.xpi",
+          "version": "91.11.0esr"
+        },
+        "bg": {
+          "hash": "sha512-Pt6NlaDrCFnAyBWZXg5Q6AAE8xtONJkit4EQ4wDH40mOjyqnL3evdoBUzF9k9Jo4hzF8PRknKT5Z0P3ey8w0XQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/bg.xpi",
+          "version": "91.11.0esr"
+        },
+        "bn": {
+          "hash": "sha512-UKe8O+iPPcxEdQcI9ZTcPESSi7oKvobjW25zCctBfbDtkS6ij4MhH5fNKvxbTj4i0yHdCt6yZhU8vfc767dLeA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/bn.xpi",
+          "version": "91.11.0esr"
+        },
+        "br": {
+          "hash": "sha512-QdOJPx91Msc+XYzQ+AoNNLW2t2fG7E54qw7m6oM266ppoTt1oUVScSrOTLQAOhJrIg7ZHq4paJeXFef/yv9+HA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/br.xpi",
+          "version": "91.11.0esr"
+        },
+        "bs": {
+          "hash": "sha512-2CvN3yDgQWtBSRvF56KSAueljmWPb6ZgR2oszvrSV5gWnObgbRRYrp3JBljbLF79VqL8rQ4VnfK8UWzFMX7X3w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/bs.xpi",
+          "version": "91.11.0esr"
+        },
+        "ca": {
+          "hash": "sha512-jr8i6v5GcWZbjGuHMrdc0wo1Dv2PDKhe6J8xPyUza3CdRhr9vyWXPwRQZgdXbsN4lHmV1n+9aRFyNEYApYlaqQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ca.xpi",
+          "version": "91.11.0esr"
+        },
+        "ca-valencia": {
+          "hash": "sha512-fhuSeL+aH4brhi04kyK7I47iqANqKkqPB+vWmIuGHV+zK8tgmFHv3dgaWyd1qExnaRPcN2HPoAbfUkbT7hKqIA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ca-valencia.xpi",
+          "version": "91.11.0esr"
+        },
+        "cak": {
+          "hash": "sha512-Dgocidgf8KqwSpjOyO8x80tyxHFovF+f3SNPDCHIvRWFF4D6sMIGu+Bq5D0vzx7KiPcofXqwUtWP87IMqWIdeg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/cak.xpi",
+          "version": "91.11.0esr"
+        },
+        "cs": {
+          "hash": "sha512-I9D/+/I68WCXFc86niMfGHkxtOowFLW4CxMyQkJJoIw6MyzMABfAVlV+PlZBtewbCr1s0JPy+PGLFP6l+duRzQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/cs.xpi",
+          "version": "91.11.0esr"
+        },
+        "cy": {
+          "hash": "sha512-zKpoeFcrOZJPibm+fqNRDh4l9d/Ok1g1S79tkZrpShzH1XhSDmTCczC6hLN+i9aYFVt7Z0xfT7WP0ADcFKI9Rw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/cy.xpi",
+          "version": "91.11.0esr"
+        },
+        "da": {
+          "hash": "sha512-fLyB2fDeKrzHzQi+91wA0pFo5SKgsdhSoISCUE/PH7q+MRfk0dfj/Yq4J5XOKEpgYzamr2GfAN+58CUXa7o3Xg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/da.xpi",
+          "version": "91.11.0esr"
+        },
+        "de": {
+          "hash": "sha512-/m1FB4/dTBUX5S7jtWPBIsxrHZbamWaGbIESj7cmS/7HcgwYTQU7LLHt2vIQI4Z6l3XGdqHILyT8k9DScWR8SQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/de.xpi",
+          "version": "91.11.0esr"
+        },
+        "dsb": {
+          "hash": "sha512-E/KZit146PjKX1s3eKlV9GZugjB3h3FpEinB29h1CljZvuqYzKVIxxQNFDY7nM355o8ImRTID8aXkV7IAqqmMg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/dsb.xpi",
+          "version": "91.11.0esr"
+        },
+        "el": {
+          "hash": "sha512-lO2J52kBcZGUYMEw/gU6MbVPErttpR/EdjWmwF8d5jENmdRKuIe4neQPoSyC+tkLPJZyPLQXspHsgurPwBVKLg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/el.xpi",
+          "version": "91.11.0esr"
+        },
+        "en-CA": {
+          "hash": "sha512-NcvBzq518rAfJSabvIQbTfk+IC+xnJgwv4A57RDrLeywhadZUn4cIaTj0j00PLNPAI7UlxzWGsi/RsUWqFaNCA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/en-CA.xpi",
+          "version": "91.11.0esr"
+        },
+        "en-GB": {
+          "hash": "sha512-lnMgfyRh9rfqfcr6b0pBf1fWuFgOm8CyORnG3c8kkEHYKRILGJYPtbB8Dw34+G3a2WbU63jHkIRRj8IZJMuwDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/en-GB.xpi",
+          "version": "91.11.0esr"
+        },
+        "en-US": {
+          "hash": "sha512-ORrlrbpmKMGUiRwxj0AP4fw3/LUD6smF+ohTIH4DSdy0d84PkKhoQ+8f0BybcBLR+GkA1okFLbZlQ+gJw+vE3w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/en-US.xpi",
+          "version": "91.11.0esr"
+        },
+        "eo": {
+          "hash": "sha512-hLcYuRiXOEIUs5CAuZp+aBXOFPDinr2Wy1AqAxbCbWOIWKG6kqBbAavaGIDH8aIi1qZg2ay+XEgdgpCYQJPN9Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/eo.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-AR": {
+          "hash": "sha512-+U45lF6ibVHUkgGnT3gA0d/B7l/Ag+a9QkN7zzqmaPKqQR/kzOco3K5cOivNaZna9LpZ+rfMS6ElxUx+LmsfBw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-AR.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-CL": {
+          "hash": "sha512-GDl/22384NIUhPxxvCHoCMtCE4AAHWzoZ6ZsL3TqcfBBfPKgEa56ZNdBeKM5I4tckQtkJUF464JZj9zZPm1ccA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-CL.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-ES": {
+          "hash": "sha512-xSlyakBEHiLCl2S0tmLoKDabJCe9BS5wcaAtOK2l0Ce3T07tjWRnh8XyIUH50G8PaJpK5P7xW17d0HG8Rk6WWw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-ES.xpi",
+          "version": "91.11.0esr"
+        },
+        "es-MX": {
+          "hash": "sha512-zaoWYM32ekRtlNSOEWunKl5h2GuTodxNu7/zfq+UHoL56Fy5DiAE6JGVXzY4mVNHOitpxbT/QIO1KLHbAu3PyA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-MX.xpi",
+          "version": "91.11.0esr"
+        },
+        "et": {
+          "hash": "sha512-nhzyYLmQBIYtPrF6SNIPvuh7gnYPaboJqqIW8/inPIFmnxTmVyt6YJZdBQLSCXXP9cko9d36laaTvomikbDUKw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/et.xpi",
+          "version": "91.11.0esr"
+        },
+        "eu": {
+          "hash": "sha512-usB8aJLfYiPFZBaT8k2MmCJmjbceZ6z0TCWaUhNejxfsqD2XhJ407CT/4GcspLa7KYT1vmo/31cS1+odjxTPzA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/eu.xpi",
+          "version": "91.11.0esr"
+        },
+        "fa": {
+          "hash": "sha512-fdawOVw1HrAsjYuOs8uld4Z/P291kPQxU0yv8msVb1xBYRTMarY4NG2QFImhDCcBbPXHMzKV3pY7Z3+cJCrjFQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fa.xpi",
+          "version": "91.11.0esr"
+        },
+        "ff": {
+          "hash": "sha512-XGJ59kaFLoZXFR7RthoUJD9VtqmCoUSRT5/nkU6g7iHMcuUwus2p5rtwiwRVyHCDqSCLDWvV5/TyzOSiTwTcMQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ff.xpi",
+          "version": "91.11.0esr"
+        },
+        "fi": {
+          "hash": "sha512-2c1t1XPFiCvMP4K3t+a1Su8EpH2VjDVN/JwE3nrOOPBIWVk92IWj/s1LX4GhVYIyWbr0r5I/6zHHa3OkxkTW5Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fi.xpi",
+          "version": "91.11.0esr"
+        },
+        "fr": {
+          "hash": "sha512-FKFhdAPPX3oOFG7zBacAZcXSAkQUMNoqLbi7JiB8q4Sm57uHOHhH4Nm0A9myp5eoc5+fppXuwMnP9kjBdZ5i6Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fr.xpi",
+          "version": "91.11.0esr"
+        },
+        "fy-NL": {
+          "hash": "sha512-rNyGzgwgaRod8erqF0vOdfKIa0UgZMZgH09+WT66C4jPnCOi5L0pM1sKD8Yr+4dPTMTEOSi+hSiXOdLzYa3ctQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fy-NL.xpi",
+          "version": "91.11.0esr"
+        },
+        "ga-IE": {
+          "hash": "sha512-PrpkCjVQ0mlVA/djl10eOOg6H6SfhXZJj35yWceYxLA0MZ/sHlXnBaulqGSclHm1mQHjLUtPvI9zHhEcMlFMzQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ga-IE.xpi",
+          "version": "91.11.0esr"
+        },
+        "gd": {
+          "hash": "sha512-YYwUXGpPGiQy74XlcmnZFQaj/18sJGRjKhjB4W/9w94bPCMjAC4j4Bl/twG3QI1JBa0ZBQQyOeG9iN4vXd0Fyw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gd.xpi",
+          "version": "91.11.0esr"
+        },
+        "gl": {
+          "hash": "sha512-DX5NcJsBqNkB+Wwl/VESKHSF9kj6FBiFQh4mVqgeQLcfhzcSQ5AhesGdkCwi5g8cqm8z6jzb5DUgjxm0P0+R5w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gl.xpi",
+          "version": "91.11.0esr"
+        },
+        "gn": {
+          "hash": "sha512-CrRKbWcy8FCFXFs9e59uX5IxaVEYcDDJUZLTXiF2LciRumhDCjMsHT/+IBYJYIrwhJv87QH0+es7euvDRZwrNw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gn.xpi",
+          "version": "91.11.0esr"
+        },
+        "gu-IN": {
+          "hash": "sha512-8+p9QmOx1Bj7i9wZ0LT8gAjU547ya5S7fU0k8ktkD5QQy3NFaQzzR57XlUt+AckK0BZ1mBIN+6hr6Xg+z5lHgw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gu-IN.xpi",
+          "version": "91.11.0esr"
+        },
+        "he": {
+          "hash": "sha512-VPVsppwYyDAT9gQTmx4/U8Mxv3a5r6UGiDdQWceqh4MnkireXm6vJSCFnE/Q+K27j7Y2En7nr/ehg2a7hmeW0w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/he.xpi",
+          "version": "91.11.0esr"
+        },
+        "hi-IN": {
+          "hash": "sha512-2wzPeBMx7KaCe4j9jvs3qupZKUS3sr7pVg/Q1+RHyjK7kQoMmX7WHFVBV4U4t1SZxXtm4loZykSbXmwZVhSh9g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hi-IN.xpi",
+          "version": "91.11.0esr"
+        },
+        "hr": {
+          "hash": "sha512-8gc7m9/pEKbRSqVY5897jB9hEJk4uKlaMTgPCMRhjwzrssoUD2kyF5GWXcuXm9SuonFvCpLRF/B45hXOd9ouJA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hr.xpi",
+          "version": "91.11.0esr"
+        },
+        "hsb": {
+          "hash": "sha512-JdzryecYb4D44HNwxr6/UFybZ4DBalPb3n0V3HNBA6xXw/GC9dFUL/2qqm1vPJaGDegRRsY07WiqIloHzcATAg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hsb.xpi",
+          "version": "91.11.0esr"
+        },
+        "hu": {
+          "hash": "sha512-Qer9YcD1yjZjqtzG1X8bty5kPFNPMlZkP9CGvpV+lKzuWTL7wQyD2rZb/tmC5BCYrMscqAZ13aiHybsj5DyOuA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hu.xpi",
+          "version": "91.11.0esr"
+        },
+        "hy-AM": {
+          "hash": "sha512-Aa035IVCc47fgtBwPvsVJ62NLj1CvxC8XLE5qrIqc8r0MmoMiK0b5IjhtMy16yZoZVh5SsmQwdExUj+edXFUJA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hy-AM.xpi",
+          "version": "91.11.0esr"
+        },
+        "ia": {
+          "hash": "sha512-OxogOR76N3b88N8uMtd4KfugN/EeYasVPSrsk/FyPJptWqSFIdNV9C008g/hkUiXal30IbHBaR0dlyzcMUtLUg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ia.xpi",
+          "version": "91.11.0esr"
+        },
+        "id": {
+          "hash": "sha512-n7UKOL6P2JS7MheZuMM7FCv5y7EePNBhGGDvl0yYes3Vez2kBwGspvPTacbU9TTa32nX5OvAHEyH1UuztreICw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/id.xpi",
+          "version": "91.11.0esr"
+        },
+        "is": {
+          "hash": "sha512-57NuiYfXsCgoRVK/NKvswDnoO0avP7fJVEcbIo2r+EPuEqWNgk+NFg/XQkWJnQfiRh44oJScj6IWNbk3UPss8g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/is.xpi",
+          "version": "91.11.0esr"
+        },
+        "it": {
+          "hash": "sha512-Ytl7MCEHLYZC4NPqsdMv0Ec8IVemPoZ5YTLWzHIExpbL6qP61JuQnLagaARd6G3iU+QWBLjLA39a+1QbjJOTAQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/it.xpi",
+          "version": "91.11.0esr"
+        },
+        "ja": {
+          "hash": "sha512-v1PK3QAWiRUMqMvsuHLPwiyf0CbtNGO7JZXyw7nWZ4p2gpBhCLxZcllNxD7glTWICUplKY2kGsO66AOpDskgrA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ja.xpi",
+          "version": "91.11.0esr"
+        },
+        "ka": {
+          "hash": "sha512-C52pfkRqUvwdDDfqQCUXanxuobU/dlISd8+90cQZ8oQPH5i/vTM8AzhZKgIRix7MtEp6dxbzqNF1ggfWsV8k2A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ka.xpi",
+          "version": "91.11.0esr"
+        },
+        "kab": {
+          "hash": "sha512-v7DoY70F+wyrScPMewWA//ri9Bkt0s+xhSRw9eDeQld7l1UZGWdDUPKz+G5Tl2Oi00WLvrQKGFLYZuWya7qoiA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/kab.xpi",
+          "version": "91.11.0esr"
+        },
+        "kk": {
+          "hash": "sha512-9Jd+FDpOTouR6423KrGsQ3hxztEoLkcAZX11Jn1FWc9oSvrDIPyx/MyLVBj55lI+CIeZWEk7tMlpk4qUrxwXag==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/kk.xpi",
+          "version": "91.11.0esr"
+        },
+        "km": {
+          "hash": "sha512-UvKQ1ASbzjKs5kozwDKoBlILKekn/ov5LV+iJsXSHeDSmLAKJuBbulObr6LXAq8dvrcyhFxFZfdaF+Q74ZXjsA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/km.xpi",
+          "version": "91.11.0esr"
+        },
+        "kn": {
+          "hash": "sha512-ZAs6D9HJiF7ijjLN97ce6mk9XgHmfgkQs/Sf9QaxWTgn1M2YysFIGhfaMNs3RZkRTPmBvRC4jbjaNRjubR3HlA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/kn.xpi",
+          "version": "91.11.0esr"
+        },
+        "ko": {
+          "hash": "sha512-oxGM12zwwvl6kViugzUknQQt3jEJPfV6Hg5BdTbLkxFRDuV37CsSXhF8Uqaho9Betiud5H3Td4bpQq1ZDnG7mw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ko.xpi",
+          "version": "91.11.0esr"
+        },
+        "lij": {
+          "hash": "sha512-nGHU9ZZFgMIeSjYEkvq7C2ABuU1/Yo0cvIqOd5EuXP4MNZO/HPEh5VGW/u5i9aO35KzdR/17EqUcKyRT4jt9xQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/lij.xpi",
+          "version": "91.11.0esr"
+        },
+        "lt": {
+          "hash": "sha512-cPTizsOTQJYqws3hMl7KeHkpjR5XM7ySKGweIJK1sXYBsjzY1knVgJ0PK/VjbLT6JNw7j+g/vjoWlIE3Q1xkIQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/lt.xpi",
+          "version": "91.11.0esr"
+        },
+        "lv": {
+          "hash": "sha512-PjkQU1UrPSCLeYo5mbCSbjVorFtxiCrcOpZPEO8E5guOqMZkOE0wjsprBonM022i6ttEzlVotSqdz/LyXddoOA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/lv.xpi",
+          "version": "91.11.0esr"
+        },
+        "mk": {
+          "hash": "sha512-uEI6kPkmEsUIlaSSteqrbmzh1mZmdaxomq48vyhWQ6ATI3nblXkaWVKN7QKku168HS3kSrssPiQD77QfJLfKhw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/mk.xpi",
+          "version": "91.11.0esr"
+        },
+        "mr": {
+          "hash": "sha512-NuSfd7GeKwzqJDw7kgGhK7+1pj6C+1z5JoZ6cWusRASbj8/Kyuc4BNDMO77aIw50dgjKHJyRFc9gzmlx5n7JKQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/mr.xpi",
+          "version": "91.11.0esr"
+        },
+        "ms": {
+          "hash": "sha512-ZaQrukzvxklI7NT2rqhheKLTXXArvSnz6adTqtbuTEc4dEWvC9yOVYogWTV+J/bvMPMJGnBhZjmdk07h/xW+gg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ms.xpi",
+          "version": "91.11.0esr"
+        },
+        "my": {
+          "hash": "sha512-J5sXSpMNnDx/lFlD8zI3HbDGSGl8iyt0PwkZklAJTeFcw+1NGDdF1R7T8Hh2p/36Kj2DtMV5F1fZRINvBwR+rw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/my.xpi",
+          "version": "91.11.0esr"
+        },
+        "nb-NO": {
+          "hash": "sha512-9Ps9OR3CqeofXANUEU417kPEvYGQ164fDNx4V31lI0HPAaNgNDVfYV5V06gJqvKFHXePrZtr0mt6nEjbPgUhog==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/nb-NO.xpi",
+          "version": "91.11.0esr"
+        },
+        "ne-NP": {
+          "hash": "sha512-jaQzMpw/svWQEASDu5h6hyDUH7BUNeyvcU9Flob00ZjlQbDDRKMT7o0mvlPVSMHKpITXrSKaS5D5zFHA6Lshrg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ne-NP.xpi",
+          "version": "91.11.0esr"
+        },
+        "nl": {
+          "hash": "sha512-XWXxAHYuMlF2lF5PmidbcB75gBDT1hMtulOV8JVPpyPppM8YZGLzDZQo2Int24pxW68HDqcPf70+12phib/D+Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/nl.xpi",
+          "version": "91.11.0esr"
+        },
+        "nn-NO": {
+          "hash": "sha512-4HBsfHf7mAGgI2Z6pbrL7BpzUWSWYaXXsqCyYMIH5cWTYxPU8ZJxnJXnmDKHNoQUuaONzhat65JJfzmRH9Qelg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/nn-NO.xpi",
+          "version": "91.11.0esr"
+        },
+        "oc": {
+          "hash": "sha512-qIJpoqELzTVFRtULFjG5irzpcvN2c3gGtSYKT0yw9kpJz5uKInK2eqZlz5m46Iwr0is4RqMp+zpT47y1/SnP0w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/oc.xpi",
+          "version": "91.11.0esr"
+        },
+        "pa-IN": {
+          "hash": "sha512-WBf3NDJYzV7vx2Muo2Om/wx82c67wMhQofnMgi1PWrK4OhnujYEbGvYSx1lN6z6NJ1i62qOoJfnA8/JL5UuG9A==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pa-IN.xpi",
+          "version": "91.11.0esr"
+        },
+        "pl": {
+          "hash": "sha512-0zuQ2Rq4lgjp9xEdcmptMv6Vgxrggwamd61/XeWeq5n9j0I6Vm/BdZCzsldrKdzTMoB1EzApiz06Li48JNsdoQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pl.xpi",
+          "version": "91.11.0esr"
+        },
+        "pt-BR": {
+          "hash": "sha512-ke7mRVO+XwK+ovpm5m2CeUQLAiJOLv48a4lekUT4mnkQpgZ9bdMgOGuSe7+Q/pmUK+xkfiO0WtzvUL6ZQu6SpA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pt-BR.xpi",
+          "version": "91.11.0esr"
+        },
+        "pt-PT": {
+          "hash": "sha512-qRUx5NNaCqMcQ6CTM6ArKTTxqT7GQTwR5W+MwPvvl0e6qzmpYuQjb22bUbSCqHBBOZUfw8WH56memD+6VAucqA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pt-PT.xpi",
+          "version": "91.11.0esr"
+        },
+        "rm": {
+          "hash": "sha512-d+jMQC61PaaV45rC5t08Wj3G0heaHeyEV1sdNvIhPhcnJoOIYeXp34l8oyniErT/dJ25VzjqU20lvO6AGVBPCg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/rm.xpi",
+          "version": "91.11.0esr"
+        },
+        "ro": {
+          "hash": "sha512-caMegR7q/ZhWzBjtljt0lSYQdNXlrHorthxFoGyqg7ao8g+fVmR0uiFBEWcYouCOpqbn6qicskAZHXSAEF300w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ro.xpi",
+          "version": "91.11.0esr"
+        },
+        "ru": {
+          "hash": "sha512-pHOVKn/D6XGaicl0O3xJkQch1mipVYI6V9mZTsvOr6ThFs614RzBES8zPnWs3Kh/l1zd2riCTjhIRlBBRFqFgg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ru.xpi",
+          "version": "91.11.0esr"
+        },
+        "sco": {
+          "hash": "sha512-jnXjz3aLhInVVxiVhf7mjgm5+rfW1AMCOt6bmsPKUfCGwjvf54TAGZ5HrtIiq/+Wrz5naV/xof3yUyB7XM5JkQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sco.xpi",
+          "version": "91.11.0esr"
+        },
+        "si": {
+          "hash": "sha512-1oTnKo9GGBfx2DrUIhejlgnbYYjFb+bcROz708eg1H71P6APDzjCqK7xNPzaHCxi0jvIFtRKXBtb1FoN3cWX2w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/si.xpi",
+          "version": "91.11.0esr"
+        },
+        "sk": {
+          "hash": "sha512-ZPCDMylV+HWMhGB0pD99ANkFONq+Hl2a/pIE0RxjduSx3jPN4F50i/IeYNQPedZjHq6POXY5uqcmIBpXk7Bgjw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sk.xpi",
+          "version": "91.11.0esr"
+        },
+        "sl": {
+          "hash": "sha512-ij3hLLneA7b91oJFbCh+aTpeqKzFUpXYI+yuCBmS4eCpu9Ereqfmz4aACBmENnUA2FQmTND/P/JCKdyMGFK39g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sl.xpi",
+          "version": "91.11.0esr"
+        },
+        "son": {
+          "hash": "sha512-XJjPQ+9+Log6emtH5l3LqjhLqbZYSTIneGXy+IQ+KGJKd2wHTVFC457IyDjGl6V3ds1Xfma1+eI3S4idAOX7jg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/son.xpi",
+          "version": "91.11.0esr"
+        },
+        "sq": {
+          "hash": "sha512-VWA5j9+UELrqTJr3u/B9tiQCOgiHurolG9or1ngNdpGCExfyGyocISsGpjE+oigAFeeGL1A7B54AhjWzxuoaGg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sq.xpi",
+          "version": "91.11.0esr"
+        },
+        "sr": {
+          "hash": "sha512-9fxFJ288PLWRnq2wsjacWHG2MXTSJcJjQqnaDLwncid2bd2PUO9XBlvBFEXgGFVdMRgM47gMGJ1iqkaF4DWIpw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sr.xpi",
+          "version": "91.11.0esr"
+        },
+        "sv-SE": {
+          "hash": "sha512-OJ8EK79SYfu0P1kBGrd2gDakVBwo4VxDkQ+dGoKPyASHglz9lLbPYti+KRX1w9fK7PAkhCATtKAeEfD8fS0OKg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sv-SE.xpi",
+          "version": "91.11.0esr"
+        },
+        "szl": {
+          "hash": "sha512-rOPDKqy9WllR+YxGKyXdYiCPTe18POcafgq0uST7VtombQG9ik5WE3IPHKXm0EjkMtdgrFYGrNXrcyeHDuG68w==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/szl.xpi",
+          "version": "91.11.0esr"
+        },
+        "ta": {
+          "hash": "sha512-kI5CW7B+PDMe9UltqPhVCPFu8228Rq91tExzNJFlJAOryjF1HuaigOAR7UNNlugw/RZxCOXCkCPjxyLObuTEjw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ta.xpi",
+          "version": "91.11.0esr"
+        },
+        "te": {
+          "hash": "sha512-kNDt5A5+Le1ntmg/NtITZCTabBOXE0d8uu3owtXEcPzDzJ7k0lQxlfZYIEYDfFSxMIFbl+BbVUS7ykfuL1vykA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/te.xpi",
+          "version": "91.11.0esr"
+        },
+        "th": {
+          "hash": "sha512-24gEYPrOH/0ntop6hZ1pz5VZeELNMaXS+bxpCTEUQayGH0K54cTv5vb8STjVmgsIABX8iYVzvVHKS0oRiK+wHg==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/th.xpi",
+          "version": "91.11.0esr"
+        },
+        "tl": {
+          "hash": "sha512-onsjwThqW6YUhlBD+nKkRyhQeOGIow6uNxISJQybWzYVuZbN7u8lzkN1MGEOByXVRKQhSoUNWTTs80nVqcAA4g==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/tl.xpi",
+          "version": "91.11.0esr"
+        },
+        "tr": {
+          "hash": "sha512-lmlWRvgoeAwYjOP4qtChpz6eMkpDB7qnlya3E1ogkQpXF7iNG8cE79aElbBRPlwNUZzA+rs57/5hCJ1qlO6sDw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/tr.xpi",
+          "version": "91.11.0esr"
+        },
+        "trs": {
+          "hash": "sha512-EPYqiH32MK37bSbxJwAO++sNO3GDrYhsKMDpCabXi/hlDV6tOE0x2io7lmU/FUE99QDC/G/IQGsCe71tyKT4Lw==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/trs.xpi",
+          "version": "91.11.0esr"
+        },
+        "uk": {
+          "hash": "sha512-3oO1rQDC7y77vuCwsMDVbVXJeUhNW5nqJz5Ggd09O8VF3K+GsU6bxv38hZY6x5xYtZbEmLlGle9Aii0vCWyWIQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/uk.xpi",
+          "version": "91.11.0esr"
+        },
+        "ur": {
+          "hash": "sha512-YJDxbzK0Sr1kBLebp157FP5DdCSFLZMqOfrCbiieYy5gBHS1PjmRjjc8WNiZSQ18X6ykI6JoqhJFeIXjI5S1sQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ur.xpi",
+          "version": "91.11.0esr"
+        },
+        "uz": {
+          "hash": "sha512-ISmfN85/73lmp3Tq6U2YICDIkAVpScxE7YI+rJ7Um3J1Q13gbmPeL6fNey+xziF9+Vwbpmkn+wRRja6HN/YcYA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/uz.xpi",
+          "version": "91.11.0esr"
+        },
+        "vi": {
+          "hash": "sha512-HC/qjULmgiTJWkNoKwgLpe1kb3ZQlT2w7DuTMtWMmVmK8ArigxqsKhg3n/EbihAn2QhGcFy7h4FaWTDzA8h3TA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/vi.xpi",
+          "version": "91.11.0esr"
+        },
+        "xh": {
+          "hash": "sha512-snkL2RSIKnFO+DVVWsONsnpoGDjSj1ObAE7QkYGjPo1yDv9Upz7sUSbjjIjndffjtf8NPeXrwo9rsZFerkarXA==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/xh.xpi",
+          "version": "91.11.0esr"
+        },
+        "zh-CN": {
+          "hash": "sha512-dYLq+uiNHlAkKXBq2IjBbWz46s9SYyrmNEImvmCYuIvvKxW8uKwNZMtW9eVHIzyrwrqn/480plwww3QNkmMX8Q==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/zh-CN.xpi",
+          "version": "91.11.0esr"
+        },
+        "zh-TW": {
+          "hash": "sha512-LChooIbS5pPNFX5ovZWUJ3OBIhyUzlbJyzGLyjguaWHaoq/AE4YydnazhOr50oJH6nlFuWjKpmvI1GwOwAzmDQ==",
+          "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/zh-TW.xpi",
+          "version": "91.11.0esr"
+        }
+      }
+    }
+  },
+  "thunderbird": {
+    "102": {
+      "linux-x86_64": {
+        "af": {
+          "hash": "sha512-BGLojJIbAdl9RgJsNKqlYtnZIu7iSMAOCuVBavfotmye2/FlttH/qgrOL9mMLuIvtX33ZhnGPw235itDHvkgOw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/af.xpi",
+          "version": "102.0.1"
+        },
+        "ar": {
+          "hash": "sha512-oQuzqj6cnflohFQDRXKe70GCEufAmFv+LustZIehIP7imlI6sQujiNB0Y0RScQoGc5mBP65+LXGMjwn67STzkg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ar.xpi",
+          "version": "102.0.1"
+        },
+        "ast": {
+          "hash": "sha512-DOcJ08y1ulPKDeKy1Bnbwh11ZVG0dd12PSA9i+T/ADx8wac1qJvlfvPA7L9jTuSMZSKfgNPYjuV3FzLlNeTvew==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ast.xpi",
+          "version": "102.0.1"
+        },
+        "be": {
+          "hash": "sha512-fJhNGGXrYLicuzya0Du8+aa0tWqTfGOTflYXtnJ8DZooxdHqvRMDSULQ+tEQwmr4rTWwyvCrsvA36xtDAcpN7A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/be.xpi",
+          "version": "102.0.1"
+        },
+        "bg": {
+          "hash": "sha512-thjRmNBbVjMepP/FEeM4SMZjpRAdJCEaOTfszKxtZDJEzvCnQ9Ps+BnkYqCbCUjKHDL4hMbvq8qv2EBjIQEzJQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/bg.xpi",
+          "version": "102.0.1"
+        },
+        "br": {
+          "hash": "sha512-FOLM7Ju0I9vHktl2F+CKX36f6YESqRttATcehjCA75+Nby1j7h1DSu+sPRdgDmHYHYEMns/7/b7cf80SSUn4mg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/br.xpi",
+          "version": "102.0.1"
+        },
+        "ca": {
+          "hash": "sha512-+TnslTpADNHUGZ2kXRpAY0N9O2qcVBOAZOdX0ZHSKMzhh2wQQLTUKx/wNRrYyRN1KJelOG6847+XOH005pa1AA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ca.xpi",
+          "version": "102.0.1"
+        },
+        "cak": {
+          "hash": "sha512-5nmB6WnloAeBU2diAgGUrNzfvVsie56GV6Ty0xMM9aGDIBsHAdQ89C9/jybE3j3hiXMZ2rIaEWMOE7WBe3emLA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/cak.xpi",
+          "version": "102.0.1"
+        },
+        "cs": {
+          "hash": "sha512-QAjAx8hoFgcynu47YkbcER2FAVOdzj4ZVyZ+uPRmtYSNbamafcSmrivQtmVNmsLP3830ebTHXrEcBuNZ+Sas7A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/cs.xpi",
+          "version": "102.0.1"
+        },
+        "cy": {
+          "hash": "sha512-y0xThwHRQL3wHPpefJLkKQm3XfUQ5TF2mOqkeA8ZGlFShSv/2ip3Zhq8ogDODguANqC0XtuItIgaRVkyAbBxXw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/cy.xpi",
+          "version": "102.0.1"
+        },
+        "da": {
+          "hash": "sha512-skK5gLaQgt5zURukvN8xbqMxFHdtYwwxQqaVmjoJ1x/rDQ+wE56y52h4bTXH1H0LxLD3Alj+6d8tqVFkGiAYWQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/da.xpi",
+          "version": "102.0.1"
+        },
+        "de": {
+          "hash": "sha512-4Rt04/oexRIWIQJSUeMZrRvYzMgrvtwqGjoR42kPgcvSThiYtMA7Kod0nh8WqbEaEaJLmiXeRg4hGuYxTTA6gA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/de.xpi",
+          "version": "102.0.1"
+        },
+        "dsb": {
+          "hash": "sha512-Q6KdJK0XyhIPw3bZGZ795MLFbEIsgQYIwtHp1RqKWVU18xS42jEaZoxvnQodgfIzMPerMg926nGJ6tU3O39wCQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/dsb.xpi",
+          "version": "102.0.1"
+        },
+        "el": {
+          "hash": "sha512-FtbnCnSDBRjA0Vx1qYjyfO+XiP//CNBsoOBjYmdlzlp04mNdqgrXyywQWWgyX53DoHqoxD2ZeAJaPUIWiMzmLQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/el.xpi",
+          "version": "102.0.1"
+        },
+        "en-CA": {
+          "hash": "sha512-hUAnzP9bcmEqXzSpilMOWA+J9ML+NolaKTLglsJghwuMeMNqV/Gt8AP1VDm/EPFmJPCuzPG66GVQRIAtAACXDQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/en-CA.xpi",
+          "version": "102.0.1"
+        },
+        "en-GB": {
+          "hash": "sha512-tnJrrda6ks0Cl7U5JcySzk7vyw67MoasV3uiER0CkRN0+bkp2p9HB92IGKhgAawglahLeQf9KE5B7d8pEufANA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/en-GB.xpi",
+          "version": "102.0.1"
+        },
+        "en-US": {
+          "hash": "sha512-atBUsWqUV2VyjNqXQPMRLGakcrau4+MKOs6cjBwksCdC69/gDjrJzKWp/X5FO0kl3oiPVARQqBwXl3JjYweUXQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/en-US.xpi",
+          "version": "102.0.1"
+        },
+        "es-AR": {
+          "hash": "sha512-BigQgMmx+TycsWkDfnrFSQ/CU1XiJmNyuXG4Jjng+VcVoi3ZOlJoOG3nqZ8N1xJxKSiJZnxnhEmOBWEJFPvFgg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/es-AR.xpi",
+          "version": "102.0.1"
+        },
+        "es-ES": {
+          "hash": "sha512-n2ZjpjiE3C7xGMXw022NPpb92DxRCNgMULyfZKNSKGsriEERaX1vKfoQtxpHwl146yYSnO39gWrMTWokmqiqSg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/es-ES.xpi",
+          "version": "102.0.1"
+        },
+        "es-MX": {
+          "hash": "sha512-pTz++rOHGwU8NrAsBlnXL0rVgzAYmJDclpA/xYxUp8UJCdBWMOcnW4sY3a0kH6TszXNIdFU2Ier88n/7ufmhdA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/es-MX.xpi",
+          "version": "102.0.1"
+        },
+        "et": {
+          "hash": "sha512-iIpnkCxHDPGzi5T2SMuuQkRfpYAihsAformlMVZvnT6pFabSWXCIEL03k67ZaUkdZE7F2pF91hqDbwVpmF0zNA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/et.xpi",
+          "version": "102.0.1"
+        },
+        "eu": {
+          "hash": "sha512-3JmKkkFmPmzcGiFOfCP42/9/gLw75OW//nbbVl1D+SwB2HX+QsSK0WEtc6KMjALyRbpFBiuGIZMnpD18HMgFnw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/eu.xpi",
+          "version": "102.0.1"
+        },
+        "fi": {
+          "hash": "sha512-wzO7pbZbczerrJNYMxDKESRUxP2RhwheO6zXesTGtRtJqXYsSZxInKFBFcM295g9OrIovve8CogLHfl4CPOncg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/fi.xpi",
+          "version": "102.0.1"
+        },
+        "fr": {
+          "hash": "sha512-bndWTtFf9LO+QS/cvyhDRwrQtaUNJl72MY2iadnU0FRhc3Bw9l91sdfRZVUiCUka+e1RunTYsn6tJsct24uRSg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/fr.xpi",
+          "version": "102.0.1"
+        },
+        "fy-NL": {
+          "hash": "sha512-vJllLj1cS+dA+WpF0hAsPMG8uAqEcwZw6jpqBLkn3iBDvYwZypAfsB40Zy3wLtQ/oB3MfeezqDdpVneFxdmkRw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/fy-NL.xpi",
+          "version": "102.0.1"
+        },
+        "ga-IE": {
+          "hash": "sha512-xoJFbHoNQWRvbZlhL2BU4GoB0Hui0fXKM9hgqnzP+eGS6fd/R6kJu/oKPkbo1klQY7sxvLoBAPcKuXqKCwzCUQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ga-IE.xpi",
+          "version": "102.0.1"
+        },
+        "gd": {
+          "hash": "sha512-hpJ1ZQ+X9FkNm98nGk+15JxjD3i2fkm36AtE6sSo+n3mobotFWeaufxnDe6i6EbX4QHR7ht9aRVEyUGHg8CSFA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/gd.xpi",
+          "version": "102.0.1"
+        },
+        "gl": {
+          "hash": "sha512-yYsr6/1n7w8SkXTWUzQKWmSh8FkoOM3tAnlKPNWPjHQIJmV3AAeiwB/JsE4asM2fp35vCcb6EqFi/U3Qtai22A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/gl.xpi",
+          "version": "102.0.1"
+        },
+        "he": {
+          "hash": "sha512-kZBeDzhA7ubCfidVW4+OVfiKuEcB9sHLhTtVSWcT5idQ4WclMOC2eRTr/jdIwEtxZFS1nh6ApnO8MDwCr6CDVg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/he.xpi",
+          "version": "102.0.1"
+        },
+        "hr": {
+          "hash": "sha512-KqRfPCoNF9M5GBCYxd2tp7hOR9BpwvJnPH0Y4MKptNAVXq7xlHfpApQUfEkVW1p+kV9CuqUkHH1L068ntYvEiw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/hr.xpi",
+          "version": "102.0.1"
+        },
+        "hsb": {
+          "hash": "sha512-7Zh2i2XKhMVDpJyfT7g2uNx4hlz1ldMFDmpyZG4TxE5cdVpsFl7bGDCCuKRJGkXxzL5bU5NtP9zG9uUgJJTqYw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/hsb.xpi",
+          "version": "102.0.1"
+        },
+        "hu": {
+          "hash": "sha512-mviFoaDY9uQs0YgdWX9j3ykmaH+V9P7AGgIMUnTxiHPcwGdAPbhC4l60tAA9xdkhTb3rY2Gpk8uck5RHDpDD7A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/hu.xpi",
+          "version": "102.0.1"
+        },
+        "hy-AM": {
+          "hash": "sha512-NVZevo9ULXEJFxUQX0MIJMgJiXrYOMxQJ8p9Ehn1MDA/1BzaP8H02N/bn4jESoc9+nBRwDiiPfespCrQAhF3Lg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/hy-AM.xpi",
+          "version": "102.0.1"
+        },
+        "id": {
+          "hash": "sha512-NGDgNn04i8HAd4FMZjAWHLzo/uty12OO/0OuOOVkkMEvb3cWe5SQSY84LBnBYjSw2N84/NWUrAK01mn2oG8fFw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/id.xpi",
+          "version": "102.0.1"
+        },
+        "is": {
+          "hash": "sha512-WvQtoDk5GorPBspPXM24lq1hiD2L8nxbi1HunltGPU+tihs4j4f3PmmPFS7i+opROhQhJAf1HyhTxk3B8D6SAQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/is.xpi",
+          "version": "102.0.1"
+        },
+        "it": {
+          "hash": "sha512-p0x+t3XKJIvoIbpcZL3MXL7wYbHsLgLosqbEnMH8bLZ6oS5OXvpIIHkLjcNbmTrZszejvZ9Ssoeh9DCihgGWWQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/it.xpi",
+          "version": "102.0.1"
+        },
+        "ja": {
+          "hash": "sha512-JozSdi18RDN/ixmT/p1JzYyAsWws1D/oa4PeztzwoIJzWWxLDjUS9fQdylAql4oMhNGE/BnxTNKrYnEpoP2PgQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ja.xpi",
+          "version": "102.0.1"
+        },
+        "ka": {
+          "hash": "sha512-yYr0Aimopx4R8v3d34Gt3TfXHtYMuB76Ja1w0Rqy9zDXcHz2n+xVcRx2OsnmoBUveQQEc7ctuXDz4zqzgEWRYw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ka.xpi",
+          "version": "102.0.1"
+        },
+        "kab": {
+          "hash": "sha512-9lxix+rISdzjUUmoJIAgqcW0F1gymVtp1QOzjmKfBYp92Y+zj4G1+5UarXKhj69iXEE93csssQFRxTPKlQrRaw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/kab.xpi",
+          "version": "102.0.1"
+        },
+        "kk": {
+          "hash": "sha512-129gXctyQjsvhrY6xSfyDv20kslopQIgSswVIDz1G1DF2Ch5/7tW2EE6Jxli252hr9YQBTgfxhtD9zw7pETcCw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/kk.xpi",
+          "version": "102.0.1"
+        },
+        "ko": {
+          "hash": "sha512-wn3weYYMPqV+93q9G4wjmD8jeu8bJExRgQBK4a6Tz9bGfbF0Z/zZ2sirJyRMZwDQkGi83DJwuij0Efw+O9Sp6A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ko.xpi",
+          "version": "102.0.1"
+        },
+        "lt": {
+          "hash": "sha512-qNO1Zah93LaE0kB83XcEWTuoMncrI47EqPJ9gTcWauZqmo9hNaWdTCEt2s7ehEfAxXgYf/EAbDP0a96V6ara4Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/lt.xpi",
+          "version": "102.0.1"
+        },
+        "lv": {
+          "hash": "sha512-O+08K4thEnFmc3g4xYPivma4QXNUbf2/f7r/Sg+LfW/p3TcY3xvEQohhpKvI76ds80cy69SrCCtxkX/pkN1lmA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/lv.xpi",
+          "version": "102.0.1"
+        },
+        "ms": {
+          "hash": "sha512-J7BDNqe425bmCSo5vRMTmgUZshHTpsCRC6GTjo9TePjqibZPif8t5kmayu8QEsHZfRj1rr5VKh10owwgtUjfKQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ms.xpi",
+          "version": "102.0.1"
+        },
+        "nb-NO": {
+          "hash": "sha512-OrTQLy/V3IyMnI938oLRTBu9xyGxG7JzYACDUSnYRG8EocR+WsEu4o8mnGOCHU8XiohHLoL7fIwG/vxnAO3f/A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/nb-NO.xpi",
+          "version": "102.0.1"
+        },
+        "nl": {
+          "hash": "sha512-qCseNlng2WCY4fNletmY62XB92kwS/mlaneF/5t6UQipngInUkj7S8iWuZOudCd18NollMj5XiFK0xJdEsccRg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/nl.xpi",
+          "version": "102.0.1"
+        },
+        "nn-NO": {
+          "hash": "sha512-+x0TWIIWxYqFMrZkoMkWdt0aj3ulzXWlhWwAZ5stdy1ew2OAweFqomX2GXTL/St+3cyeVwCeCevkdQVQwxqUhQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/nn-NO.xpi",
+          "version": "102.0.1"
+        },
+        "pa-IN": {
+          "hash": "sha512-jVNLiVRi+CuR/Tk5+vyLM7n0j4bM/ag/LLFGX5HylejoTZ9cBOeXE6WeT1aqZL2gvBT0bVyA5NShyLoJPhJWQg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/pa-IN.xpi",
+          "version": "102.0.1"
+        },
+        "pl": {
+          "hash": "sha512-G6sDhxCAkOEX/nf6tstatWjFaDuVH6tIn0gL5Fdyd3+7Du5/CB3qz+1Y3mTE5Cna1Lzoytxj8Zvv6C6taMxYpw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/pl.xpi",
+          "version": "102.0.1"
+        },
+        "pt-BR": {
+          "hash": "sha512-yAn5t6hemhyb5egjdu6ytFxVT3OiQy5Tmy/LN7ZmCoZwX5B/XM2w2hatS3rRpmOIVZEGnFzW+XVNzFWHTNMZHQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/pt-BR.xpi",
+          "version": "102.0.1"
+        },
+        "pt-PT": {
+          "hash": "sha512-D9+2iUmd+0Vdk661OS79n+Dkp33tlooDordBDYtI/PO9U6445XiXH9My4/YDySh7FV6TvIhk9j7JM2T83ek5kw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/pt-PT.xpi",
+          "version": "102.0.1"
+        },
+        "rm": {
+          "hash": "sha512-UK48Tv7oXDavjPO2PB0N18XtWKn02NWOQkwHg4Dkmg2UD8NaEmLnaCuIyYOQpwfldazm+UkgvnHlHnRkPEfseg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/rm.xpi",
+          "version": "102.0.1"
+        },
+        "ro": {
+          "hash": "sha512-gukFPCQWnsyE4twv73WbtvpkgMYCgftVM7+fO8Suj+MaHr+4g+7S2nWNAuYhXXMzBEFIKbWEaI9Y0kPiBSSOMg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ro.xpi",
+          "version": "102.0.1"
+        },
+        "ru": {
+          "hash": "sha512-R6SjesaGu32Wwd+puuvkJykd93tcBcBdsmiO1ENw5XxGLmPP70c1y37t+L4ODXdwg0KxB2gATQ86eETsZ4sJCQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/ru.xpi",
+          "version": "102.0.1"
+        },
+        "sk": {
+          "hash": "sha512-PNKd2gPpEKpxsTYQl6WPyZbg4Eoys9He6zjrlPTbgZlLGgeyuRZdpa2CPX1xhHXySQIZib4UpM4MrxwTt0ikYg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/sk.xpi",
+          "version": "102.0.1"
+        },
+        "sl": {
+          "hash": "sha512-eM8gLg0TdStCf9LStjra4hHpH5yD2kQ1N0+nA7lX0U/Gf+5NxBKBxyecXXN/11ahc+3tcrgUERrPLMLovPP98w==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/sl.xpi",
+          "version": "102.0.1"
+        },
+        "sq": {
+          "hash": "sha512-+Buxk8klDLq2DdeRL5BiWFB9YuwfqYDFSySvoPUexCaJnhbaBBy94bKPOM24aXQTNquqUKGDnUGmXTjhzkvdsA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/sq.xpi",
+          "version": "102.0.1"
+        },
+        "sr": {
+          "hash": "sha512-F9h66quUnAfMNvdTxWCMdtSy3jmLJQJqzd2gxacmIapp1SqkqiiWXFKpZTrcgUTr0Ed3OW9POaoxP5Ay72K6gA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/sr.xpi",
+          "version": "102.0.1"
+        },
+        "sv-SE": {
+          "hash": "sha512-amA5ltcM6jmyOG1vdzJVmFmG9AIzKqbGv9JVOAmh/ZnWRmiE86DLISPcUMHt3NxXAMeg6PcRciOQAXeqeXhDcg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/sv-SE.xpi",
+          "version": "102.0.1"
+        },
+        "th": {
+          "hash": "sha512-FLAaLMMw80g5yIWvlcQaHuYEVAyGGXWcNa5GYqWnQdNR5rPa43UOCetKUKxB3happqrLQENmWDtNqASVbeo2NA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/th.xpi",
+          "version": "102.0.1"
+        },
+        "tr": {
+          "hash": "sha512-6JxHKOAWLgop3IoDBClk/PJg9/IrkUNr8aOU+uI+aR1FloEjacmmw3fbmea/ThNvX4u6sABzlWzNdh7rDBWzfw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/tr.xpi",
+          "version": "102.0.1"
+        },
+        "uk": {
+          "hash": "sha512-HF6qRMzhzfFPFBuEdhGjEcQAq3MtmQL8UmZ4eAoslrUyW9IAF0ETYxeAd4Fj1VaPSoEIUtBCqldPBIBHggeo8A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/uk.xpi",
+          "version": "102.0.1"
+        },
+        "uz": {
+          "hash": "sha512-vt0YIzKMpszC51eFJQQ7zhBl/R4DrfRZu7TbAA1yOCkVLls+XH4mmK/1aYldyo38ZzLNOUqyviLkPfmu4LhF1Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/uz.xpi",
+          "version": "102.0.1"
+        },
+        "vi": {
+          "hash": "sha512-+MJxH6mNB3P7lp71L2YtuhAHWmBQlpDVzCEMMPQ0b57z31FKkt/ksFMQdzh3f+wxVxRHsd2ksJYsaZqweaAfGw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/vi.xpi",
+          "version": "102.0.1"
+        },
+        "zh-CN": {
+          "hash": "sha512-VBoGHLLw5nC9AF753Sdb35i1pZKKf2Of0Jj3dfOiYsLecLPtc4YH8Lr/LtdWb9ceSFoqW3VptgrNqCYqkEiP5g==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/zh-CN.xpi",
+          "version": "102.0.1"
+        },
+        "zh-TW": {
+          "hash": "sha512-X3O/MJCLDNwMfYCtqCgf3y7pxvE6v7YZ/0+z7+Sq4K6LSgbt0fX4RKiDj9Spz0Yr6BMHn6QNa03xiSTOJl0khw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.1/linux-x86_64/xpi/zh-TW.xpi",
+          "version": "102.0.1"
+        }
+      }
+    },
+    "91": {
+      "linux-x86_64": {
+        "af": {
+          "hash": "sha512-rzOifvErUOF56SngW9J3SEZj4w2vFWpzQU7IEUibaAUvZxv9V7effZATcGZIQIoiOyuweRl5yqdnc9su0rDGcA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/af.xpi",
+          "version": "91.11.0"
+        },
+        "ar": {
+          "hash": "sha512-H28foTzNbzjdM6MRpTQL+bAvikQ6uAnjFOSAHVQCtjwX8CSLstvWU+owKG+SrnHDfeXZ/d9cGlY6ygwbRCuWwg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ar.xpi",
+          "version": "91.11.0"
+        },
+        "ast": {
+          "hash": "sha512-qDgz3JIRBO9lJPTT3VpQ7aNHlaRlPKWKEHPuJPq5Z0F6QqqXb3QLLs5CR6zmNq1vGLvnBHEghb1skl/29x9FuA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ast.xpi",
+          "version": "91.11.0"
+        },
+        "be": {
+          "hash": "sha512-qCPn0zL72CYUhGVvB1KeZPmxLTa8zGGcDwp4F3DFy1sb7ppdIadMuJuLD7NjnfnHEOrTcE1csiw5CckbViq3oA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/be.xpi",
+          "version": "91.11.0"
+        },
+        "bg": {
+          "hash": "sha512-4vsVeExzAe3ETMpHF9lrJ+bwBb72eYnE1QW1HpR3h9E2yAdZBga9xefm42WrSsFwRlhMvitJ47WGgXeHHWu+3A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/bg.xpi",
+          "version": "91.11.0"
+        },
+        "br": {
+          "hash": "sha512-DFglH9EfxeDxfY7IreSvJnRN+EiOh2jcmOABsfiCsOCiCjD2htWyDyHCVbQYmNpHdTOkp/1Q3jrZCt+ogooCcw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/br.xpi",
+          "version": "91.11.0"
+        },
+        "ca": {
+          "hash": "sha512-e0FL2sbgsu1GMeKY9aFhg9cxB6zKabhm5RCTmgtc+gQHgOSpitkVx+2cXKWU4XQaYLqNrWXA1Q5V994DVtxffQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ca.xpi",
+          "version": "91.11.0"
+        },
+        "cak": {
+          "hash": "sha512-UcsFakmJ+LnWS4zj4SotLZ7iAwLueMQ7YQWEDI/g41TsptnTfiHVJtcubrsH0SOv2myGDbaJEROUPl9Tp1hNJA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/cak.xpi",
+          "version": "91.11.0"
+        },
+        "cs": {
+          "hash": "sha512-HUMT5XG2UqZYiJxtL/PmLCim/ii87V4XRyL6AUyr0QpQWEIoGLjTveyRzuTtkrLtxfp72GUMytk2EM7zxNQF+A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/cs.xpi",
+          "version": "91.11.0"
+        },
+        "cy": {
+          "hash": "sha512-hQYZH8wIm3ajTN0rmiTW/X6G4ZUtESomdros+uFkWucAaeo1hmIRYzUfFx6EULemM3msivo3tYb8HW92/8dKYQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/cy.xpi",
+          "version": "91.11.0"
+        },
+        "da": {
+          "hash": "sha512-nPaoiG64mvYwFlGITlrHcshEopovBbRfIW1jEaO6J4pG2+aSRj6pOfza42a+WJggrfuQVWNw/TLBdVsfTnScTg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/da.xpi",
+          "version": "91.11.0"
+        },
+        "de": {
+          "hash": "sha512-VUw5hxVxROnde4rbHJXVg1jPki9O7UO++UVf5y9QrgsK0kh37vhcWCTMoou3k3el8Hu6qfRIUvBwOck4db84hw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/de.xpi",
+          "version": "91.11.0"
+        },
+        "dsb": {
+          "hash": "sha512-OcPJpP/7Hi3wN7Svm8imuQ31E9FbshOJTbVtytW8MPFkE+aNjfOrbL0IK947Otu3xNyHIOLmdRDOekjCLsqknA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/dsb.xpi",
+          "version": "91.11.0"
+        },
+        "el": {
+          "hash": "sha512-tzz5t56UtnSr/UguCoEszbglMm0QKIo76wtg5nkrACtysd2XL5kKkrUFO7Jit+GjRj+QU3Dwa2mCBKo+iPIkwA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/el.xpi",
+          "version": "91.11.0"
+        },
+        "en-CA": {
+          "hash": "sha512-yCAeRcyDF4bsq881oiqZ2TA423CiffztYBb/PUo5APvzWO9BVSj8X8z/pmrzdn1j6xMz/tptULyd03cZJUFncw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/en-CA.xpi",
+          "version": "91.11.0"
+        },
+        "en-GB": {
+          "hash": "sha512-LSjP82NcoCX+TxsM0PUGN5mXWP8sAUULVIE53CRE6neObYijf9leV02N1BUjVe/cSLpWwd9CFtasz9HNQf+zGg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/en-GB.xpi",
+          "version": "91.11.0"
+        },
+        "en-US": {
+          "hash": "sha512-KkRRsE+EyoYHN5G4OJe2sVl95vBMGCwLd84cWdSeRpCES8pitVQPZvOB22uxR3XUoKyIQX34wJveF5kOnQcuRg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/en-US.xpi",
+          "version": "91.11.0"
+        },
+        "es-AR": {
+          "hash": "sha512-PpmMEmYAKgYhPA4fYqfxvMHh6FQGauTl7JUD9U2eN7uoSEVXzmvOCiRMAyW2t02t5XRsHRnot4wTK5QdGTVEXg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/es-AR.xpi",
+          "version": "91.11.0"
+        },
+        "es-ES": {
+          "hash": "sha512-Qy1KLwnfaFvjHQN26E0itOHNgY0+NbvDVwqq8DAAyblk7/+fRJexV5u9XO4UfLDIF03GBDctiE7sQSBpiyGXSA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/es-ES.xpi",
+          "version": "91.11.0"
+        },
+        "et": {
+          "hash": "sha512-5lR1/vZl6ZdetL+EIldyhqzXFzsHZJpLg0gQnlOBhCY6kZiNQx800acD9EweiYhmJTmSakIZyZg0pfT18FLiJQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/et.xpi",
+          "version": "91.11.0"
+        },
+        "eu": {
+          "hash": "sha512-5G2tRCR4jRYpKBybFuJniZgJBPE9CptP8G5YAe87pLbCkPm5rGh/haCCofgb6PgTPh5KprUzboIaOqMK01JSig==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/eu.xpi",
+          "version": "91.11.0"
+        },
+        "fi": {
+          "hash": "sha512-iRNSmkF6bPbUTB0vhkw8LFApS6b6c7nJQlMIOZUboxFyN+GTrlWePutdGZJdvPD/H2DfhOypSHydXJmmujPvmg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/fi.xpi",
+          "version": "91.11.0"
+        },
+        "fr": {
+          "hash": "sha512-ldOJGevrz0LJFJsm37BcBHBVsiMt7V49BVukBIBBEnyTGur2qQ0NQMjWAmR3o3W6+8hN4oPfXrHSomjboDx2Dw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/fr.xpi",
+          "version": "91.11.0"
+        },
+        "fy-NL": {
+          "hash": "sha512-Q3wllGVHGl3ad4urNBbQYg75gxSpTemU1n2UTFihlZhS6Is9sBzFXp6S+htMTmb5EvRhkd8mbw5mpZ6EuJmL7A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/fy-NL.xpi",
+          "version": "91.11.0"
+        },
+        "ga-IE": {
+          "hash": "sha512-M0Tq6pfABKXKuVvIiWWA3nrgapkjnhIRxaG9TXEqllUyMIjYEpkNT26wjSb60iV718pX7FJv74qWT/TvkUhpnA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ga-IE.xpi",
+          "version": "91.11.0"
+        },
+        "gd": {
+          "hash": "sha512-vYnfBl1SbCsVJGwZWCvK2Y/xlPIZVR28D0v31gFJZPomSyMJfGmIX37K76dl3b66+ljs6SDpxNQuQ1ROcYVtDg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/gd.xpi",
+          "version": "91.11.0"
+        },
+        "gl": {
+          "hash": "sha512-VEmx/oIXYVxm1eTxicyqPvMWOkb1H/q0ZOOPb5mOKu0rgriqQl30Vaywx2hoiu98wMQSVK7yddtFqYwggFj6ug==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/gl.xpi",
+          "version": "91.11.0"
+        },
+        "he": {
+          "hash": "sha512-FYuV2DErEdqVTm8s00vVoaod5oR3tbOELvqLIly04KSXNT5UPJZ7PVP7Lo2M1f8ILbyutCNljn+r8xazzuQSOw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/he.xpi",
+          "version": "91.11.0"
+        },
+        "hr": {
+          "hash": "sha512-wOkWQ3JunZJWakRZ36p4FYvomNE3j7dViSqr9NuHY1phxmhr8pF5JDiKAOW2dgXo+rOmPIleb/a6v3KTdHAfKQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hr.xpi",
+          "version": "91.11.0"
+        },
+        "hsb": {
+          "hash": "sha512-0H4smMvZ4cnkITyHeFK8luRtqWbi+sucblaAsiZGaoNaqzknmg+qRBsRZpRb3P+KGdedQDELlOpYezc3exLj4g==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hsb.xpi",
+          "version": "91.11.0"
+        },
+        "hu": {
+          "hash": "sha512-/08BN4coXAtqpIgMTeV2zdlOknH+/Ya8ugo+VA/z2/LKMHJxKd9xHDGvu/zAW/x/dl1QmJ/HIldyYUoprBHQMg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hu.xpi",
+          "version": "91.11.0"
+        },
+        "hy-AM": {
+          "hash": "sha512-me8Zn6QJ14PXBQV3EScurcx6vt+BsGMkJUuAVxFabsccSKhhpxsEcwPNtrLSPIkvOxagyGs3xTaoXQXuSxFxsw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hy-AM.xpi",
+          "version": "91.11.0"
+        },
+        "id": {
+          "hash": "sha512-FToHdF8DSjYxamNTqwlYfoJoODQDMNVTveyDOGWqkAT5GB9hfr+5RsEOt1iLbhVn82PJ+rJ3iyIDsIS3uR6olw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/id.xpi",
+          "version": "91.11.0"
+        },
+        "is": {
+          "hash": "sha512-K4BY9K85UcXxQusWRAmFL8nZQtKqNbX6vAlsyH31aAx/3B1qGOAX02RIpX5fcJ75v91dYQeZ54b3ewjIXJJm2g==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/is.xpi",
+          "version": "91.11.0"
+        },
+        "it": {
+          "hash": "sha512-9VdtBTi23R7eN9P2IOKrVfYHUienDj/Q9KWDWBRrDFCgRbp9HEunS64hvOxXCsVl4Gwt3mdCZD0xlOpHH0N64Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/it.xpi",
+          "version": "91.11.0"
+        },
+        "ja": {
+          "hash": "sha512-Jj9rvaT9o0b5Za5zgcBroQOsRAvZySrvgRthzv2jJpgiVJW3UZgU2KGKjQ7/X+zUoDrQXvKckmnrij/HaBepPg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ja.xpi",
+          "version": "91.11.0"
+        },
+        "ka": {
+          "hash": "sha512-bYlMRTKr7S7ipDJGTpjz/BN6KnnyGDJir2OnpTDy3S+RJ9ZskLRYtuYu+BpYbIJtdIoCqXoCKwGzic87Bmrh+w==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ka.xpi",
+          "version": "91.11.0"
+        },
+        "kab": {
+          "hash": "sha512-IHl2hL5MgM6+DGCHoGDs6PiI90vEhYlDMxaynGBvQWfBqQr3LqSeixOXeF2E1xjfq735OIvtSncxjBwI28G7Sw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/kab.xpi",
+          "version": "91.11.0"
+        },
+        "kk": {
+          "hash": "sha512-9BXDRPcjNqV1GK2pdsb80qoA+d03SKnVc4TetP5HHDj+3hQpm52elr40RLeXxSsZZjbNHYY5zrdT2sYggaCn9A==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/kk.xpi",
+          "version": "91.11.0"
+        },
+        "ko": {
+          "hash": "sha512-YrCS0O7mi1zHTqo9loTNwY8/EzgRK9BffysqPADAB2b1WMIe2WK4SlJsQRiG72M0iZQMLm7AjvV7+G2OTsjp+w==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ko.xpi",
+          "version": "91.11.0"
+        },
+        "lt": {
+          "hash": "sha512-3ySQeJcqhrdkOtaYBM4OmLGjz7nsctlysAlTd/hq0Ad5wEyAD9bQgTLmpW8m1qxHC7l9X/Vy1gtlz2PlhIKlLQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/lt.xpi",
+          "version": "91.11.0"
+        },
+        "lv": {
+          "hash": "sha512-8qr5LqpbkrBa0olGhg5GAgakd2A90O9W9pLXwvgpa2CN1/4CFvublteU0vNfa4CZI5Rjq2W5kF59tGyKgfjGxg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/lv.xpi",
+          "version": "91.11.0"
+        },
+        "ms": {
+          "hash": "sha512-5Nw8WQbWb3Odq1hREACnoyhN0uFZUdBc4ibDe0q7I9waF/QVMWUafJWtPryJ6EuPeGjQbYRqJUy9CkmZeDrjlg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ms.xpi",
+          "version": "91.11.0"
+        },
+        "nb-NO": {
+          "hash": "sha512-WyAc9zByVXezSU+4NwiWSJNgUDu4Erf45olEkVZstYbwmAyi0sSyvfKtC2azCGhFsxi2xpA4+398dtcZpq8gRA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/nb-NO.xpi",
+          "version": "91.11.0"
+        },
+        "nl": {
+          "hash": "sha512-ayEZXm3YJqL/F5Juz28h0jikTZ/0IOPwtAR/v/y6KvdX/dP+fTsdhaNma48vlmR2ZEGNYtdFE6Q1eCt2VQg9+Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/nl.xpi",
+          "version": "91.11.0"
+        },
+        "nn-NO": {
+          "hash": "sha512-d3C+PLDiw27hYJZz2EQ0ZFDM6hnmlmI5VB2ULDrsURPP0iZjtKHfQHLKG+Oru0sCWPa7Lk7dcAUl4FGSbGYHpQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/nn-NO.xpi",
+          "version": "91.11.0"
+        },
+        "pa-IN": {
+          "hash": "sha512-UFRCNWLoRhf0ctJjzQ6hcolvw6boL0jXjtdjpLrxfWXVzSqwFVnkvRNpx2TX2LoaLZuHpjPg8Gp4PpYnoAdDYQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pa-IN.xpi",
+          "version": "91.11.0"
+        },
+        "pl": {
+          "hash": "sha512-HX55GTtCD8ZEChfnEsptLcdcH0s59GL47yAOjJJ2cTSxTldnFrVctR2765plikfemTFRsduGlMAafB7+HU2keA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pl.xpi",
+          "version": "91.11.0"
+        },
+        "pt-BR": {
+          "hash": "sha512-CcYyhc97HWX7Dus0nBPDN9IH00snyuT1sBFXNQ+NuV6TnNBUUq9rabmwyiYbQJeH5K0BB1tmTw0tBGzAerBV9w==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pt-BR.xpi",
+          "version": "91.11.0"
+        },
+        "pt-PT": {
+          "hash": "sha512-8c8gSuN2rmGgtjy7Utee2yqC8j24Jp/3+WSSkmxl9INhEic2jwBxx0kR+DR4+ReRLI4wXjmSy/PeGWnKQwmXSw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pt-PT.xpi",
+          "version": "91.11.0"
+        },
+        "rm": {
+          "hash": "sha512-mrC111igwHq1dAecbhSqCEFJ1EXGUKkJdGZ5PDK/ieFhKy+iwcr5DDFSx2nD2SxqaNeE4BBNrzbO/Bi9GYi3Jg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/rm.xpi",
+          "version": "91.11.0"
+        },
+        "ro": {
+          "hash": "sha512-AywPZu1XuQU18Ak5P1cegKd/JPDR7Md2fvUqcyb693PGvGH0j5FBRYlyjO4vZls1CpXCC4rC8U0uPSeWjEhF3Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ro.xpi",
+          "version": "91.11.0"
+        },
+        "ru": {
+          "hash": "sha512-yjz5WdPN0kVRaIMoVmp3AtrRbP9Jo59gx9XOyTkThbk1r037+XnBGtPu5JK+BcOteBsAkPR7cAxt98GxaXpBNw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ru.xpi",
+          "version": "91.11.0"
+        },
+        "sk": {
+          "hash": "sha512-SiCknuCjqda0uKhZh5zvUXZoIz5DCR0VBOfHGaVp7li/F7RNN3paQrEXbbcc5ugV+mJnXlDk43HptAfgYLr7Pw==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sk.xpi",
+          "version": "91.11.0"
+        },
+        "sl": {
+          "hash": "sha512-s4MTGkD0Bi3hcw3IFwXwcKS9xGgojDMd7g+7mXK35mIF6LTL9zJmNEzK8BHMchFQRfhHSR11UqcUCnnpOluRyg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sl.xpi",
+          "version": "91.11.0"
+        },
+        "sq": {
+          "hash": "sha512-LVDCONjKMO2HAGuC1loPg3JX76/ahksW2Y2w7j6AcUT401DwjkDsFnpMEIL0l+z5TspTK9/69+ew9LcL3jRa1Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sq.xpi",
+          "version": "91.11.0"
+        },
+        "sr": {
+          "hash": "sha512-3GhCZqZ2oJvh718ogLm900TZNiA9x5/iQOYWWBIHbY9QFng8kIIEsNsFfOzFzE70oa8mPr6IFNtSQTi/7LfgzQ==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sr.xpi",
+          "version": "91.11.0"
+        },
+        "sv-SE": {
+          "hash": "sha512-qZcouoeKskTNTYUB3/M8J2d0Izwu/766ULAVJ1TrOqHQATn+HhdhCofrZnKrdnaHoj45EaRbcZtDD0+hjz8h/Q==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sv-SE.xpi",
+          "version": "91.11.0"
+        },
+        "th": {
+          "hash": "sha512-lWHvNqbcEpzJefkUdPIArN1Aj95ypko7uSdtkHZ3BVQVQQWs8btf9cn59/y12Vj0UZd/7uiKtbCbn8U12frrJA==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/th.xpi",
+          "version": "91.11.0"
+        },
+        "tr": {
+          "hash": "sha512-hKFCTfRrpPtQ1egxo7/G/CjJmyiMHRB+uOxkc29wkwPoGmbqbeLaUdB09PTGPw1sZUvJFmpuJhPiKflQ77R31w==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/tr.xpi",
+          "version": "91.11.0"
+        },
+        "uk": {
+          "hash": "sha512-GZ5BuBhGJVFTX6kBIp81lowbSUjmuGiDZ9ujclJLMmpp0eIhLUe9EThGQZI/zvy8XZ9An18+csYjssb6cEJUng==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/uk.xpi",
+          "version": "91.11.0"
+        },
+        "uz": {
+          "hash": "sha512-homWcMuguZKPtWt9wHEBeHpt58dS4d718M8KjkdLNpD8ZIFQCIIkVX7YFBsJ2Y62QaQWJJEGHBFzpEK6A+tjIg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/uz.xpi",
+          "version": "91.11.0"
+        },
+        "vi": {
+          "hash": "sha512-+RqXd1PRQbNQ8lyCIm0J6GaCsoozjOQFwsaNbk9Imp1WpdjAFb+63YfHkh93mxUuvKmP7XFUtgRjXvsl2cD4zg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/vi.xpi",
+          "version": "91.11.0"
+        },
+        "zh-CN": {
+          "hash": "sha512-Qd6AvHNnv54Hser2a64SZ7AIXV4ZlPEW+FNt/oJrlwj01biwrVTVu8AKrHLyJGESkiPoKBqeb3wCD4WC/NnSfg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/zh-CN.xpi",
+          "version": "91.11.0"
+        },
+        "zh-TW": {
+          "hash": "sha512-ZFDjQdckcoRv0jqmXrCpMceX+cKPtVJLj+TBw/SrEpIaV8dQ/kh3yY6JPC7XKdLtMmkf+rXepGJKz2+rkfPQHg==",
+          "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/zh-TW.xpi",
+          "version": "91.11.0"
+        }
+      }
+    }
+  }
+}

--- a/pkgs/mozilla-langpack/update.sh
+++ b/pkgs/mozilla-langpack/update.sh
@@ -1,0 +1,190 @@
+#! /usr/bin/env nix-shell
+#! nix-shell --pure -i bash -p cacert coreutils curl git gnugrep gnupg gnused jq libxml2.bin nix
+
+set -eux -o pipefail
+
+source_dir="${0%/*}"
+
+# Set up a secure temporary directory with automatic cleanup.
+original_umask="$(umask)"
+umask 077
+tmpdir=
+cleanup() {
+  [ -n "$tmpdir" ] && rm -rf "$tmpdir" ||:
+}
+trap cleanup EXIT
+tmpdir="$(mktemp -d)"
+
+# Set up a clean environment.
+mkdir "$tmpdir/home"
+export HOME="$tmpdir/home"
+mkdir "$tmpdir/gnupghome"
+export GNUPGHOME="$tmpdir/gnupghome"
+
+# Get the signing key to verify the signatures on hash lists.
+gpg --receive-keys 14F26682D0916CDD81E37B6D61B7B526D98F0353
+
+# URL and version list file for a particular app, indexed by the app name.
+declare -A releaseUrl releaseList
+
+# getReleaseList appName
+#
+# Prepare the URL and version list file for the specified app.  Downloads the
+# version list if that had not been done before.
+#
+getReleaseList() {
+  local app="$1" && shift
+  if [ -n "${releaseUrl[$app]:-}" ] && [ -n "${releaseList[$app]:-}" ]; then
+    return 0
+  fi
+  local url="https://archive.mozilla.org/pub/${app}/releases/"
+  local index="$tmpdir/releaseIndex-$app"
+  local list="$tmpdir/releaseList-$app"
+  curl -o "$index" "$url"
+  xmllint --html --xpath '//a/text()' "$index" | \
+    sed -e '/^[^0-9]/d' -e '/funnelcake/d' -e 's,/$,,' -e '/b/d' -e '/rc/d' | \
+    sort --reverse --version-sort \
+    > "$list"
+  releaseUrl[$app]="$url"
+  releaseList[$app]="$list"
+}
+
+# getAppLatestVersion appName majorNumber maybeESR
+#
+# Outputs the latest version of the app specified in `appName` with the major
+# number specified in `majorNumber` and the ESR status specified in `maybeESR`
+# (which should be either "" or "esr").  If `majorNumber` is empty, outputs the
+# latest available version of the app with the specified ESR status.
+#
+getAppLatestVersion() {
+  local app="$1" && shift
+  local majorNumber="$1" && shift
+  local maybeESR="$1" && shift
+
+  getReleaseList "$app"
+  cat "${releaseList[$app]}" | \
+    if [ -n "$majorNumber" ]; then
+      grep "^${majorNumber}\."
+    else
+      cat
+    fi | \
+    if [ -n "$maybeESR" ]; then
+      grep -m 1 'esr$'
+    else
+      grep -m 1 -v 'esr$'
+    fi
+}
+
+# The latest version for the given `${app}:${majorNumber}:${maybeESR}`
+# combination.
+declare -A appMajorToVersion
+
+# processAppNameWithVersion "${app}-${appVersion}${maybeESR}"
+#
+# Parses the app name with the version number appended after `-` and optional
+# `esr` designation at the end, then finds the latest available version with
+# the same major version number and ESR status and saves the result in
+# `appMajorToVersion`.
+#
+processAppNameWithVersion() {
+  local nameWithVersion="$1" && shift
+  local app="${nameWithVersion%-*}"
+  local version="${nameWithVersion##*-}"
+  local majorNumber="${version%%.*}"
+  local maybeESR=
+  if [ -z "${version##*esr}" ]; then
+    maybeESR=esr
+  fi
+  if [ -z "${appMajorToVersion[${app}:${majorNumber}:${maybeESR}]:-}" ]; then
+    getReleaseList "$app"
+    local latestVersion="$( getAppLatestVersion "$app" "$majorNumber" "$maybeESR" )" ||:
+    if [ -n "$latestVersion" ]; then
+      appMajorToVersion[${app}:${majorNumber}:${maybeESR}]="$latestVersion"
+    fi
+  fi
+}
+
+# If there are no command line parameters, use the default list of packages.
+if [ $# = 0 ]; then
+  defaultAppNames=(firefox firefox-esr thunderbird)
+  # Get the list of packages from the `nixpkgs` input of the current flake.
+  flakeUrl="$( cd "$source_dir" && nix flake metadata --json | jq -r '.url' )"
+  currentSystem="$( nix eval --raw --impure --expr 'builtins.currentSystem' )"
+  for pkg in "${defaultAppNames[@]}"; do
+    # `--impure` is needed to work with a dirty flake
+    nameWithVersion="$( nix eval --no-warn-dirty --impure --raw --expr "(builtins.getFlake \"$flakeUrl\").inputs.nixpkgs.legacyPackages.\"$currentSystem\".${pkg}.name" )"
+    set -- "$@" "$nameWithVersion"
+  done
+fi
+
+# Parse the command line.
+for nameWithVersion in "$@"; do
+  processAppNameWithVersion "$nameWithVersion"
+done
+
+# Add latest versions for all mentioned apps.
+declare -A allApps
+for appKey in "${!appMajorToVersion[@]}"; do
+  app="${appKey%%:*}"
+  majorNumber="${appKey#*:}"
+  maybeESR="${majorNumber#*:}"
+  majorNumber="${majorNumber%%:*}"
+  maybeESR="${maybeESR%%:*}"
+  allApps[$app:$maybeESR]=1
+done
+for appKey in "${!allApps[@]}"; do
+  app="${appKey%%:*}"
+  maybeESR="${appKey##*:}"
+  latestVersion="$( getAppLatestVersion "$app" "" "$maybeESR" )"
+  processAppNameWithVersion "$app-$latestVersion"
+done
+
+# Process all requested apps and versions.
+for appKey in "${!appMajorToVersion[@]}"; do
+  app="${appKey%%:*}"
+  majorNumber="${appKey#*:}"
+  maybeESR="${majorNumber#*:}"
+  majorNumber="${majorNumber%%:*}"
+  maybeESR="${maybeESR%%:*}"
+  version="${appMajorToVersion[$appKey]}"
+  majorKey="${majorNumber}${maybeESR}"
+  url="${releaseUrl[$app]}"
+
+  curl -o $HOME/shasums "$url$version/SHA512SUMS"
+  curl -o $HOME/shasums.asc "$url$version/SHA512SUMS.asc"
+  gpgv --keyring=$GNUPGHOME/pubring.kbx $HOME/shasums.asc $HOME/shasums
+
+  for arch in linux-x86_64 linux-i686; do
+    cat "$HOME/shasums" | \
+      ( grep -F "${arch}" || true ) | \
+      ( grep '\.xpi$' || true ) | \
+      while read -r sha512 filename rest; do
+        this_url="${url}${version}/${filename}"
+        this_locale="${filename##*/}"
+        this_locale="${this_locale%.xpi}"
+        hash="$(nix hash to-sri --type sha512 "$sha512")"
+        cat >> "$tmpdir/sources.mjson" <<EOF
+{
+  "${app}": {
+    "${majorKey}": {
+      "${arch}": {
+        "${this_locale}": {
+          "version": "${version}",
+          "url": "${this_url}",
+          "hash": "${hash}"
+        }
+      }
+    }
+  }
+}
+EOF
+      done
+  done
+done
+
+# Write the output file.
+umask "$original_umask"
+jq -Sn 'reduce inputs as $x ({}; . * $x)' < "$tmpdir/sources.mjson" > "$tmpdir/sources.json"
+mv "$tmpdir/sources.json" "$source_dir/sources.json"
+
+# vim:set sw=2 sta et:


### PR DESCRIPTION
The `firefox`, `firefox-esr` and `thunderbird` packages in Nixpkgs are properly built from sources (unlike `firefox-bin` and `thunderbird-bin`, which are repackaged from binary tarballs built by Mozilla).  However, while the binary packages also provide localized versions for various languages, the packages built from sources do not support localization out of the box and require going to addons.mozilla.org to install the required language packs.

Add packages which contain various language packs for Firefox and Thunderbird in the same format as other extension packages, so that those language packs can be installed in the user profile as regular extensions.  (This method of installation still requires the user to confirm enabling the extension at the first startup, but that just requires some clicks without needing to search for the particular language pack, so it is still useful.)

------

Only the Firefox language pack was actually tested at the moment; language packs for the ESR version of Firefox and for Thunderbird were not tested yet.