### PR TITLE
Add a test host which uses newly added NixOS modules

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -148,6 +148,7 @@ runs:
           while read log_src; do
             log_src="${log_src##./}"
             log_dst="${log_src//\//}"
+            log_dst="${log_dst//[\\\":<>|*?]/_}"
             printf '%s\n' "$log_dst"
             cp /nix/var/log/nix/drvs/"$log_src" .build/logs/"$log_dst" || touch .build/logs_fail
           done

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
     {
       lib = import ./lib inputs;
       nixosModules = import ./modules {inherit self inputs;};
+      nixosConfigurations = import ./hosts {inherit self inputs;};
       overlays.default = import ./overlay.nix;
     }
     // (

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -1,0 +1,3 @@
+args @ {...}: {
+  test1 = import ./test1 args;
+}

--- a/hosts/test1/default.nix
+++ b/hosts/test1/default.nix
@@ -1,0 +1,40 @@
+{
+  self,
+  inputs,
+  ...
+}: let
+  system = "x86_64-linux";
+in
+  inputs.nixpkgs.lib.nixosSystem {
+    inherit system;
+    modules = [
+      self.nixosModules.default
+
+      ({pkgs, ...}: {
+        system.stateVersion = "22.05";
+        networking.hostName = "test1";
+        fileSystems."/".device = "/dev/sda1";
+        boot.loader.grub.device = "/dev/sda";
+
+        sigprof.hardware.gpu.driver.nvidia.legacy_340.enable = true;
+
+        services.printing.enable = true;
+        sigprof.hardware.printers.driver.hplip.enable = true;
+        sigprof.hardware.printers.driver.hplip.enablePlugin = true;
+
+        hardware.sane.enable = true;
+        sigprof.hardware.sane.backend.epkowa.enable = true;
+
+        sigprof.i18n.ru_RU.enable = true;
+
+        environment.systemPackages = [
+          pkgs.tor-browser-bundle-bin
+          self.packages.${system}.virt-manager
+        ];
+
+        fonts.fonts = [
+          self.packages.${system}.cosevka
+        ];
+      })
+    ];
+  }

--- a/hosts/test1/default.nix
+++ b/hosts/test1/default.nix
@@ -28,7 +28,13 @@ in
         sigprof.i18n.ru_RU.enable = true;
 
         environment.systemPackages = [
-          pkgs.tor-browser-bundle-bin
+          (pkgs.tor-browser-bundle-bin.overrideAttrs (old: {
+            version = "11.0.13";
+            src = pkgs.fetchurl {
+              url = "https://archive.torproject.org/tor-package-archive/torbrowser/11.0.13/tor-browser-linux64-11.0.13_en-US.tar.xz";
+              sha256 = "03pzwzgikc43pm0lga61jdzg46fanmvd1wsnb2xkq0y1ny8gsqfz";
+            };
+          }))
           self.packages.${system}.virt-manager
         ];
 

--- a/hosts/test1/default.nix
+++ b/hosts/test1/default.nix
@@ -28,13 +28,7 @@ in
         sigprof.i18n.ru_RU.enable = true;
 
         environment.systemPackages = [
-          (pkgs.tor-browser-bundle-bin.overrideAttrs (old: {
-            version = "11.0.13";
-            src = pkgs.fetchurl {
-              url = "https://archive.torproject.org/tor-package-archive/torbrowser/11.0.13/tor-browser-linux64-11.0.13_en-US.tar.xz";
-              sha256 = "03pzwzgikc43pm0lga61jdzg46fanmvd1wsnb2xkq0y1ny8gsqfz";
-            };
-          }))
+          pkgs.tor-browser-bundle-bin
           self.packages.${system}.virt-manager
         ];
 


### PR DESCRIPTION
Test that the NixOS configuration using the modules from this flake actually can be built.  Also add some potentially problematic packages to `environment.systemPackages` to make sure they can be installed.

The build process uncovered a problem in the CI build action — `actions/upload-artifact` [does not support some characters in file names](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md), but file names of Nix build logs can sometimes contains the problematic characters (e.g, `?`). The CI build action was fixed to sanitize the file names by replacing the unsupported characters with `_` (this should not cause file name collisions, because the derivation hashes in file names must be unique).

The `tor-browser-bundle-bin` package in the used Nixpkgs snapshot is technically not buildable, because the source URLs included in the package went stale (the Tor Project likes to remove old releases of their software from the normal download servers, because those old releases may have known security bugs and therefore may be dangerous to use). This problem was worked around by temporarily replacing the source URL to point to the archive site; this caused a copy of the source from that archive to be stored in the binary cache; then the change was reverted, but the package could still be built using the caches source.

Currently there is a problem with the CI build process that causes the NixOS configuration and some more packages to be rebuilt every time the CI is run; however, this does not result in pushing anything new to the binary cache, and the build process is reasonably fast, therefore solving this problem is deferred for some later time.