### PR TITLE
Add more NixOS modules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@ in
       hardware/gpu/driver/nvidia/legacy_340.nix
       hardware/printers/driver/hplip.nix
       hardware/sane/backend/epkowa.nix
+      i18n/ru_RU.nix
       nixpkgs/permitted-unfree-packages.nix
     ];
     mergedModuleName = "default";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,6 +6,7 @@ in
     modules = [
       hardware/gpu/driver/nvidia
       hardware/gpu/driver/nvidia/legacy_340.nix
+      hardware/printers/driver/hplip.nix
       nixpkgs/permitted-unfree-packages.nix
     ];
     mergedModuleName = "default";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -7,6 +7,7 @@ in
       hardware/gpu/driver/nvidia
       hardware/gpu/driver/nvidia/legacy_340.nix
       hardware/printers/driver/hplip.nix
+      hardware/sane/backend/epkowa.nix
       nixpkgs/permitted-unfree-packages.nix
     ];
     mergedModuleName = "default";

--- a/modules/hardware/printers/driver/hplip.nix
+++ b/modules/hardware/printers/driver/hplip.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkPackageOption mkIf;
+  cfg = config.sigprof.hardware.printers.driver.hplip;
+in {
+  options.sigprof.hardware.printers.driver.hplip = {
+    enable = mkEnableOption "the 'hplip' printer driver";
+    enablePlugin = mkEnableOption "the unfree plugin in the 'hplip' printer driver";
+    package = mkPackageOption pkgs "hplip" {};
+  };
+
+  config = mkIf cfg.enable {
+    services.printing.drivers = [
+      (cfg.package.override {
+        withPlugin = cfg.enablePlugin;
+      })
+    ];
+    sigprof.nixpkgs.permittedUnfreePackages = mkIf cfg.enablePlugin [
+      "hplip"
+    ];
+  };
+}

--- a/modules/hardware/sane/backend/epkowa.nix
+++ b/modules/hardware/sane/backend/epkowa.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkPackageOption mkIf;
+  cfg = config.sigprof.hardware.sane.backend.epkowa;
+in {
+  options.sigprof.hardware.sane.backend.epkowa = {
+    enable = mkEnableOption "the unfree 'epkowa' backend for some Epson scanners";
+    package = mkPackageOption pkgs "epkowa" {};
+  };
+
+  config = mkIf cfg.enable {
+    hardware.sane.extraBackends = [cfg.package];
+    sigprof.nixpkgs.permittedUnfreePackages = [
+      "iscan"
+      "iscan-gt-f720-bundle"
+      "iscan-nt-bundle"
+      "iscan-gt-s650-bundle"
+      "iscan-gt-s80-bundle"
+      "iscan-v330-bundle"
+      "iscan-v370-bundle"
+      "iscan-gt-x820-bundle"
+      "iscan-gt-x770-bundle"
+      "iscan-data"
+    ];
+  };
+}

--- a/modules/i18n/ru_RU.nix
+++ b/modules/i18n/ru_RU.nix
@@ -1,0 +1,54 @@
+# Configuration for the `ru_RU.UTF-8` locale, including some personal
+# preferences.
+#
+{
+  flake,
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkPackageOption mkIf;
+  cfg = config.sigprof.i18n.ru_RU;
+
+  # The Terminus font is used for both the text (or framebuffer) console and
+  # the GRUB 2 bootloader.  Currently this is not changeable as an option,
+  # because the code expect specific file names in the package, so it's not
+  # really possible to replace Terminus with something else.
+  terminus_font = flake.self.packages.${pkgs.system}.terminus-font-custom;
+in {
+  options.sigprof.i18n.ru_RU = {
+    enable = mkEnableOption "custom configuration for the ru_RU locale";
+  };
+
+  config = mkIf cfg.enable {
+    # Set the default system locale.
+    i18n.defaultLocale = "ru_RU.UTF-8";
+
+    # Set the console keymap and font.
+    console.keyMap = "ruwin_cplk-UTF-8";
+    console.font = lib.mkMerge [
+      (lib.mkOverride 600 "${terminus_font}/share/consolefonts/ter-c16n.psf.gz")
+      (lib.mkIf config.hardware.video.hidpi.enable
+        (lib.mkOverride 500 "${terminus_font}/share/consolefonts/ter-c32n.psf.gz"))
+    ];
+
+    # Set the font for GRUB.
+    boot.loader.grub.font = lib.mkMerge [
+      (lib.mkOverride 600 "${terminus_font}/share/fonts/terminus/ter-x16n.pcf.gz")
+      (lib.mkIf config.hardware.video.hidpi.enable
+        (lib.mkOverride 500 "${terminus_font}/share/fonts/terminus/ter-x32n.pcf.gz"))
+    ];
+    boot.loader.grub.fontSize = lib.mkMerge [
+      (lib.mkOverride 600 16)
+      (lib.mkIf config.hardware.video.hidpi.enable
+        (lib.mkOverride 500 32))
+    ];
+
+    # Configure the X11 keymap.
+    services.xserver = mkIf config.services.xserver.enable {
+      layout = "us,ru";
+      xkbOptions = "grp:shift_caps_switch,lv3:ralt_switch,grp_led:scroll,keypad:oss,kpdl:kposs,compose:menu,misc:typo,nbsp:level3n,shift:both_capslock";
+    };
+  };
+}


### PR DESCRIPTION
Add NixOS modules for:
- the `hplip` printer driver (including the option to enable the unfree plugin);
- the `epkowa` SANE backend (which is unfree and needs multiple entries in `sigprof.nixpkgs.permittedUnfreePackages`);
- I18N settings for the `ru_RU.UTF-8` locale (default locale, console keymap and font, GRUB 2 font, X11 keymap).