### PR TITLE
Add NixOS modules with settings for the NVIDIA driver

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,5 +13,5 @@
 in
   self.nurPackages.${pkgs.system}
   // {
-    inherit (self) lib;
+    inherit (self) lib modules;
   }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
   }:
     {
       lib = import ./lib inputs;
+      nixosModules = import ./modules {inherit self inputs;};
       overlays.default = import ./overlay.nix;
     }
     // (

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,0 +1,12 @@
+{self, ...}: let
+  inherit (self.lib.modules) exportFlakeLocalModules;
+in
+  exportFlakeLocalModules self {
+    dir = ./.;
+    modules = [
+      hardware/gpu/driver/nvidia
+      hardware/gpu/driver/nvidia/legacy_340.nix
+      nixpkgs/permitted-unfree-packages.nix
+    ];
+    mergedModuleName = "default";
+  }

--- a/modules/hardware/gpu/driver/nvidia/default.nix
+++ b/modules/hardware/gpu/driver/nvidia/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  config,
+  ...
+}: {
+  options = {
+    sigprof.hardware.gpu.driver.nvidia.enable =
+      lib.mkEnableOption "the proprietary NVIDIA driver";
+  };
+
+  config = lib.mkIf config.sigprof.hardware.gpu.driver.nvidia.enable {
+    services.xserver.videoDrivers = ["nvidia"];
+    sigprof.nixpkgs.permittedUnfreePackages = [
+      "nvidia-x11"
+      "nvidia-settings"
+    ];
+  };
+}

--- a/modules/hardware/gpu/driver/nvidia/legacy_340.nix
+++ b/modules/hardware/gpu/driver/nvidia/legacy_340.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: {
+  options = {
+    sigprof.hardware.gpu.driver.nvidia.legacy_340.enable =
+      lib.mkEnableOption "the legacy version 340 of the proprietary NVIDIA driver";
+  };
+
+  config = lib.mkIf config.sigprof.hardware.gpu.driver.nvidia.legacy_340.enable {
+    sigprof.hardware.gpu.driver.nvidia.enable = true;
+
+    hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_340;
+
+    # The legacy 340 driver does not compile against kernels newer than 5.4.x.
+    boot.kernelPackages = pkgs.linuxPackages_5_4;
+
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/120602
+    hardware.opengl.setLdLibraryPath = true;
+  };
+}

--- a/modules/nixpkgs/permitted-unfree-packages.nix
+++ b/modules/nixpkgs/permitted-unfree-packages.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) literalExpression mkIf mkOption types;
+  cfg = config.sigprof.nixpkgs;
+in {
+  options = {
+    sigprof.nixpkgs.permittedUnfreePackages = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = literalExpression "[\"hplip\"]";
+      description = ''
+        List of package names that would be permitted to use despite having an
+        unfree license.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.permittedUnfreePackages != []) {
+    nixpkgs.config.allowUnfreePredicate = pkg:
+      builtins.elem (lib.getName pkg) cfg.permittedUnfreePackages;
+  };
+}

--- a/nur.nix
+++ b/nur.nix
@@ -17,6 +17,10 @@
     };
 
     lib = import ./lib self.inputs;
+    modules = import ./modules {
+      inherit self;
+      inherit (self) inputs;
+    };
     nurPackages.${system} =
       (pkgs.callPackage ./pkgs {inherit (self) inputs;})
       .packages;


### PR DESCRIPTION
The simplest way to use the modules is to import `nixosModules.default` from the flake (or `modules.default` if using NUR); the `default` module imports all modules that don't cause any immediate config changes when imported.  However, all modules are also available as separate entries under `nixosModules` (or `modules` for NUR), but using those separate modules requires knowing the dependencies between them (some modules set config options which are defined in other modules from here).

New module options:

- `sigprof.hardware.gpu.driver.nvidia.enable` — enable several options required to use the proprietary NVIDIA driver (should be suitable for the latest version of the driver);

- `sigprof.hardware.gpu.driver.nvidia.legacy_340.enable` — enable even more options required to use the legacy version 340 of the proprietary NVIDIA driver (also enables the above option to get generic NVIDIA driver settings);

- `sigprof.nixpkgs.permittedUnfreePackages` — allowed unfree package names as a string list (unlike `nixpkgs.config.allowUnfreePredicate`, this option is mergeable, therefore multiple features that require unfree packages can append their package names to the list).  Sets `nixpkgs.config.allowUnfreePredicate` internally, therefore that option could not be used anymore.