### PR TITLE
`mozilla-langpack`: Fix CI always rebuilding the packages

### DIFF
--- a/pkgs/mozilla-langpack/langpack.nix
+++ b/pkgs/mozilla-langpack/langpack.nix
@@ -19,7 +19,7 @@ in
     lib,
     callPackage,
     fetchurl,
-    stdenv,
+    stdenvNoCC,
   }: let
     inherit (builtins) elem;
     inherit (lib) filterAttrs;
@@ -30,7 +30,7 @@ in
     langpack = mozLangpackSources.${app.name}.${app.majorKey}.${app.arch}.${mozLanguage};
     addonId = "langpack-${mozLanguage}@${app.addonIdSuffix}";
   in
-    stdenv.mkDerivation {
+    stdenvNoCC.mkDerivation {
       name = "${app.name}-langpack-${mozLanguage}-${langpack.version}";
       src = fetchurl {
         name = "${app.name}-langpack-${mozLanguage}-${langpack.version}-${app.arch}.xpi";

--- a/pkgs/mozilla-langpack/langpack.nix
+++ b/pkgs/mozilla-langpack/langpack.nix
@@ -44,7 +44,7 @@ in
         };
 
       preferLocalBuild = true;
-      allowSubstitutes = false;
+      # Do not use `allowSubstitutes = false;`: https://github.com/NixOS/nix/issues/4442
 
       buildCommand = ''
         dst="$out/share/mozilla/extensions/${app.extensionDir}"


### PR DESCRIPTION
The packages produced from `mozilla-langpack` were getting rebuilt on every CI run, because they had `allowSubstitutes = false`, and `nix-build-uncached` does not work properly when the top level packages have that option (actually the built packages still get uploaded to the binary cache, but `nix-build` skips the cache lookup when a derivation with `allowSubstitutes = false` is requested, therefore those packages are always considered as needing a rebuild).  Remove the `allowSubstitutes = false` setting to fix this problem; now the built packages can be cached normally.

(See also https://www.github.com/NixOS/nix/issues/4442 — some people believe that the whole `allowSubstitutes` feature is bad and should be removed.)

While at it, also change the `mozilla-langpack` packages to use `stdenvNoCC` instead of `stdenv` — the build process does not require a C compiler, and using `stdenvNoCC` can save some resources if there no other packages that need to be rebuilt and require the C compiler.