### PR TITLE
ci: Use `cachix/install-nix-action` from the upstream repo

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -66,7 +66,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: sigprof/install-nix-action@6c5ba55bfdc791cfad61ac72e473340c1c3ac992
+      uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
       with:
         install_url: ${{ inputs.nix-install-url }}
         install_options: ${{ inputs.nix-install-options }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2.4.2
 
       - name: Install Nix
-        uses: sigprof/install-nix-action@6c5ba55bfdc791cfad61ac72e473340c1c3ac992
+        uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v10
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v2.4.2
 
       - name: Install Nix
-        uses: sigprof/install-nix-action@6c5ba55bfdc791cfad61ac72e473340c1c3ac992
+        uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v10


### PR DESCRIPTION
The `sigprof/install-nix-action` fork was used before to get better log messages (https://www.github.com/cachix/install-nix-action/pull/139). That PR has been merged now, so it is possible to switch to the upstream repository for that action (but a release including that PR has not been made yet, so a pin to the commit hash is used).