### PR TITLE
Use fixed output derivations for Firefox/Thunderbird language packs

### DIFF
--- a/pkgs/mozilla-langpack/langpack.nix
+++ b/pkgs/mozilla-langpack/langpack.nix
@@ -30,28 +30,28 @@ in
     langpack = mozLangpackSources.${app.name}.${app.majorKey}.${app.arch}.${mozLanguage};
     addonId = "langpack-${mozLanguage}@${app.addonIdSuffix}";
     installFilePath = "share/mozilla/extensions/${app.extensionDir}/${addonId}.xpi";
+    name = "${app.name}-langpack-${mozLanguage}-${langpack.version}";
     homepage = let
       matchResult = builtins.match "([^?#]*/)[^/?#]*([?#].*)?" langpack.url;
     in
       if matchResult == null
       then null
       else builtins.head matchResult;
+    meta =
+      filterAttrs (n: _: elem n ["homepage" "license" "platforms" "badPlatforms"]) mozApp.meta
+      // {
+        description = "${app.fullName} language pack for the '${mozLanguage}' language.";
+      }
+      // lib.optionalAttrs (homepage != null) {
+        inherit homepage;
+      };
   in
     stdenvNoCC.mkDerivation {
-      name = "${app.name}-langpack-${mozLanguage}-${langpack.version}";
+      inherit name meta;
       src = fetchurl {
         name = "${app.name}-langpack-${mozLanguage}-${langpack.version}-${app.arch}.xpi";
         inherit (langpack) url hash;
       };
-
-      meta =
-        filterAttrs (n: _: elem n ["homepage" "license" "platforms" "badPlatforms"]) mozApp.meta
-        // {
-          description = "${app.fullName} language pack for the '${mozLanguage}' language.";
-        }
-        // lib.optionalAttrs (homepage != null) {
-          inherit homepage;
-        };
 
       preferLocalBuild = true;
       # Do not use `allowSubstitutes = false;`: https://github.com/NixOS/nix/issues/4442

--- a/pkgs/mozilla-langpack/langpack.nix
+++ b/pkgs/mozilla-langpack/langpack.nix
@@ -29,6 +29,7 @@ in
     };
     langpack = mozLangpackSources.${app.name}.${app.majorKey}.${app.arch}.${mozLanguage};
     addonId = "langpack-${mozLanguage}@${app.addonIdSuffix}";
+    installFilePath = "share/mozilla/extensions/${app.extensionDir}/${addonId}.xpi";
     homepage = let
       matchResult = builtins.match "([^?#]*/)[^/?#]*([?#].*)?" langpack.url;
     in
@@ -56,8 +57,6 @@ in
       # Do not use `allowSubstitutes = false;`: https://github.com/NixOS/nix/issues/4442
 
       buildCommand = ''
-        dst="$out/share/mozilla/extensions/${app.extensionDir}"
-        mkdir -p "$dst"
-        install -v -m644 "$src" "$dst/${addonId}.xpi"
+        install -v -m444 -D "$src" "$out/${installFilePath}"
       '';
     }

--- a/pkgs/mozilla-langpack/sources.json
+++ b/pkgs/mozilla-langpack/sources.json
@@ -4,491 +4,785 @@
       "linux-i686": {
         "ach": {
           "hash": "sha512-nuEw1Olrtz7C7AG9dfqiaHvLYgcn9E4ZnuF9s+UjJU4KDovY0YE/TuvrgOV1uiCzEmd9I6SZSq3GpNT7m7+luA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-bSj5Rsk5fCf7foErHBzBnLzYqDfN/3icRM9JX2yXMsXYLrxRIq4ncC5eWq3nTZn/8k1vN8bDBcuBORpdsOzNow=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ach.xpi",
           "version": "101.0.1"
         },
         "af": {
           "hash": "sha512-yd3rTd1t2HBMF/Xdi/jr24gdiK0bseAXN7cLoO/TN0/aCCkSOvy/v5i3cL5MKBpxT7qy7jDW/O/z6sv6OY352w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-jAo4aYBfWcNyadJKaMBIZMJERdCtGvZ6gpFC6AJL2a+jwfcrwDHHjy+cVwa+F3fOwoi8/kw1x95W3cVak3GvSg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/af.xpi",
           "version": "101.0.1"
         },
         "an": {
           "hash": "sha512-+n1nXVLVR8cWjkAuapxPRoehsd0lHo517Y0LfhcZYOJ2KuQtlNlQ0ZJUZ7YZUUEQHdC2YsOZGYIv8v3SokhhPw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-w9DGfcWo9ZUorI/iSsFXG7JEYXsTTGl0o2Cc7XgVlrr0rm6pYkQhdmEhJc3CoUG+HQElJPlnCefxAP+RGul/sA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/an.xpi",
           "version": "101.0.1"
         },
         "ar": {
           "hash": "sha512-3Ip2xH63ywXIxBHacGaCC3ZtW3rxksHuklZHn7Jo8tgpRCEz6Ac7quKUW20YkqjGqkDxwMx5CBnz5O8RzuBMbA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-eibjYfTEvbhrBzv1RtZQqCz8nX4SqgmmP4UWqCSCNlsVNEi71QKblCw4W8pd2/9jf61Et5CMRolubZWW5AJsLQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ar.xpi",
           "version": "101.0.1"
         },
         "ast": {
           "hash": "sha512-l3fFkiJGs9AQZSGRqQqloL6dCTjQQy/p46KBnM8Hx9YF7X6qHY4G8QPe13uUOvs6Fs2ZlQQOdp/Z4yilvVBxyA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-ZRKFUO1m8+bw48xubWGkNz0bRUwucveVc9I5P4e9XUYDFvo7xVQ858pe+I3blJGW+dR1bRoSlGecZCYAk6AS4w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ast.xpi",
           "version": "101.0.1"
         },
         "az": {
           "hash": "sha512-e3q/+lo6uex5wGH63bVJIjPGMgYVA4Z/xZGuJDjSlOp3g4+VXRrduH73llUz8JkKDkrgaCB58ndSBPuVyiZtgg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-QfqTIJUS1DhrcFwt6JAOM1LzhTaNRJP1afvOkZ+RBT6QAqq8S8Y3h4BUECxrQ/nCzSG0KT13acXy4Ts0aMGaZw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/az.xpi",
           "version": "101.0.1"
         },
         "be": {
           "hash": "sha512-TBbaYJmb5Viq4lAE4Sp1zgYGHvyJbtX2EpgbEuxsKTs7ao2ND3MsqbRobBoGcdQ1nhFcS7LmHr5hsthsw00oUQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-RVhiQNPyDWKYJ2+ZvBJvMNDKf0RGjER805Dwf5NGNvs4GGyfMPBl6IdZGLtXfSoTllcrkOjghkxjGCh/vB5/rw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/be.xpi",
           "version": "101.0.1"
         },
         "bg": {
           "hash": "sha512-gFlmd5ow1RfzN1XE/umxYHmv1R7awuq9oypk1xiDfSvUcxkwL++U57heY+wbyGpjvjCLfxLBhHtbf/dZ1VaEMg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-1x3VM76HQg2RFMu9Uj2jbf9++jYxhIcASn3Juf/kyjindbSDzZsBruI1PdnqstOWHkJmIFTiJEBJs6j4DOUIfw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/bg.xpi",
           "version": "101.0.1"
         },
         "bn": {
           "hash": "sha512-tJEGQrlYsPW437Nwj5c7mFA5xMw1ky/Gs9HwrSSuLfdUV7HRA7orOYZKZR1KPA8ZMBrClQTbfMfDOcR1c4K1og==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-QOdyCgJ/yYI3/bIDCLXlrjOQaM+Cl32ODw0ZJL4UFcilQjDOdXpG7zmfggUBU7RdLMZSK32SqsOxMrsYEpvuAQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/bn.xpi",
           "version": "101.0.1"
         },
         "br": {
           "hash": "sha512-32X58M8b2HWsN2tcbG6PLm24haiFc7aqQDI+Cb3Ad5AWT+AdJQl1hFyDpfVM+Dbj93pHYD2GEQsix15NoiMfpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-vEN6FFnpaMrwBf5mcyh22Gc1Wn4+9g8YwhRUMomZjb/pnRuAQbfvBOis4fhOuTakqFHDsNT7HgDXJzrwlfEubw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/br.xpi",
           "version": "101.0.1"
         },
         "bs": {
           "hash": "sha512-evNVOnp3O9XCbhbDiLfNB+CX6Ik32+6Dw/qPMUY/eEWSOmKmVa60uny7BsxrzRKK1snrH+1MdrWUzI8IvgHQBA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-Hv4UffDbnMFdwBCT6QEQNy2v+GgsPmYcYrSdXM/NdSRLwcuNMEJVe4q0SCbhlUPz93+eH6ZmqUcXSEPkPj1knw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/bs.xpi",
           "version": "101.0.1"
         },
         "ca": {
           "hash": "sha512-lLEKHYARAVIwQzaXba1XaB/aMcB3YRb0tr/I4W0W2PsUlFtHDl716t9LSCqMY+1wXeBZOQIeg3KVE01aFO3SGA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-xo5yZpXImBj+aiVEu6cB76s1mvEYiefb1Ki+0BQjrBcmYpksARLQkoy51EXSaVcKtgyNlNzqVQKP0ap3IFFFVQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ca.xpi",
           "version": "101.0.1"
         },
         "ca-valencia": {
           "hash": "sha512-Rpf3TyWLha8FFr2FIRQ4Zx/9U5Ri1Y0+rEnlNcOowKDU//fayX2r9Q9023eqzPnWZNU0ZjMSKIrWUpDBi8DcBQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-n3O1C1eQARoC+FZZS8LJEKrEfMI+rTxOLQoEhhELVPGmwhLmdPsZI1deqkX4HVZdKmUyJ8j+E/0nRGtu9xzUwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ca-valencia.xpi",
           "version": "101.0.1"
         },
         "cak": {
           "hash": "sha512-3tK+k9lG3ozIFTRhLA8XzCCpkD+PR/1poH08ILftL1m2Gp8G1iIwJM+v7s35gD6NJlckgJlVabkbQls0phbFew==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-pmCyaW1tyPUcQo9poH8r9Cmn4JQrvvxnP5BCPfkRmtADNcceuSdkNPh32KuazE2DYEH2p5Fmc6fzI5ZuoOhnTA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/cak.xpi",
           "version": "101.0.1"
         },
         "cs": {
           "hash": "sha512-VBYSjEo42m7q8Ux0dU+wnnavXR+NzIsm9VzN0CTihP5NzTp8IN/cFNXI4+mkjAxOgNe+DG5sOPJ4NnvHoCDghA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-goXiPmbPEZnFfVbVnCiqnq9mbrFtUflo0CQDgeS0tpkUN76suH3JqyLJ7igBZNUS2RL9KSoa7uuf+U7WFephQg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/cs.xpi",
           "version": "101.0.1"
         },
         "cy": {
           "hash": "sha512-kuaFEvH39YPeBM9f4qW/CV8UnmkfXKKVQOU8fgVtpFqulz+QUZpYt7n82OP5RKHXGSlOctHZltaDOrUEILOzaw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-/KLVulj58YLk70CA0f/f1ZVwdAkfB/Lrl9M85ViRnr9HXVWhb3Lxz9m82T1PVRCIfJe+Pr9NFM8IOLRuDes3Gw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/cy.xpi",
           "version": "101.0.1"
         },
         "da": {
           "hash": "sha512-KdKe68t1tb0PGfplmvjIOecweFSll6WbNFvwvPliF92VlsJKqwVtmIs/X5trMsl+EUOyRJ1AX/29Vh8i3AiRsA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-bppTUi1uNt2A8bR8E4UCyYeYU39UBGZRGK/rTgFN7NikVQrg/9gj57tpy2jMj/QXsrLV/3AMpKrCKgz/En/0Ow=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/da.xpi",
           "version": "101.0.1"
         },
         "de": {
           "hash": "sha512-t+N/IN9XwCouISIcnNzbiUVYX/tzhZjCcvczNjCeMfQM3SPDq89rBIt1mogH3q7S1eAFQmJVtdyK3+CdLjuL3Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-z5PUenZiJs2Nkk3MEDrabZQXAYPiCmbQ13cRTmcX4paopc69TTZC8GKXdEwc1dZVUfi0/D21EDIFguBcHX+cAA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/de.xpi",
           "version": "101.0.1"
         },
         "dsb": {
           "hash": "sha512-nHLZQBS/hZrsyimM9yeL5KuWgmMf4zA+z4hjxfyCUY5PxGijG6XIqP3rNicSLtPFSjdiH4qBcmnQ4eIA+QQsLw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-sRHcIrYoEr7Mti0QYi7sx2gdRapdECXG7Cw90H9jWRtx+Wnki8NKCuCG8xAyqrjUemAXtVlHgyYjPBEmHAIPVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/dsb.xpi",
           "version": "101.0.1"
         },
         "el": {
           "hash": "sha512-HcXCIMv4KUY89iLrfSg5Wm+2hRXpx0rjFrEmSQkB78r4S7jFaCwF8gfvxUU3mD4gWfSZHh359iNvq9p8rcePlg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-9cecIFbx0dVb9TgBCYb+E+NhHEw0W1VccsXH14io+w0ppSum2LlYbW0dF4X4dCPwkNEQzVV6Mv9VF6vXJpphQQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/el.xpi",
           "version": "101.0.1"
         },
         "en-CA": {
           "hash": "sha512-wUwMHG3SifL6L/sB1ISM3s8vQFSUCCxpD4nYUklQuMzZQQNAo+cxStzi6NPVE+MVy44DFQl8qvYc9bEHRuwCUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-X+olCNTpJXFUhG1ANtWUtCl3chbfDFTgDvlr1znAZC182ZjaXeZKaod1NlfTI7axEierpUyP4pllZdflqc0VWQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/en-CA.xpi",
           "version": "101.0.1"
         },
         "en-GB": {
           "hash": "sha512-F/3dfKOyNk8uKCEktoxyUJC4BkRGdn+GbdRW6bd+G1Vw1BM9N4ObgN77w+OIz4STij/q7Mu9ZbduOKnCpWN3FQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-Ilh4puSRT8DRELDmRroxnlDGXgegUUWN2Xdrs679UvvrcgPQrP6fM7hPtHUFyMPdzs/Ac8gD9ZeImSwzmiuZ+Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/en-GB.xpi",
           "version": "101.0.1"
         },
         "en-US": {
           "hash": "sha512-xwlW/eHl/c5tBY7S0reUlTr7Y9Eg3wo2Q8LceXYk7dq7WjNa7LG13ccoTtxlYot/06wBX8zS36ORhwLhPMUzLA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-EttqzzYmFQQoqoeIA/+pNI4uz/iU/XDiwLn1THuaP8TKFmjnQiMHRhgrQwOvdFyCOTMnztAf6LhpuUW+9ZTM+g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/en-US.xpi",
           "version": "101.0.1"
         },
         "eo": {
           "hash": "sha512-fJp+ELWq0hLD3o3VeZQQ/gsf+A872qwIxqi2knYn1WpqNfJ4t90yg1EN43U5ppx/g1ZlPsOVnQ7zM5YiLxmlEA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-waisCdCPwznkNI84pYCYcVZ8zRZehq7CW9d3s31gOYDWSMBPGHAMTxpNx/HD8AzS5geIuymsxV9Y8zf3DoGM5w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/eo.xpi",
           "version": "101.0.1"
         },
         "es-AR": {
           "hash": "sha512-0dJyuEthNUCjOF/jySKP3fNxjvHebGOxH3UJYdJ8O5hfwsPJBhg7F1vFyi59j1FRK7rLl8juuwZHoWsN+PoHYg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-XbMNLp9w1kH97FG7QRTPAJn7UOtVwZAreMXAVKrhoQSRjFTjbtLfrFdxHqgwM1pD7P/8oxE9IThLTvTKmr69kg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-AR.xpi",
           "version": "101.0.1"
         },
         "es-CL": {
           "hash": "sha512-uicZK9Xmlmk3I/R1N1jkpeaz84metVH4BvhMAnOQ06FPB0+i+qMxcjbFvA7F8vNH7ZecWL9GdNlpj2vy1ykcCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-7Jd7NaaPRZrw+60nXEG/bzf6CcHmED9oau0q/afKo3hcBcGcwLaWojtuCa07JEffrcyWmj/zQAuQng8YgZuJbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-CL.xpi",
           "version": "101.0.1"
         },
         "es-ES": {
           "hash": "sha512-OscmHqSvShPAWyGns24YdogFnvhAe8nHMSApMYNcSJ7KsBsW4Um37/uBErsFYSzbKO0cytdI5jT4kQAAIZzkIg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-FWM9uSG6DmtNdHb49uGI3b4rYaN7YZTAaWLrlyOsfHXS7FvuWm92cfqh6hFmUAgiy8lbn2lVr6P4xoVZ7V6ytA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-ES.xpi",
           "version": "101.0.1"
         },
         "es-MX": {
           "hash": "sha512-ApTn+bn4nCyrCySU2pNp9RdVk0sXaMr5f7j8Ga/gAYGAjJpLgmu7l01GedsZbPRl97jPZjJa/6q6u0r5LvsDbw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-M9W4f9FAX4S2uw99+GIL/a+DXXtozx9Lxhnri+BGno9VwOXnnyNam/Mm2J2duGfmUuCgvOSX2XhS3U4YDqTckQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/es-MX.xpi",
           "version": "101.0.1"
         },
         "et": {
           "hash": "sha512-kRC4Ev/6oA6K2YxooeqHKmDZdJCC5UPwTe51mCQD8WqZrYmjFaHKVdyA8aoh4AtiqKROs3EftGpgDxK8L0PZWg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-8T7nb0uVaDGIIqCS0rhq00cUtWKWHFPWBRHLJGqnRA1IYgD4U8olcLq537EwmRwgVr600k+LdbSVR1edqzuz2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/et.xpi",
           "version": "101.0.1"
         },
         "eu": {
           "hash": "sha512-OZtN5rzARiWre3i4+O+Co4sU9X+GSItb0PKZNL3faK7+iWuLgsb2kLmoInq4cydR8ia9Pf8/R3fDp1spKO9AMw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-pxk+qqk2QDXaHiQxfMc7ZcaNnAI5TPQ6gzC5BlHoMLgQ/0Swoxk7RKrYvFLATaXQExc9ETFCZS8IW3YNzzYy8A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/eu.xpi",
           "version": "101.0.1"
         },
         "fa": {
           "hash": "sha512-7MqibXhGFBtdT2a0p/8BlmBw+QQTj7JVp/0BcbBccPBHZWCRe06LYRy5BgvCZMWgWN6hJIKl+k4LX3dFoUMqdg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-p2GwQxeL+GI49SOo58jaaDcnSJY0ApsTNoXFDEbsZdLuho6KHFyKdDUpNTzaOkqE6dafao9GpKmszbE/6cgW6w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fa.xpi",
           "version": "101.0.1"
         },
         "ff": {
           "hash": "sha512-FH26UEt0uPnKcZZYl8e8vX4PHbaBLA9ld279pLyb2/skrCT2/ONn6wl3j37vGTsNSyP3Nqjzs/qpG/woB86LTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-EF4OrX79GbLBfawo8Jq2EFV9lbBhOWewQywKt8hqEIy0Wl7eDOlBJeIVq0gY7ZU7uDt2X1ANYtgudgT72I575Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ff.xpi",
           "version": "101.0.1"
         },
         "fi": {
           "hash": "sha512-MBVa3obS8+3WVtf+xASiNCxmszvUdbXyRi/mr1PGyL2hmpw1l89UC8//3QWSdsDxiUMDDkCbLs1hsYWGM4hgBQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-2xI7CZdJV5l9L7C+1PaQB6q7gK8wG6S1F8fOLKro5/aOGP1st3RuWi3WjOzLnVo4PTK1Oj8O6KrOYAJUF+1reQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fi.xpi",
           "version": "101.0.1"
         },
         "fr": {
           "hash": "sha512-Ntj/CIjA9G27awtsKp4LWkzEYARxNBz9E0vqShrn1S7VBfPlwtSRR0cneg7UvdiiQe4mdhfkTos5uM13iDsRCQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-SSq1bkQJVlW9BNlDkSwPywDlwNcNeFCl/BvYa7uqXzT2xb4IwHv8U2GCk5qUPiOcvBslOhBejaS/CKv1h1igHA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fr.xpi",
           "version": "101.0.1"
         },
         "fy-NL": {
           "hash": "sha512-9CICKmEGhglQJ/7npuYwdl/6jiO0TU9hvGvpDhRm4s97NKklqLJfj6YZ187IyEkV+QukaFeLd88GHupkoSq3aw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-AotckhiPTERj5en4yHkQQHJ6bZY8HEOde9D2JdInbYtKv/OTim7DQUuIjG28wuIZDUXcT4KgaczU0n9urNSxoA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/fy-NL.xpi",
           "version": "101.0.1"
         },
         "ga-IE": {
           "hash": "sha512-UrQpKPVAmgDuxXYjyVGYFmiEr6xlFYdBmmqybS7iPrIGVVyh0nJiv4N6bkOV/9DxdLhx0OWQHOwBuczDeuQlMw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-wZ0Adca3qYUX1d2jx2GRNUl0dixfpU4AnsJfUki5ZpwfB/SUIYRTMoB+nZ09SMxI/VHZqXhHFZbXr33BnKw+Ag=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ga-IE.xpi",
           "version": "101.0.1"
         },
         "gd": {
           "hash": "sha512-rEz0kf+oROxeeifVDy+8VcdGpCRw7NP/XSjZQGLU+wZTI1xWFz/xF4GnobWyzKvV4/0OPxEBesKTeG9jFxvMQg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-k9IfaardTbANflgkXrilY9czFxpHiCimsAoz+HFHDlEgWiuVg+iw/SlptFuXxVmmX3dhgHeK18Hv19hEy7Gcrg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gd.xpi",
           "version": "101.0.1"
         },
         "gl": {
           "hash": "sha512-aqiUW8e75oIENZuUSvFJyUK68mWiehzLBLPRl7saBsn5BfG/jlItnri6cmeLsJtxfWqOm/6Ey+4RnjbbMVykEg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-15komOzilGaWX6VynkqLFPUppXKnA4b2EPAIyoxIpQbRj1G1IdMVJRnsSGclTmf1rcfFVBZlsGYn5dCkFCOHJg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gl.xpi",
           "version": "101.0.1"
         },
         "gn": {
           "hash": "sha512-FzZ7I7+OPWSNBOgeitzovRMOdBkMz9/jYIVAZKe/iczvGVQ7YMxonOzZaBc4+oH4bRPkFnDaHz4btke+F35duQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-C/HbhyDQmoqRSj//zZ1BVAGMU533oYDPHz6vpXlOXlmerQcYlqc3S3y/0DyxO1Rpc5igX7XL2JXFbx6MkaOKLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gn.xpi",
           "version": "101.0.1"
         },
         "gu-IN": {
           "hash": "sha512-H/lNNIo0gNeCCXXZxhk2GkTFQzfFYfJGEs3WoKZPHQdq2iV1Don06ZjbGs534zF5muzlXXEFpNJ2XWOZM4aypw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-JRuhkiHLxWWst73pojNDARFjx3x/SUKCFPZxLUgKZWCCIpi6VAXxkFKGOSkLL47OiphO/i/tRM5CVpVhf45N2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/gu-IN.xpi",
           "version": "101.0.1"
         },
         "he": {
           "hash": "sha512-w5RNn5AG0NbhiaCqF+eF1eQVbIckPKDzc94UyitGBwkvrYKfkiPw2Lu3xe+3ndV1Yc3TNuyBYV/duAMiTppw4w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-7biF+CGkKRDNBFe2rSps6CRZu/tMz+zKPBjmPZ2AyCdssN+88QICE9of8gHfDSC58BEIeJ6jtVL5xwulvwh+RA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/he.xpi",
           "version": "101.0.1"
         },
         "hi-IN": {
           "hash": "sha512-rMhs9R+9zIGhujSS3BEVsZ7j+nZMh1fqNOZLPRea2WCvsS8F7BjB1bnpheQOz/zEJ9AdjmwhpGtHg2FT7COWoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-CtII6F4CMOE52qkoPYIx7dYczbO4eLxwSpkVROrc/yIMjacbD08YCljL2UeSrImO0ucXEoSrgbt3ly3wMApgNg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hi-IN.xpi",
           "version": "101.0.1"
         },
         "hr": {
           "hash": "sha512-zVxU4ZZ4eYqSTazv8YLtFuWcI/EQNCL+IwptbnDyI5UTcZ/mCxuRxgt+998dAeu7qKHs3iqilO9hx46Y8FzEzA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-ECtBG1Bqf8FY6uRokQpzlsNx6aqFO+yioUFCPKIHa6DDNhIsE5mFMkDQZZ3Z7v8E72tRjkQ0OH3xyHyTNjGa8w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hr.xpi",
           "version": "101.0.1"
         },
         "hsb": {
           "hash": "sha512-lt0EcBLfhGtBeDNafvH+i2BV8Tf0SuYX0lebmLC7h7LS0pwqGycO3NynBYiwB8c1CPe48cNtXYqYopwBHzMfcQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-8+/CUphssbXDrnOnRR+rD6C/Rn/70xBVcefmti2KBTy47f4CR9GZ4OWAgmPzU0Ssor24/19XB4Jowg8qk7HYMg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hsb.xpi",
           "version": "101.0.1"
         },
         "hu": {
           "hash": "sha512-6WEdY4dGCfmUlxobYAe1rLdakVEiaXu1TA+sRVgFX46cyftbi8CJLNX6iq+wL9O4gyir68qclnwu5poUtR7b+A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-SKNvYc4mYAo/f+ZTHmvYU3qLiPcldDlFyQh5U849RJQ25Yjq4gdMIxn7B2AcJmwcjCzimUc1mijPxQYjGnMVQw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hu.xpi",
           "version": "101.0.1"
         },
         "hy-AM": {
           "hash": "sha512-aoKZV4x4JjVtgjLnJGiXdS0dMowEAdWKDDQUgFxsoYFS9fgDdhIbWrJB5YrCRHESXqaa7H4FvZ4I8+jsO7BI+w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-D3e8i60DnbiSeCbNHJ1kUY3zhODRwc7NCLwrzvkf+LzcuZWzJT5CraVFKaUAd5LPQ8fJFS/ZEHoNXzmhKhhqjA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/hy-AM.xpi",
           "version": "101.0.1"
         },
         "ia": {
           "hash": "sha512-HfzTjtdTtPt0pgxzDKn8iHcM3a/LfcyCy0r4bPc2P+RGy09pV7FI4mJX4HskJHn1gC2NM69e7sbxtQivehMZXg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-OqIfL4Fq59w/QKC4C0ViLmCD2PNamOS4iFX8Faojgp/ZvQTqK8ZHDOJW4XUFpcfzpPDd1T3a0ccO54R9GqTozA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ia.xpi",
           "version": "101.0.1"
         },
         "id": {
           "hash": "sha512-nWpHpLesZKvdNc/gsfxhwJqbHocTeT/GGkmGf2ELlhAGWh7wIo37p4JFuKA1sCITNM452UfQX0ZOSRFc9GjfGg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-YdY6F+PpxxTrISCHeiACFh3bpJVh7Ca5XzPSyyZNFtgD7aH9T0JDOpOSrQ1/vivBzBspEFsfSgaAQRc8p57tAg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/id.xpi",
           "version": "101.0.1"
         },
         "is": {
           "hash": "sha512-oAnHJC8cPTIDlsQVGhOctk0IcWzGKCf1LaYCgYV/7IE8Il6jWgJO7dk023Yig0ByeWB1qp9olnW1FPoqg1nOWw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-n9sM9h8SI9hNOv47WNMgIYQS8POdsLO13bKK5BI5Rw8p5daos8yC0WePefZ11OeA1YQZ6/UvskebJ3fLR2oC2w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/is.xpi",
           "version": "101.0.1"
         },
         "it": {
           "hash": "sha512-hPjtKiFBPVcl1xqyYzgU11blf60I2yDIphXKlPGnwEDhcKV+oVtj2n4kXpIe7L0N8NxPceLNugejVd9RM8NryA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-tdLQx24cVPx2wCjakHkkVpvNGhJuyMXEjRBPVgAW/+efe1SIW9b8hO4TNl9d/0MeOiY06d8Tu2xkFm1LK8niRQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/it.xpi",
           "version": "101.0.1"
         },
         "ja": {
           "hash": "sha512-vOGVdgQWzl39/vz8rPU7QT0/ptxvNo4yR68yEgqI3FjBKoKXWzoFNRdncjRI5uUsNqIp5yTzDpeGG5e20PpCtQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-n87NtiJcP9QtgICP1ZMl6ZWQI2U04Wj5ip0iTy2MUZnUUp6LWE5v5ZslRAP8VTv6+GplXdsE06SGpzPE8QJCwQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ja.xpi",
           "version": "101.0.1"
         },
         "ka": {
           "hash": "sha512-/5AzE+yNDrwYnNZKTTRxt5ZRwZ7x2oKM9GbuQE+opqwmZK98rROCiqmuSfYX9RtloP++ynYnbDbs98NLLT1ubQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-+Mrqj/YxbzfyL46B5WszCa4Fe7fWMnkGhH0l79AnIzh4rVZKeQ7liqIebTv13WmjphIU8HlcfS+acPeA6wYQYg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ka.xpi",
           "version": "101.0.1"
         },
         "kab": {
           "hash": "sha512-FeEBFNwsDe5bvN6CB6y9dZSOm/jwtl4DDC23pdNTx1tA79cP7FlWecergbRh7h7ePbA/IOrtqhDP9jK1hOgW0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-zLmwVMd44k0yupAenrDvxon55peHMIFsZl/KPi9rxv3VGdXAnVEMu8l22ZgkeSfF/fsZS5lqgBjDBs9bbYVz3w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/kab.xpi",
           "version": "101.0.1"
         },
         "kk": {
           "hash": "sha512-k1O1reWZE/XKkWfN3sN0zl7J9G3tfVuOuDmwzQKayZ0hI+BjdChWzcRYrfgl8GNf/52HgrP6XxHXWIhsnO4JaA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-ofH19rcLoxRe920K6VqUN6GwYqY/YCtZBskB8BAlmL6/bLXHEg//dV/rQSYcuqmF7rcFJdZZfaId8N7GJA797g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/kk.xpi",
           "version": "101.0.1"
         },
         "km": {
           "hash": "sha512-igGpXJBKmFUKx123B5fZU4beDbf8Bm/34GQxHZke+uFXgeymYsV7v2LCA7CrowaBModBpkerXiTglmeglUrE1g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-ATWThQo5l10BYPxVzvFkrELnt3wI7H6au1uz3XjBVsxKoSq2l3okSG6mkSymWSW+m3uZ+UX86I0rtTrittApJw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/km.xpi",
           "version": "101.0.1"
         },
         "kn": {
           "hash": "sha512-V3cPtJmHOxQFB5MMUB+t03QWcI7amT9fUpW1ngVglmDAFabW+o0DmCg2c2uBNhKXCKZ7izcQh+4vSOK7xECoDA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-DyXGXauRt79fDF/87PjdrzYDxMoYurYhb9rb36TOyp+h7cEP6Z7I+S3YS9WG7hPKPASv8o2GSclSxjErQWSk1Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/kn.xpi",
           "version": "101.0.1"
         },
         "ko": {
           "hash": "sha512-Wqj/VFIrarUcdXazTCRavftZ5zhOvEKWy5zNTL0jV8IbxkQoQiYuSjXTyMerwUK0dAzPKOhbEUYSW6jNUqRRBg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-bTymTJjH874hO3CCWgJNqvgIM56bBA5RAK01TDD0j5eG34wdXXHXLcSsoggOXwabc4C97TsFIKqPqYSOGx2+/w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ko.xpi",
           "version": "101.0.1"
         },
         "lij": {
           "hash": "sha512-HwOUk3su90qK0xlPFiGcc8LBHcgRqxwRexl7+/yW0lXwA3/H/WHLqQzev3tL60P/lqNbQQNNs4KxSOmW4F/XdQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-jiuGIvB0xdIJinRTl5bhjOKMlDg2671GLQgH5QpiLALzza6YmpiGo1DhgfDPGjOe2JoqFVBbqvy/Uf2IaQQcJA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/lij.xpi",
           "version": "101.0.1"
         },
         "lt": {
           "hash": "sha512-vO6lS0XrgDnYJrKOSMusIWLlhAUMRSIeW/RofcMpyeAo/3Oc9CGNl8yspe+fqJqsd/+6JlETGpyTKOlOPnPITQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-BN43TdCRaIif2k9FkL4GocbxIMsgNsW0qbZLwhLrtM5q3ZWHFBl5PxvTAB/f8Q9K2qkS/i7dMal7SHTrB7nfNg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/lt.xpi",
           "version": "101.0.1"
         },
         "lv": {
           "hash": "sha512-DrFKrvALJcmPBsWhvnhvg6+bHZ0CfKZV5SR0R3OsS7Qkp3ljxdk4hccM5nGazHCzitk0UISyZMoJkugjuxXV5A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-WnTNGupmlqxyOl/iTuwJ+zSbXMG4qVfauDslNErdRLkP4cyoMSOjdDNi58PuYAdrDMXpFMxC7EAh4B0d1eAVlg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/lv.xpi",
           "version": "101.0.1"
         },
         "mk": {
           "hash": "sha512-pXLcZ3qcgiovdaitgeOzDkW3wBi6wzjtjwTf2BAhzudLRIb/P+4DD4ic4gLHPnPXW4NI/1W9pLuC3bf43PB+wQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-uWwanYVMQmj8QDggCPzk8mEKnlCof5NKJkLtE4x8bGnBLeXuYnrEFa6H+G6MHjQLoYJv2V+sdlkMk7R4qUNTpw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/mk.xpi",
           "version": "101.0.1"
         },
         "mr": {
           "hash": "sha512-KVMjhoO3SlaCqwCp0VEL5IjcwfmiPxbjOq5drj3zS2OxGPWmsjkb8I1E9lSRftgNGdQImDvGCGJSvWaBl8z4Xg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-jjdnqlxADO5Yv/s6iD7bZITDVa4Q28IS+tE4nYrHQ85kgUVZKFokj+knSPIcgpuQ31cwnAKnw5MuU53vIj3x7A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/mr.xpi",
           "version": "101.0.1"
         },
         "ms": {
           "hash": "sha512-VAhpep1ULFWd5gmd6n9Yhg8ylB3s6W0EztspPwWQVhew0aOt9+qodaUwN9mUujxZTgIIlQAA8OGsBbf6JW/Q3g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-hcsqnvAQ9s3W1UOfrNi/5jXXy5W3AoVx5srr7jpG/5eKmbeuY93ahg0Ukcwysyx9VnwIj1PBzLUvhaPFWYdctg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ms.xpi",
           "version": "101.0.1"
         },
         "my": {
           "hash": "sha512-tmH7HD7zJU6jsz6M1ExmiF7JSuMvqtx0Iw5tk6y+E84nywgG8l8tXy+YumoFocXhhUmf76kOJUELL/lK4m7+Sw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-O4nPCKJw+tWu9Y53EZKSOCFYjn4N1JGhjRTYdb7AVnnrqRPevMni49ldMmSNAwNlDDX+V0PgwGO76qXSdl9ghg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/my.xpi",
           "version": "101.0.1"
         },
         "nb-NO": {
           "hash": "sha512-6G0e0x7sbIph2av+OZcadMXYI+r6iFYDKVmzfRkGOa3x1wrG2M3ogPRk+7hFIgK/cOknN6MGG6UO3M7FtffzPw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-A7oMh3hF2bwbxbiIHPCjLpV0h+cNV9wRTiQ45uTh+wVsr6ByrKZkmTWHbNhUv7/IQgpK8MiwYVeeEV8VGpq4mQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/nb-NO.xpi",
           "version": "101.0.1"
         },
         "ne-NP": {
           "hash": "sha512-MHXzX9vZYeHCmsj3qfF71qUKsXfMUE11VP3yg0R485cs5sa/F8a7AZhBd4bAc0M0I4AqeDY2qbhYwsG2lJsdlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-gOhFON3n4fL3MehzTrcaieU5FsAP/iCXY8QVX7sfARYFkfCpMWsMuDLuDErb6bLQoqXenxGFy35dC68fUrtC2Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ne-NP.xpi",
           "version": "101.0.1"
         },
         "nl": {
           "hash": "sha512-QbNfW5WHCsMzRoaxn4L0lYKhpZksPtEu9CHT+7k+WPq44dQzss/JguWCOlxY060+le2CB7ngPZ40MLN1isBknw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-EUTldLoRzedV+wbIYfDyG+2hEvSpHLpCewPvtsePxZRFLiMq9GzxYreB6VUyU8HTD6eCT0sXOFIgYuLdkfgVUw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/nl.xpi",
           "version": "101.0.1"
         },
         "nn-NO": {
           "hash": "sha512-eXF4NToXtLW6Db/BF+08KjjT0JPzBhISUWO4kOZupupNjIdA1iewWdKXAcJ6Xmcw5EA4RLCt1C6UZICf8N7yFA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-rBi1bgojVRvgB9+A+n4FqLUfEUVPAIxxSJ7cSy3rV2cPWKaEz+BRaM2UJ3KLhYqWU8j0elfnhaHMU1SUyoxyqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/nn-NO.xpi",
           "version": "101.0.1"
         },
         "oc": {
           "hash": "sha512-cnAmDFON7naaXYzqz2ka5gIZWtjx3RfokNv1hVlnE+kBhQa7M1yeh+AlHe72fmQ6TjCvU7ojbERtW70W6or5dQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-8m0v6+5OdMHrgrPTxAseB7rY7egCjV6CHrBvIFccFdPwgDXat9Btz+iPVAOWupwexhVMocI1KpvuE1oiGjm3LQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/oc.xpi",
           "version": "101.0.1"
         },
         "pa-IN": {
           "hash": "sha512-r/M9Y0lvKPhDXOQQ68oY3+z6+noyHYP6g6UagLA7BTXewYeMM0XojzF5HzxogX6IPQbWRqgkKXLnf6Y0KCbvQg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-kKFNfpyTBz1lE0b0grrsSxffiVLX0T3sfucO6JIKrYngjv+BrXxXXyNnQvcGuNt3gqvdcd3zRkZfJGt4hpPqog=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pa-IN.xpi",
           "version": "101.0.1"
         },
         "pl": {
           "hash": "sha512-I5uwSkHYs4a5ykq4nTBntFJowtgAECLnCjdVMroLbRNmvBGCUW6Wk22bK2dKXaq+o10ZyZFeMyOGDPpzyC8S4Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-Uh2uUzU8mx1o8TyOigG2rv3QTonFhpDBhJM1Tnr2794WSDpUGrFITIVAbf5BRwQHazaUcYj+8GyWOyXR+cB2Vw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pl.xpi",
           "version": "101.0.1"
         },
         "pt-BR": {
           "hash": "sha512-j1PM5YSW9eHdvP63OEmembHrg98DnNFk+V2oShBXtfZR8JgXpqDHfLxdxiJRLFkWqwxVk8wvNO6htqFUFVibEg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-TERwPKKbSdej4vyG5RMsbH4cz0mKTauNcAB1ehhP7/D4PYwuy4FVjS/REzW1+gMd0wznB6ZvYfArhy/WLEos8g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pt-BR.xpi",
           "version": "101.0.1"
         },
         "pt-PT": {
           "hash": "sha512-NATYnIZi/MtC5hF5foX9wb8fY82s2JdDEvAoVI8c5+VPnOck3Zrnt/Na/5XTFT4iTP/khark2HD49vl/wQFHCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-zmL98l5ehBz4v4AIvRmEBZt2H2cwbtFGXBWpHwL+e9t32fQmxAvh2qqbkTzH7ouZN+v4+LKSD1p6zdLSQtCHeA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/pt-PT.xpi",
           "version": "101.0.1"
         },
         "rm": {
           "hash": "sha512-TyOXb6kQBOjPeCiGdTWrq2lRpZYOoU2yGmKS6zbS3vNhCPuvohcm6ZdxXM+W3n0qf1nnpjVcGdipEr3giEANcw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-ZwdxUq71TAwGSlgUVABSm6Sgsz+J6w8Nx5ygdQvSUrbt4hYO+0vOxVAl7lJsoJvy2KkMUH4pKwVh+h5P77A4Hw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/rm.xpi",
           "version": "101.0.1"
         },
         "ro": {
           "hash": "sha512-Aeth9hddONx2CEkHoPgJVtET7ugrptdhFtdfhQ51Saybq/E+uLRA1uBpGy8JHzPdizC7FkguvglHL451UDRFag==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-JyvMpDe4ZtOcmM7gxaA26FlkbbfJyXDagRhpcn04Cf208LKnZQF1zY71mAA1Dl+0gxGpsyaqeWQaX8adnKbZLQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ro.xpi",
           "version": "101.0.1"
         },
         "ru": {
           "hash": "sha512-E8qjUEc6T/CI/h8RgCfgz3gZb1v2IZvKSkNyTdYV6CNcE8FOIXBy1HzodCsrrkbI49mp+a2tgNik9yKJWHA7oQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-wDCWDcy9E2Ddtwv71VRuhj/8vLrHpqphSHs9nwwk+Q85n18cEfl46KwGEhRWYcGPd4k7GuC1cfUTAC6ADpaQZQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ru.xpi",
           "version": "101.0.1"
         },
         "sco": {
           "hash": "sha512-GLPDmnQ3Nt7jq/dgpFzqNc3lXUW20p5CX0uqVWg2+93MZTa2xZOHzacOg7cd8Q3cVGTTKNV7cu8M7Um9DXMJ0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-LBbv0tqaK+reaOJszi0la1+cDu9Qa14ZgEjinIqQeyuMnl7pu3LMglxD/LO0/fZ4B/CzAj9rkANMQfmlGIr9xA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sco.xpi",
           "version": "101.0.1"
         },
         "si": {
           "hash": "sha512-rxTECYGRUoc5ykXU35+RGBBvIg3Lfa8Qdc5O98sFMNQKy8JWmtqeSK8Z6vttWa4J0P5XvntOcewBThVHolDPNw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-SQSDGnjxCrpSRndYNyWtU8RONe+Foph/UafULWuVv/M5J/aGa7lYEkCFkIwflGJ/4c08pM53k8VQp1oGFy9+WQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/si.xpi",
           "version": "101.0.1"
         },
         "sk": {
           "hash": "sha512-t9ej9Nyqy/ADipyK8afOAlVkjGojAnlZKesgR4ORZy1/XalFO3wbHcJ5ENzz7UM7PaxqyDc6gs82o3c5C8Wj0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-tuokD/qEj6RQQiWyLOdVIAuvaICHGUVwkg+wnoFZk0Pw/3vdsMbGUarzqM3plY9wG9Du0F824AVbUtF0f8sIUg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sk.xpi",
           "version": "101.0.1"
         },
         "sl": {
           "hash": "sha512-EHR5AM0+3ZYVrq60sKVKUVgiYoXQLQhU0BuU0Xa7R2zQVN9RHIskS1U6ayhBZwBkk+ORkfjbXZcssS7z2RKXRg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-OzyToDsm9+yzP651Eg46QTdBWMM927ROd9y8MGOSX3xeIZfwLPxxypukWQ01rxK2IIlGHFjbmb/KPRbk7etwAg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sl.xpi",
           "version": "101.0.1"
         },
         "son": {
           "hash": "sha512-WphxvXDS6p17dKWnixJsUDQz7HL6+typkHaQFaf5G/cdJ2tRCKPGldE+VHJSgFU7NfuCWiCL1Tm4YkKNaAvnNA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-VX8qqVdZhZ5Fw+vYJ/L0GJHlbeu+DofDTu2bJJdGRRD0Tss1mjG/IpkAs1Ul+6UTYKyuX3jJHXk4YxmGwfo3xg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/son.xpi",
           "version": "101.0.1"
         },
         "sq": {
           "hash": "sha512-jFJncZ3H9U+bKzLTMvso80GaWrlc3W4sOrpkaKzENh7MLPnNb9sxPPjfrv/6qfDlBIcH8Q00zMSKBAJrX53cTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-0iMX11wQfiaYCDCTPwRDJLY8c2WxVdmpu6oVnOiNl6yBB787irHdhnz+vL7uIC9GpR3ZEMVHhQKxJfaO6O9kTw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sq.xpi",
           "version": "101.0.1"
         },
         "sr": {
           "hash": "sha512-MCUglPxmDN+Or6ZUqR6DtWXVbibyRDz6b80UdZA1CC+mzYct7ciZ2iB88ixVi0bGka/euuAy97rPK8BcGHJL1g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-8jbkLjvO2gJFPikTTgKa3j94ePKAsWmr9n8snIp2KRQSlIyCKQfLGKHqerzaOH0SvM5JqXJRv6cXMW2MUXCu6w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sr.xpi",
           "version": "101.0.1"
         },
         "sv-SE": {
           "hash": "sha512-yRDVE+7mloFFgO/LcTFU0eyKmYxK3EJpdpBCU3UIF3bOT28/56w2lnAT/cU/6mxHGQygDR4J1A/t0YhIE2FoGQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-aXOVmuMDtuXSd7ad4BryR4j5O6+i2ACbupYAyft4Bz6SKpdiJkbMIkvLDz7We7lTXgasnyyoCQKHEVDmc3ZUsQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/sv-SE.xpi",
           "version": "101.0.1"
         },
         "szl": {
           "hash": "sha512-r+Ff43PDJSZDVf6NOvIWgfyUf6OMoyUHM3p+BzgA/Qx/e2wl5JN+zOxjCyY1U8fOfD4tfxr596WNuVJdxz98GQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-khV1IBss2+KTetvnXVcGkKPUY19MsNLtZGWdmIPz+QSfQykQ3KwTix1Kg1SPYuYluG7wEJs0p+kCSau+fW+GUA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/szl.xpi",
           "version": "101.0.1"
         },
         "ta": {
           "hash": "sha512-Y1r9or/uPpTkXbH/HtwxdvWIqmBalLagoIjtdHPJop+40jJV/yb9M5gaBizNuvnxQaZEFZ/smWPlVNM6OXBehg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-Uh4wRT5kTypUK4tQshpQhzQE0VrBVem9rk3bKIVI3oqIyKgscUdjKUn23SD+JhewDeIu+IehnoYUEoFKMKL32A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ta.xpi",
           "version": "101.0.1"
         },
         "te": {
           "hash": "sha512-yk85fYeek/5yr4w2llVxxougBrKH9zq/HcEWTOEPrOx8noPv5+XXx7sxjVgMA6COt3sfg9LnF4vKhOxJdaPUcQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-d1zFGJh6rcCtQx/mf/D3vR6RtYSFIId8UDIH83KtE/opNd5Ei27DdNFapF4hv/l/AjKnkLLAo23jaR9zAMfLmA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/te.xpi",
           "version": "101.0.1"
         },
         "th": {
           "hash": "sha512-nhhCqnxVFskVc0Brz8VFrdt/DfSyFzgwoIC9S3xIjCsFVHmY3t/7kTn09481uiGRq2DhJwJ60LXG/Hgcsf/Xtw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-0w7F3Hqh0dumb7NMzxqPvbmHzlA1wcp1F1WwSRUWP9Qz0XGUftvAqTKW9tMNYYSBhLXn6zWaGJvV4qp3lgGWHw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/th.xpi",
           "version": "101.0.1"
         },
         "tl": {
           "hash": "sha512-PnwGbMv9mj+VTQk0AwHwbvJhoVqO5F7XReh3OAPLhABgcKc2lnjxVxlG8z806Loxq15XdSnDQ4mpIzHG67RewA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-/UdberFGHsJGcG/YYdoDBN4U9eRMHSq/dfhDrThmb7EumSZdeZfN0kiOeR89NiOzhcBv9JBNbgkiwMVnQ932bQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/tl.xpi",
           "version": "101.0.1"
         },
         "tr": {
           "hash": "sha512-3mCjYYNek8qXssANZdrWlFRsVSsdvkGfdo7+xtOgGSMz0BMINJN2SovdtdzgfCKJIFw7rQEUYUT5UhZbgPaHwg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-w9XrdQXhXbs9tdpCK6CvQ7YYh1CXgqUIrh9SYp1p9IvcxuO4gg69uIgkbE8cPh3wF3lKtE2GCLJTPobyY//j2Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/tr.xpi",
           "version": "101.0.1"
         },
         "trs": {
           "hash": "sha512-DoAf4bPi+bm6U7KfUFiDbH6jbTpeQ1z4K/cLEYWwKkTfCRDNZnTUbRmeUiiceo+J2u4UMg54oVg8ASQ5bJ/ZYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-qtsgAkiSNMGzQlzOW9sg1Q1VitWGjvFWKUl9J3vdG9Tnie6U8hrucVIHjm4Pwe828+0H9XWAMNkZyrARPt+jZg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/trs.xpi",
           "version": "101.0.1"
         },
         "uk": {
           "hash": "sha512-R0kAC159cqHMNFped+XBkdSuuSg+mZ1VIIHSC5Nqt3dtRAnMdzJ1rXSYCoiKv1X5GrCcLoIwkM5m+ZQVzvYSQA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-qlBwCB06wwlBAvdaifMwiX4b/uPBDWBJ/EZXlZjJJG2CR2sLP32poMHzCdZI64Qm34/kFQo91vhfCclVnCkPpA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/uk.xpi",
           "version": "101.0.1"
         },
         "ur": {
           "hash": "sha512-I5uPe1nmaAmdl+RrDzS8lKBqcP/cjocgjRc5mwxJEs9jYR84UxprMI2IVB6kBg4WIiXIAf/mD0PDliVOpvr+Rw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-AAOPCuRVz2TWc9FrdTqBTj52ThnnOOoe3RbtHjUrzrJAqE3omK77I0OITbUdptxjHlm24an34treJdVYWkHgQA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/ur.xpi",
           "version": "101.0.1"
         },
         "uz": {
           "hash": "sha512-dHifXoqydpmxM9D0IZsPAXqrih6ZRFP31iLnL5sNT+N1Q5+s7kL14pqMqHQyQTpyIGbmjrSgwaB/e2xBcmrJuQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-R7VajBI8LXlx2Wr0NMsJ1L2T4/qzeyAb8nteKyf05DlkW31W2XUPNr7OZfE+YlG0QQNfylL5onNe7s3r77uTXg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/uz.xpi",
           "version": "101.0.1"
         },
         "vi": {
           "hash": "sha512-QpkYQfOKCyUvCa5EWSgw0KI2T+6nxAGFbwRb7QUKh012SC0vZmj53niFCJmuT8gskjzZFs9u/tpLQca6po/uTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-PtqyKZSJcEN/f/21Kmy3bk/+YzHSp0GNrz3poEkCOycLmso/+buC7DS+SRJ67a/0QnOcb6Gfo77c9lg0zHc0Sg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/vi.xpi",
           "version": "101.0.1"
         },
         "xh": {
           "hash": "sha512-LN0NypBHOFRBqCCKhGCbF3KAYeS2mOwgZtHNL1RmJAnuRhu0RLPYveYwNIZ8++9EjgT4X0UgS60CLfWOibj3Tw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-6D9esd9zB1Ui2newZtgrsoTj9DtgZAqdN6lWKH2jJgueT2EeLVTcRFbTjK/UsbJQ8tfkPGk9uodwQ4bJlme9qw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/xh.xpi",
           "version": "101.0.1"
         },
         "zh-CN": {
           "hash": "sha512-hIRirhjaYteaphY9yw5TrbSsD+AxqA3R86C5QxAgYFSGgviSGwJDHfVS/YF7vSRrrFZj4JF2LrHsBAMI80/mOQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-4+H1F4r3VhsKcNUheNA2cwRTnIJZ2QKcTHGo7nTJmz7j/BH+Jsw9Ao1ZTTJsfWBG1kGz2egE9ozokQdd9BNo+g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/zh-CN.xpi",
           "version": "101.0.1"
         },
         "zh-TW": {
           "hash": "sha512-IvqHJgQhiVgT9bMmnooyDSS0R3utXGEI0LaPgK/qrqLZDTZ8Q2pJ1kNSOgC/+99MVwx9VUTT5vGXehxbBHOztQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-+0CKDh73EGxR7IyHdLK9lE5MkLXCiQqFOgAixXZuIheLAXb3V3jbP89zgDq+kwmzoMJWokBBgH81q6mn1OCLXA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-i686/xpi/zh-TW.xpi",
           "version": "101.0.1"
         }
@@ -496,491 +790,785 @@
       "linux-x86_64": {
         "ach": {
           "hash": "sha512-nuEw1Olrtz7C7AG9dfqiaHvLYgcn9E4ZnuF9s+UjJU4KDovY0YE/TuvrgOV1uiCzEmd9I6SZSq3GpNT7m7+luA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-bSj5Rsk5fCf7foErHBzBnLzYqDfN/3icRM9JX2yXMsXYLrxRIq4ncC5eWq3nTZn/8k1vN8bDBcuBORpdsOzNow=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ach.xpi",
           "version": "101.0.1"
         },
         "af": {
           "hash": "sha512-yd3rTd1t2HBMF/Xdi/jr24gdiK0bseAXN7cLoO/TN0/aCCkSOvy/v5i3cL5MKBpxT7qy7jDW/O/z6sv6OY352w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-jAo4aYBfWcNyadJKaMBIZMJERdCtGvZ6gpFC6AJL2a+jwfcrwDHHjy+cVwa+F3fOwoi8/kw1x95W3cVak3GvSg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/af.xpi",
           "version": "101.0.1"
         },
         "an": {
           "hash": "sha512-+n1nXVLVR8cWjkAuapxPRoehsd0lHo517Y0LfhcZYOJ2KuQtlNlQ0ZJUZ7YZUUEQHdC2YsOZGYIv8v3SokhhPw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-w9DGfcWo9ZUorI/iSsFXG7JEYXsTTGl0o2Cc7XgVlrr0rm6pYkQhdmEhJc3CoUG+HQElJPlnCefxAP+RGul/sA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/an.xpi",
           "version": "101.0.1"
         },
         "ar": {
           "hash": "sha512-3Ip2xH63ywXIxBHacGaCC3ZtW3rxksHuklZHn7Jo8tgpRCEz6Ac7quKUW20YkqjGqkDxwMx5CBnz5O8RzuBMbA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-eibjYfTEvbhrBzv1RtZQqCz8nX4SqgmmP4UWqCSCNlsVNEi71QKblCw4W8pd2/9jf61Et5CMRolubZWW5AJsLQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ar.xpi",
           "version": "101.0.1"
         },
         "ast": {
           "hash": "sha512-l3fFkiJGs9AQZSGRqQqloL6dCTjQQy/p46KBnM8Hx9YF7X6qHY4G8QPe13uUOvs6Fs2ZlQQOdp/Z4yilvVBxyA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-ZRKFUO1m8+bw48xubWGkNz0bRUwucveVc9I5P4e9XUYDFvo7xVQ858pe+I3blJGW+dR1bRoSlGecZCYAk6AS4w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ast.xpi",
           "version": "101.0.1"
         },
         "az": {
           "hash": "sha512-e3q/+lo6uex5wGH63bVJIjPGMgYVA4Z/xZGuJDjSlOp3g4+VXRrduH73llUz8JkKDkrgaCB58ndSBPuVyiZtgg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-QfqTIJUS1DhrcFwt6JAOM1LzhTaNRJP1afvOkZ+RBT6QAqq8S8Y3h4BUECxrQ/nCzSG0KT13acXy4Ts0aMGaZw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/az.xpi",
           "version": "101.0.1"
         },
         "be": {
           "hash": "sha512-TBbaYJmb5Viq4lAE4Sp1zgYGHvyJbtX2EpgbEuxsKTs7ao2ND3MsqbRobBoGcdQ1nhFcS7LmHr5hsthsw00oUQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-RVhiQNPyDWKYJ2+ZvBJvMNDKf0RGjER805Dwf5NGNvs4GGyfMPBl6IdZGLtXfSoTllcrkOjghkxjGCh/vB5/rw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/be.xpi",
           "version": "101.0.1"
         },
         "bg": {
           "hash": "sha512-gFlmd5ow1RfzN1XE/umxYHmv1R7awuq9oypk1xiDfSvUcxkwL++U57heY+wbyGpjvjCLfxLBhHtbf/dZ1VaEMg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-1x3VM76HQg2RFMu9Uj2jbf9++jYxhIcASn3Juf/kyjindbSDzZsBruI1PdnqstOWHkJmIFTiJEBJs6j4DOUIfw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/bg.xpi",
           "version": "101.0.1"
         },
         "bn": {
           "hash": "sha512-tJEGQrlYsPW437Nwj5c7mFA5xMw1ky/Gs9HwrSSuLfdUV7HRA7orOYZKZR1KPA8ZMBrClQTbfMfDOcR1c4K1og==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-QOdyCgJ/yYI3/bIDCLXlrjOQaM+Cl32ODw0ZJL4UFcilQjDOdXpG7zmfggUBU7RdLMZSK32SqsOxMrsYEpvuAQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/bn.xpi",
           "version": "101.0.1"
         },
         "br": {
           "hash": "sha512-32X58M8b2HWsN2tcbG6PLm24haiFc7aqQDI+Cb3Ad5AWT+AdJQl1hFyDpfVM+Dbj93pHYD2GEQsix15NoiMfpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-vEN6FFnpaMrwBf5mcyh22Gc1Wn4+9g8YwhRUMomZjb/pnRuAQbfvBOis4fhOuTakqFHDsNT7HgDXJzrwlfEubw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/br.xpi",
           "version": "101.0.1"
         },
         "bs": {
           "hash": "sha512-evNVOnp3O9XCbhbDiLfNB+CX6Ik32+6Dw/qPMUY/eEWSOmKmVa60uny7BsxrzRKK1snrH+1MdrWUzI8IvgHQBA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-Hv4UffDbnMFdwBCT6QEQNy2v+GgsPmYcYrSdXM/NdSRLwcuNMEJVe4q0SCbhlUPz93+eH6ZmqUcXSEPkPj1knw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/bs.xpi",
           "version": "101.0.1"
         },
         "ca": {
           "hash": "sha512-lLEKHYARAVIwQzaXba1XaB/aMcB3YRb0tr/I4W0W2PsUlFtHDl716t9LSCqMY+1wXeBZOQIeg3KVE01aFO3SGA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-xo5yZpXImBj+aiVEu6cB76s1mvEYiefb1Ki+0BQjrBcmYpksARLQkoy51EXSaVcKtgyNlNzqVQKP0ap3IFFFVQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ca.xpi",
           "version": "101.0.1"
         },
         "ca-valencia": {
           "hash": "sha512-Rpf3TyWLha8FFr2FIRQ4Zx/9U5Ri1Y0+rEnlNcOowKDU//fayX2r9Q9023eqzPnWZNU0ZjMSKIrWUpDBi8DcBQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-n3O1C1eQARoC+FZZS8LJEKrEfMI+rTxOLQoEhhELVPGmwhLmdPsZI1deqkX4HVZdKmUyJ8j+E/0nRGtu9xzUwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ca-valencia.xpi",
           "version": "101.0.1"
         },
         "cak": {
           "hash": "sha512-3tK+k9lG3ozIFTRhLA8XzCCpkD+PR/1poH08ILftL1m2Gp8G1iIwJM+v7s35gD6NJlckgJlVabkbQls0phbFew==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-pmCyaW1tyPUcQo9poH8r9Cmn4JQrvvxnP5BCPfkRmtADNcceuSdkNPh32KuazE2DYEH2p5Fmc6fzI5ZuoOhnTA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/cak.xpi",
           "version": "101.0.1"
         },
         "cs": {
           "hash": "sha512-VBYSjEo42m7q8Ux0dU+wnnavXR+NzIsm9VzN0CTihP5NzTp8IN/cFNXI4+mkjAxOgNe+DG5sOPJ4NnvHoCDghA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-goXiPmbPEZnFfVbVnCiqnq9mbrFtUflo0CQDgeS0tpkUN76suH3JqyLJ7igBZNUS2RL9KSoa7uuf+U7WFephQg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/cs.xpi",
           "version": "101.0.1"
         },
         "cy": {
           "hash": "sha512-kuaFEvH39YPeBM9f4qW/CV8UnmkfXKKVQOU8fgVtpFqulz+QUZpYt7n82OP5RKHXGSlOctHZltaDOrUEILOzaw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-/KLVulj58YLk70CA0f/f1ZVwdAkfB/Lrl9M85ViRnr9HXVWhb3Lxz9m82T1PVRCIfJe+Pr9NFM8IOLRuDes3Gw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/cy.xpi",
           "version": "101.0.1"
         },
         "da": {
           "hash": "sha512-KdKe68t1tb0PGfplmvjIOecweFSll6WbNFvwvPliF92VlsJKqwVtmIs/X5trMsl+EUOyRJ1AX/29Vh8i3AiRsA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-bppTUi1uNt2A8bR8E4UCyYeYU39UBGZRGK/rTgFN7NikVQrg/9gj57tpy2jMj/QXsrLV/3AMpKrCKgz/En/0Ow=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/da.xpi",
           "version": "101.0.1"
         },
         "de": {
           "hash": "sha512-t+N/IN9XwCouISIcnNzbiUVYX/tzhZjCcvczNjCeMfQM3SPDq89rBIt1mogH3q7S1eAFQmJVtdyK3+CdLjuL3Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-z5PUenZiJs2Nkk3MEDrabZQXAYPiCmbQ13cRTmcX4paopc69TTZC8GKXdEwc1dZVUfi0/D21EDIFguBcHX+cAA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/de.xpi",
           "version": "101.0.1"
         },
         "dsb": {
           "hash": "sha512-nHLZQBS/hZrsyimM9yeL5KuWgmMf4zA+z4hjxfyCUY5PxGijG6XIqP3rNicSLtPFSjdiH4qBcmnQ4eIA+QQsLw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-sRHcIrYoEr7Mti0QYi7sx2gdRapdECXG7Cw90H9jWRtx+Wnki8NKCuCG8xAyqrjUemAXtVlHgyYjPBEmHAIPVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/dsb.xpi",
           "version": "101.0.1"
         },
         "el": {
           "hash": "sha512-HcXCIMv4KUY89iLrfSg5Wm+2hRXpx0rjFrEmSQkB78r4S7jFaCwF8gfvxUU3mD4gWfSZHh359iNvq9p8rcePlg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-9cecIFbx0dVb9TgBCYb+E+NhHEw0W1VccsXH14io+w0ppSum2LlYbW0dF4X4dCPwkNEQzVV6Mv9VF6vXJpphQQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/el.xpi",
           "version": "101.0.1"
         },
         "en-CA": {
           "hash": "sha512-wUwMHG3SifL6L/sB1ISM3s8vQFSUCCxpD4nYUklQuMzZQQNAo+cxStzi6NPVE+MVy44DFQl8qvYc9bEHRuwCUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-X+olCNTpJXFUhG1ANtWUtCl3chbfDFTgDvlr1znAZC182ZjaXeZKaod1NlfTI7axEierpUyP4pllZdflqc0VWQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/en-CA.xpi",
           "version": "101.0.1"
         },
         "en-GB": {
           "hash": "sha512-F/3dfKOyNk8uKCEktoxyUJC4BkRGdn+GbdRW6bd+G1Vw1BM9N4ObgN77w+OIz4STij/q7Mu9ZbduOKnCpWN3FQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-Ilh4puSRT8DRELDmRroxnlDGXgegUUWN2Xdrs679UvvrcgPQrP6fM7hPtHUFyMPdzs/Ac8gD9ZeImSwzmiuZ+Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/en-GB.xpi",
           "version": "101.0.1"
         },
         "en-US": {
           "hash": "sha512-xwlW/eHl/c5tBY7S0reUlTr7Y9Eg3wo2Q8LceXYk7dq7WjNa7LG13ccoTtxlYot/06wBX8zS36ORhwLhPMUzLA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-EttqzzYmFQQoqoeIA/+pNI4uz/iU/XDiwLn1THuaP8TKFmjnQiMHRhgrQwOvdFyCOTMnztAf6LhpuUW+9ZTM+g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/en-US.xpi",
           "version": "101.0.1"
         },
         "eo": {
           "hash": "sha512-fJp+ELWq0hLD3o3VeZQQ/gsf+A872qwIxqi2knYn1WpqNfJ4t90yg1EN43U5ppx/g1ZlPsOVnQ7zM5YiLxmlEA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-waisCdCPwznkNI84pYCYcVZ8zRZehq7CW9d3s31gOYDWSMBPGHAMTxpNx/HD8AzS5geIuymsxV9Y8zf3DoGM5w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/eo.xpi",
           "version": "101.0.1"
         },
         "es-AR": {
           "hash": "sha512-0dJyuEthNUCjOF/jySKP3fNxjvHebGOxH3UJYdJ8O5hfwsPJBhg7F1vFyi59j1FRK7rLl8juuwZHoWsN+PoHYg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-XbMNLp9w1kH97FG7QRTPAJn7UOtVwZAreMXAVKrhoQSRjFTjbtLfrFdxHqgwM1pD7P/8oxE9IThLTvTKmr69kg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-AR.xpi",
           "version": "101.0.1"
         },
         "es-CL": {
           "hash": "sha512-uicZK9Xmlmk3I/R1N1jkpeaz84metVH4BvhMAnOQ06FPB0+i+qMxcjbFvA7F8vNH7ZecWL9GdNlpj2vy1ykcCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-7Jd7NaaPRZrw+60nXEG/bzf6CcHmED9oau0q/afKo3hcBcGcwLaWojtuCa07JEffrcyWmj/zQAuQng8YgZuJbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-CL.xpi",
           "version": "101.0.1"
         },
         "es-ES": {
           "hash": "sha512-OscmHqSvShPAWyGns24YdogFnvhAe8nHMSApMYNcSJ7KsBsW4Um37/uBErsFYSzbKO0cytdI5jT4kQAAIZzkIg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-FWM9uSG6DmtNdHb49uGI3b4rYaN7YZTAaWLrlyOsfHXS7FvuWm92cfqh6hFmUAgiy8lbn2lVr6P4xoVZ7V6ytA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-ES.xpi",
           "version": "101.0.1"
         },
         "es-MX": {
           "hash": "sha512-ApTn+bn4nCyrCySU2pNp9RdVk0sXaMr5f7j8Ga/gAYGAjJpLgmu7l01GedsZbPRl97jPZjJa/6q6u0r5LvsDbw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-M9W4f9FAX4S2uw99+GIL/a+DXXtozx9Lxhnri+BGno9VwOXnnyNam/Mm2J2duGfmUuCgvOSX2XhS3U4YDqTckQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/es-MX.xpi",
           "version": "101.0.1"
         },
         "et": {
           "hash": "sha512-kRC4Ev/6oA6K2YxooeqHKmDZdJCC5UPwTe51mCQD8WqZrYmjFaHKVdyA8aoh4AtiqKROs3EftGpgDxK8L0PZWg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-8T7nb0uVaDGIIqCS0rhq00cUtWKWHFPWBRHLJGqnRA1IYgD4U8olcLq537EwmRwgVr600k+LdbSVR1edqzuz2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/et.xpi",
           "version": "101.0.1"
         },
         "eu": {
           "hash": "sha512-OZtN5rzARiWre3i4+O+Co4sU9X+GSItb0PKZNL3faK7+iWuLgsb2kLmoInq4cydR8ia9Pf8/R3fDp1spKO9AMw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-pxk+qqk2QDXaHiQxfMc7ZcaNnAI5TPQ6gzC5BlHoMLgQ/0Swoxk7RKrYvFLATaXQExc9ETFCZS8IW3YNzzYy8A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/eu.xpi",
           "version": "101.0.1"
         },
         "fa": {
           "hash": "sha512-7MqibXhGFBtdT2a0p/8BlmBw+QQTj7JVp/0BcbBccPBHZWCRe06LYRy5BgvCZMWgWN6hJIKl+k4LX3dFoUMqdg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-p2GwQxeL+GI49SOo58jaaDcnSJY0ApsTNoXFDEbsZdLuho6KHFyKdDUpNTzaOkqE6dafao9GpKmszbE/6cgW6w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fa.xpi",
           "version": "101.0.1"
         },
         "ff": {
           "hash": "sha512-FH26UEt0uPnKcZZYl8e8vX4PHbaBLA9ld279pLyb2/skrCT2/ONn6wl3j37vGTsNSyP3Nqjzs/qpG/woB86LTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-EF4OrX79GbLBfawo8Jq2EFV9lbBhOWewQywKt8hqEIy0Wl7eDOlBJeIVq0gY7ZU7uDt2X1ANYtgudgT72I575Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ff.xpi",
           "version": "101.0.1"
         },
         "fi": {
           "hash": "sha512-MBVa3obS8+3WVtf+xASiNCxmszvUdbXyRi/mr1PGyL2hmpw1l89UC8//3QWSdsDxiUMDDkCbLs1hsYWGM4hgBQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-2xI7CZdJV5l9L7C+1PaQB6q7gK8wG6S1F8fOLKro5/aOGP1st3RuWi3WjOzLnVo4PTK1Oj8O6KrOYAJUF+1reQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fi.xpi",
           "version": "101.0.1"
         },
         "fr": {
           "hash": "sha512-Ntj/CIjA9G27awtsKp4LWkzEYARxNBz9E0vqShrn1S7VBfPlwtSRR0cneg7UvdiiQe4mdhfkTos5uM13iDsRCQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-SSq1bkQJVlW9BNlDkSwPywDlwNcNeFCl/BvYa7uqXzT2xb4IwHv8U2GCk5qUPiOcvBslOhBejaS/CKv1h1igHA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fr.xpi",
           "version": "101.0.1"
         },
         "fy-NL": {
           "hash": "sha512-9CICKmEGhglQJ/7npuYwdl/6jiO0TU9hvGvpDhRm4s97NKklqLJfj6YZ187IyEkV+QukaFeLd88GHupkoSq3aw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-AotckhiPTERj5en4yHkQQHJ6bZY8HEOde9D2JdInbYtKv/OTim7DQUuIjG28wuIZDUXcT4KgaczU0n9urNSxoA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/fy-NL.xpi",
           "version": "101.0.1"
         },
         "ga-IE": {
           "hash": "sha512-UrQpKPVAmgDuxXYjyVGYFmiEr6xlFYdBmmqybS7iPrIGVVyh0nJiv4N6bkOV/9DxdLhx0OWQHOwBuczDeuQlMw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-wZ0Adca3qYUX1d2jx2GRNUl0dixfpU4AnsJfUki5ZpwfB/SUIYRTMoB+nZ09SMxI/VHZqXhHFZbXr33BnKw+Ag=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ga-IE.xpi",
           "version": "101.0.1"
         },
         "gd": {
           "hash": "sha512-rEz0kf+oROxeeifVDy+8VcdGpCRw7NP/XSjZQGLU+wZTI1xWFz/xF4GnobWyzKvV4/0OPxEBesKTeG9jFxvMQg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-k9IfaardTbANflgkXrilY9czFxpHiCimsAoz+HFHDlEgWiuVg+iw/SlptFuXxVmmX3dhgHeK18Hv19hEy7Gcrg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gd.xpi",
           "version": "101.0.1"
         },
         "gl": {
           "hash": "sha512-aqiUW8e75oIENZuUSvFJyUK68mWiehzLBLPRl7saBsn5BfG/jlItnri6cmeLsJtxfWqOm/6Ey+4RnjbbMVykEg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-15komOzilGaWX6VynkqLFPUppXKnA4b2EPAIyoxIpQbRj1G1IdMVJRnsSGclTmf1rcfFVBZlsGYn5dCkFCOHJg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gl.xpi",
           "version": "101.0.1"
         },
         "gn": {
           "hash": "sha512-FzZ7I7+OPWSNBOgeitzovRMOdBkMz9/jYIVAZKe/iczvGVQ7YMxonOzZaBc4+oH4bRPkFnDaHz4btke+F35duQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-C/HbhyDQmoqRSj//zZ1BVAGMU533oYDPHz6vpXlOXlmerQcYlqc3S3y/0DyxO1Rpc5igX7XL2JXFbx6MkaOKLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gn.xpi",
           "version": "101.0.1"
         },
         "gu-IN": {
           "hash": "sha512-H/lNNIo0gNeCCXXZxhk2GkTFQzfFYfJGEs3WoKZPHQdq2iV1Don06ZjbGs534zF5muzlXXEFpNJ2XWOZM4aypw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-JRuhkiHLxWWst73pojNDARFjx3x/SUKCFPZxLUgKZWCCIpi6VAXxkFKGOSkLL47OiphO/i/tRM5CVpVhf45N2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/gu-IN.xpi",
           "version": "101.0.1"
         },
         "he": {
           "hash": "sha512-w5RNn5AG0NbhiaCqF+eF1eQVbIckPKDzc94UyitGBwkvrYKfkiPw2Lu3xe+3ndV1Yc3TNuyBYV/duAMiTppw4w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-7biF+CGkKRDNBFe2rSps6CRZu/tMz+zKPBjmPZ2AyCdssN+88QICE9of8gHfDSC58BEIeJ6jtVL5xwulvwh+RA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/he.xpi",
           "version": "101.0.1"
         },
         "hi-IN": {
           "hash": "sha512-rMhs9R+9zIGhujSS3BEVsZ7j+nZMh1fqNOZLPRea2WCvsS8F7BjB1bnpheQOz/zEJ9AdjmwhpGtHg2FT7COWoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-CtII6F4CMOE52qkoPYIx7dYczbO4eLxwSpkVROrc/yIMjacbD08YCljL2UeSrImO0ucXEoSrgbt3ly3wMApgNg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hi-IN.xpi",
           "version": "101.0.1"
         },
         "hr": {
           "hash": "sha512-zVxU4ZZ4eYqSTazv8YLtFuWcI/EQNCL+IwptbnDyI5UTcZ/mCxuRxgt+998dAeu7qKHs3iqilO9hx46Y8FzEzA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-ECtBG1Bqf8FY6uRokQpzlsNx6aqFO+yioUFCPKIHa6DDNhIsE5mFMkDQZZ3Z7v8E72tRjkQ0OH3xyHyTNjGa8w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hr.xpi",
           "version": "101.0.1"
         },
         "hsb": {
           "hash": "sha512-lt0EcBLfhGtBeDNafvH+i2BV8Tf0SuYX0lebmLC7h7LS0pwqGycO3NynBYiwB8c1CPe48cNtXYqYopwBHzMfcQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-8+/CUphssbXDrnOnRR+rD6C/Rn/70xBVcefmti2KBTy47f4CR9GZ4OWAgmPzU0Ssor24/19XB4Jowg8qk7HYMg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hsb.xpi",
           "version": "101.0.1"
         },
         "hu": {
           "hash": "sha512-6WEdY4dGCfmUlxobYAe1rLdakVEiaXu1TA+sRVgFX46cyftbi8CJLNX6iq+wL9O4gyir68qclnwu5poUtR7b+A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-SKNvYc4mYAo/f+ZTHmvYU3qLiPcldDlFyQh5U849RJQ25Yjq4gdMIxn7B2AcJmwcjCzimUc1mijPxQYjGnMVQw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hu.xpi",
           "version": "101.0.1"
         },
         "hy-AM": {
           "hash": "sha512-aoKZV4x4JjVtgjLnJGiXdS0dMowEAdWKDDQUgFxsoYFS9fgDdhIbWrJB5YrCRHESXqaa7H4FvZ4I8+jsO7BI+w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-D3e8i60DnbiSeCbNHJ1kUY3zhODRwc7NCLwrzvkf+LzcuZWzJT5CraVFKaUAd5LPQ8fJFS/ZEHoNXzmhKhhqjA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/hy-AM.xpi",
           "version": "101.0.1"
         },
         "ia": {
           "hash": "sha512-HfzTjtdTtPt0pgxzDKn8iHcM3a/LfcyCy0r4bPc2P+RGy09pV7FI4mJX4HskJHn1gC2NM69e7sbxtQivehMZXg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-OqIfL4Fq59w/QKC4C0ViLmCD2PNamOS4iFX8Faojgp/ZvQTqK8ZHDOJW4XUFpcfzpPDd1T3a0ccO54R9GqTozA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ia.xpi",
           "version": "101.0.1"
         },
         "id": {
           "hash": "sha512-nWpHpLesZKvdNc/gsfxhwJqbHocTeT/GGkmGf2ELlhAGWh7wIo37p4JFuKA1sCITNM452UfQX0ZOSRFc9GjfGg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-YdY6F+PpxxTrISCHeiACFh3bpJVh7Ca5XzPSyyZNFtgD7aH9T0JDOpOSrQ1/vivBzBspEFsfSgaAQRc8p57tAg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/id.xpi",
           "version": "101.0.1"
         },
         "is": {
           "hash": "sha512-oAnHJC8cPTIDlsQVGhOctk0IcWzGKCf1LaYCgYV/7IE8Il6jWgJO7dk023Yig0ByeWB1qp9olnW1FPoqg1nOWw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-n9sM9h8SI9hNOv47WNMgIYQS8POdsLO13bKK5BI5Rw8p5daos8yC0WePefZ11OeA1YQZ6/UvskebJ3fLR2oC2w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/is.xpi",
           "version": "101.0.1"
         },
         "it": {
           "hash": "sha512-hPjtKiFBPVcl1xqyYzgU11blf60I2yDIphXKlPGnwEDhcKV+oVtj2n4kXpIe7L0N8NxPceLNugejVd9RM8NryA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-tdLQx24cVPx2wCjakHkkVpvNGhJuyMXEjRBPVgAW/+efe1SIW9b8hO4TNl9d/0MeOiY06d8Tu2xkFm1LK8niRQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/it.xpi",
           "version": "101.0.1"
         },
         "ja": {
           "hash": "sha512-vOGVdgQWzl39/vz8rPU7QT0/ptxvNo4yR68yEgqI3FjBKoKXWzoFNRdncjRI5uUsNqIp5yTzDpeGG5e20PpCtQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-n87NtiJcP9QtgICP1ZMl6ZWQI2U04Wj5ip0iTy2MUZnUUp6LWE5v5ZslRAP8VTv6+GplXdsE06SGpzPE8QJCwQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ja.xpi",
           "version": "101.0.1"
         },
         "ka": {
           "hash": "sha512-/5AzE+yNDrwYnNZKTTRxt5ZRwZ7x2oKM9GbuQE+opqwmZK98rROCiqmuSfYX9RtloP++ynYnbDbs98NLLT1ubQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-+Mrqj/YxbzfyL46B5WszCa4Fe7fWMnkGhH0l79AnIzh4rVZKeQ7liqIebTv13WmjphIU8HlcfS+acPeA6wYQYg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ka.xpi",
           "version": "101.0.1"
         },
         "kab": {
           "hash": "sha512-FeEBFNwsDe5bvN6CB6y9dZSOm/jwtl4DDC23pdNTx1tA79cP7FlWecergbRh7h7ePbA/IOrtqhDP9jK1hOgW0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-zLmwVMd44k0yupAenrDvxon55peHMIFsZl/KPi9rxv3VGdXAnVEMu8l22ZgkeSfF/fsZS5lqgBjDBs9bbYVz3w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/kab.xpi",
           "version": "101.0.1"
         },
         "kk": {
           "hash": "sha512-k1O1reWZE/XKkWfN3sN0zl7J9G3tfVuOuDmwzQKayZ0hI+BjdChWzcRYrfgl8GNf/52HgrP6XxHXWIhsnO4JaA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-ofH19rcLoxRe920K6VqUN6GwYqY/YCtZBskB8BAlmL6/bLXHEg//dV/rQSYcuqmF7rcFJdZZfaId8N7GJA797g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/kk.xpi",
           "version": "101.0.1"
         },
         "km": {
           "hash": "sha512-igGpXJBKmFUKx123B5fZU4beDbf8Bm/34GQxHZke+uFXgeymYsV7v2LCA7CrowaBModBpkerXiTglmeglUrE1g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-ATWThQo5l10BYPxVzvFkrELnt3wI7H6au1uz3XjBVsxKoSq2l3okSG6mkSymWSW+m3uZ+UX86I0rtTrittApJw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/km.xpi",
           "version": "101.0.1"
         },
         "kn": {
           "hash": "sha512-V3cPtJmHOxQFB5MMUB+t03QWcI7amT9fUpW1ngVglmDAFabW+o0DmCg2c2uBNhKXCKZ7izcQh+4vSOK7xECoDA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-DyXGXauRt79fDF/87PjdrzYDxMoYurYhb9rb36TOyp+h7cEP6Z7I+S3YS9WG7hPKPASv8o2GSclSxjErQWSk1Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/kn.xpi",
           "version": "101.0.1"
         },
         "ko": {
           "hash": "sha512-Wqj/VFIrarUcdXazTCRavftZ5zhOvEKWy5zNTL0jV8IbxkQoQiYuSjXTyMerwUK0dAzPKOhbEUYSW6jNUqRRBg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-bTymTJjH874hO3CCWgJNqvgIM56bBA5RAK01TDD0j5eG34wdXXHXLcSsoggOXwabc4C97TsFIKqPqYSOGx2+/w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ko.xpi",
           "version": "101.0.1"
         },
         "lij": {
           "hash": "sha512-HwOUk3su90qK0xlPFiGcc8LBHcgRqxwRexl7+/yW0lXwA3/H/WHLqQzev3tL60P/lqNbQQNNs4KxSOmW4F/XdQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-jiuGIvB0xdIJinRTl5bhjOKMlDg2671GLQgH5QpiLALzza6YmpiGo1DhgfDPGjOe2JoqFVBbqvy/Uf2IaQQcJA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/lij.xpi",
           "version": "101.0.1"
         },
         "lt": {
           "hash": "sha512-vO6lS0XrgDnYJrKOSMusIWLlhAUMRSIeW/RofcMpyeAo/3Oc9CGNl8yspe+fqJqsd/+6JlETGpyTKOlOPnPITQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-BN43TdCRaIif2k9FkL4GocbxIMsgNsW0qbZLwhLrtM5q3ZWHFBl5PxvTAB/f8Q9K2qkS/i7dMal7SHTrB7nfNg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/lt.xpi",
           "version": "101.0.1"
         },
         "lv": {
           "hash": "sha512-DrFKrvALJcmPBsWhvnhvg6+bHZ0CfKZV5SR0R3OsS7Qkp3ljxdk4hccM5nGazHCzitk0UISyZMoJkugjuxXV5A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-WnTNGupmlqxyOl/iTuwJ+zSbXMG4qVfauDslNErdRLkP4cyoMSOjdDNi58PuYAdrDMXpFMxC7EAh4B0d1eAVlg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/lv.xpi",
           "version": "101.0.1"
         },
         "mk": {
           "hash": "sha512-pXLcZ3qcgiovdaitgeOzDkW3wBi6wzjtjwTf2BAhzudLRIb/P+4DD4ic4gLHPnPXW4NI/1W9pLuC3bf43PB+wQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-uWwanYVMQmj8QDggCPzk8mEKnlCof5NKJkLtE4x8bGnBLeXuYnrEFa6H+G6MHjQLoYJv2V+sdlkMk7R4qUNTpw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/mk.xpi",
           "version": "101.0.1"
         },
         "mr": {
           "hash": "sha512-KVMjhoO3SlaCqwCp0VEL5IjcwfmiPxbjOq5drj3zS2OxGPWmsjkb8I1E9lSRftgNGdQImDvGCGJSvWaBl8z4Xg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-jjdnqlxADO5Yv/s6iD7bZITDVa4Q28IS+tE4nYrHQ85kgUVZKFokj+knSPIcgpuQ31cwnAKnw5MuU53vIj3x7A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/mr.xpi",
           "version": "101.0.1"
         },
         "ms": {
           "hash": "sha512-VAhpep1ULFWd5gmd6n9Yhg8ylB3s6W0EztspPwWQVhew0aOt9+qodaUwN9mUujxZTgIIlQAA8OGsBbf6JW/Q3g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-hcsqnvAQ9s3W1UOfrNi/5jXXy5W3AoVx5srr7jpG/5eKmbeuY93ahg0Ukcwysyx9VnwIj1PBzLUvhaPFWYdctg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ms.xpi",
           "version": "101.0.1"
         },
         "my": {
           "hash": "sha512-tmH7HD7zJU6jsz6M1ExmiF7JSuMvqtx0Iw5tk6y+E84nywgG8l8tXy+YumoFocXhhUmf76kOJUELL/lK4m7+Sw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-O4nPCKJw+tWu9Y53EZKSOCFYjn4N1JGhjRTYdb7AVnnrqRPevMni49ldMmSNAwNlDDX+V0PgwGO76qXSdl9ghg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/my.xpi",
           "version": "101.0.1"
         },
         "nb-NO": {
           "hash": "sha512-6G0e0x7sbIph2av+OZcadMXYI+r6iFYDKVmzfRkGOa3x1wrG2M3ogPRk+7hFIgK/cOknN6MGG6UO3M7FtffzPw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-A7oMh3hF2bwbxbiIHPCjLpV0h+cNV9wRTiQ45uTh+wVsr6ByrKZkmTWHbNhUv7/IQgpK8MiwYVeeEV8VGpq4mQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/nb-NO.xpi",
           "version": "101.0.1"
         },
         "ne-NP": {
           "hash": "sha512-MHXzX9vZYeHCmsj3qfF71qUKsXfMUE11VP3yg0R485cs5sa/F8a7AZhBd4bAc0M0I4AqeDY2qbhYwsG2lJsdlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-gOhFON3n4fL3MehzTrcaieU5FsAP/iCXY8QVX7sfARYFkfCpMWsMuDLuDErb6bLQoqXenxGFy35dC68fUrtC2Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ne-NP.xpi",
           "version": "101.0.1"
         },
         "nl": {
           "hash": "sha512-QbNfW5WHCsMzRoaxn4L0lYKhpZksPtEu9CHT+7k+WPq44dQzss/JguWCOlxY060+le2CB7ngPZ40MLN1isBknw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-EUTldLoRzedV+wbIYfDyG+2hEvSpHLpCewPvtsePxZRFLiMq9GzxYreB6VUyU8HTD6eCT0sXOFIgYuLdkfgVUw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/nl.xpi",
           "version": "101.0.1"
         },
         "nn-NO": {
           "hash": "sha512-eXF4NToXtLW6Db/BF+08KjjT0JPzBhISUWO4kOZupupNjIdA1iewWdKXAcJ6Xmcw5EA4RLCt1C6UZICf8N7yFA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-rBi1bgojVRvgB9+A+n4FqLUfEUVPAIxxSJ7cSy3rV2cPWKaEz+BRaM2UJ3KLhYqWU8j0elfnhaHMU1SUyoxyqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/nn-NO.xpi",
           "version": "101.0.1"
         },
         "oc": {
           "hash": "sha512-cnAmDFON7naaXYzqz2ka5gIZWtjx3RfokNv1hVlnE+kBhQa7M1yeh+AlHe72fmQ6TjCvU7ojbERtW70W6or5dQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-8m0v6+5OdMHrgrPTxAseB7rY7egCjV6CHrBvIFccFdPwgDXat9Btz+iPVAOWupwexhVMocI1KpvuE1oiGjm3LQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/oc.xpi",
           "version": "101.0.1"
         },
         "pa-IN": {
           "hash": "sha512-r/M9Y0lvKPhDXOQQ68oY3+z6+noyHYP6g6UagLA7BTXewYeMM0XojzF5HzxogX6IPQbWRqgkKXLnf6Y0KCbvQg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-kKFNfpyTBz1lE0b0grrsSxffiVLX0T3sfucO6JIKrYngjv+BrXxXXyNnQvcGuNt3gqvdcd3zRkZfJGt4hpPqog=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pa-IN.xpi",
           "version": "101.0.1"
         },
         "pl": {
           "hash": "sha512-I5uwSkHYs4a5ykq4nTBntFJowtgAECLnCjdVMroLbRNmvBGCUW6Wk22bK2dKXaq+o10ZyZFeMyOGDPpzyC8S4Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-Uh2uUzU8mx1o8TyOigG2rv3QTonFhpDBhJM1Tnr2794WSDpUGrFITIVAbf5BRwQHazaUcYj+8GyWOyXR+cB2Vw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pl.xpi",
           "version": "101.0.1"
         },
         "pt-BR": {
           "hash": "sha512-j1PM5YSW9eHdvP63OEmembHrg98DnNFk+V2oShBXtfZR8JgXpqDHfLxdxiJRLFkWqwxVk8wvNO6htqFUFVibEg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-TERwPKKbSdej4vyG5RMsbH4cz0mKTauNcAB1ehhP7/D4PYwuy4FVjS/REzW1+gMd0wznB6ZvYfArhy/WLEos8g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pt-BR.xpi",
           "version": "101.0.1"
         },
         "pt-PT": {
           "hash": "sha512-NATYnIZi/MtC5hF5foX9wb8fY82s2JdDEvAoVI8c5+VPnOck3Zrnt/Na/5XTFT4iTP/khark2HD49vl/wQFHCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-zmL98l5ehBz4v4AIvRmEBZt2H2cwbtFGXBWpHwL+e9t32fQmxAvh2qqbkTzH7ouZN+v4+LKSD1p6zdLSQtCHeA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/pt-PT.xpi",
           "version": "101.0.1"
         },
         "rm": {
           "hash": "sha512-TyOXb6kQBOjPeCiGdTWrq2lRpZYOoU2yGmKS6zbS3vNhCPuvohcm6ZdxXM+W3n0qf1nnpjVcGdipEr3giEANcw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-ZwdxUq71TAwGSlgUVABSm6Sgsz+J6w8Nx5ygdQvSUrbt4hYO+0vOxVAl7lJsoJvy2KkMUH4pKwVh+h5P77A4Hw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/rm.xpi",
           "version": "101.0.1"
         },
         "ro": {
           "hash": "sha512-Aeth9hddONx2CEkHoPgJVtET7ugrptdhFtdfhQ51Saybq/E+uLRA1uBpGy8JHzPdizC7FkguvglHL451UDRFag==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-JyvMpDe4ZtOcmM7gxaA26FlkbbfJyXDagRhpcn04Cf208LKnZQF1zY71mAA1Dl+0gxGpsyaqeWQaX8adnKbZLQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ro.xpi",
           "version": "101.0.1"
         },
         "ru": {
           "hash": "sha512-E8qjUEc6T/CI/h8RgCfgz3gZb1v2IZvKSkNyTdYV6CNcE8FOIXBy1HzodCsrrkbI49mp+a2tgNik9yKJWHA7oQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-wDCWDcy9E2Ddtwv71VRuhj/8vLrHpqphSHs9nwwk+Q85n18cEfl46KwGEhRWYcGPd4k7GuC1cfUTAC6ADpaQZQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ru.xpi",
           "version": "101.0.1"
         },
         "sco": {
           "hash": "sha512-GLPDmnQ3Nt7jq/dgpFzqNc3lXUW20p5CX0uqVWg2+93MZTa2xZOHzacOg7cd8Q3cVGTTKNV7cu8M7Um9DXMJ0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-LBbv0tqaK+reaOJszi0la1+cDu9Qa14ZgEjinIqQeyuMnl7pu3LMglxD/LO0/fZ4B/CzAj9rkANMQfmlGIr9xA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sco.xpi",
           "version": "101.0.1"
         },
         "si": {
           "hash": "sha512-rxTECYGRUoc5ykXU35+RGBBvIg3Lfa8Qdc5O98sFMNQKy8JWmtqeSK8Z6vttWa4J0P5XvntOcewBThVHolDPNw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-SQSDGnjxCrpSRndYNyWtU8RONe+Foph/UafULWuVv/M5J/aGa7lYEkCFkIwflGJ/4c08pM53k8VQp1oGFy9+WQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/si.xpi",
           "version": "101.0.1"
         },
         "sk": {
           "hash": "sha512-t9ej9Nyqy/ADipyK8afOAlVkjGojAnlZKesgR4ORZy1/XalFO3wbHcJ5ENzz7UM7PaxqyDc6gs82o3c5C8Wj0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-tuokD/qEj6RQQiWyLOdVIAuvaICHGUVwkg+wnoFZk0Pw/3vdsMbGUarzqM3plY9wG9Du0F824AVbUtF0f8sIUg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sk.xpi",
           "version": "101.0.1"
         },
         "sl": {
           "hash": "sha512-EHR5AM0+3ZYVrq60sKVKUVgiYoXQLQhU0BuU0Xa7R2zQVN9RHIskS1U6ayhBZwBkk+ORkfjbXZcssS7z2RKXRg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-OzyToDsm9+yzP651Eg46QTdBWMM927ROd9y8MGOSX3xeIZfwLPxxypukWQ01rxK2IIlGHFjbmb/KPRbk7etwAg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sl.xpi",
           "version": "101.0.1"
         },
         "son": {
           "hash": "sha512-WphxvXDS6p17dKWnixJsUDQz7HL6+typkHaQFaf5G/cdJ2tRCKPGldE+VHJSgFU7NfuCWiCL1Tm4YkKNaAvnNA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-VX8qqVdZhZ5Fw+vYJ/L0GJHlbeu+DofDTu2bJJdGRRD0Tss1mjG/IpkAs1Ul+6UTYKyuX3jJHXk4YxmGwfo3xg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/son.xpi",
           "version": "101.0.1"
         },
         "sq": {
           "hash": "sha512-jFJncZ3H9U+bKzLTMvso80GaWrlc3W4sOrpkaKzENh7MLPnNb9sxPPjfrv/6qfDlBIcH8Q00zMSKBAJrX53cTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-0iMX11wQfiaYCDCTPwRDJLY8c2WxVdmpu6oVnOiNl6yBB787irHdhnz+vL7uIC9GpR3ZEMVHhQKxJfaO6O9kTw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sq.xpi",
           "version": "101.0.1"
         },
         "sr": {
           "hash": "sha512-MCUglPxmDN+Or6ZUqR6DtWXVbibyRDz6b80UdZA1CC+mzYct7ciZ2iB88ixVi0bGka/euuAy97rPK8BcGHJL1g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-8jbkLjvO2gJFPikTTgKa3j94ePKAsWmr9n8snIp2KRQSlIyCKQfLGKHqerzaOH0SvM5JqXJRv6cXMW2MUXCu6w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sr.xpi",
           "version": "101.0.1"
         },
         "sv-SE": {
           "hash": "sha512-yRDVE+7mloFFgO/LcTFU0eyKmYxK3EJpdpBCU3UIF3bOT28/56w2lnAT/cU/6mxHGQygDR4J1A/t0YhIE2FoGQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-aXOVmuMDtuXSd7ad4BryR4j5O6+i2ACbupYAyft4Bz6SKpdiJkbMIkvLDz7We7lTXgasnyyoCQKHEVDmc3ZUsQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/sv-SE.xpi",
           "version": "101.0.1"
         },
         "szl": {
           "hash": "sha512-r+Ff43PDJSZDVf6NOvIWgfyUf6OMoyUHM3p+BzgA/Qx/e2wl5JN+zOxjCyY1U8fOfD4tfxr596WNuVJdxz98GQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-khV1IBss2+KTetvnXVcGkKPUY19MsNLtZGWdmIPz+QSfQykQ3KwTix1Kg1SPYuYluG7wEJs0p+kCSau+fW+GUA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/szl.xpi",
           "version": "101.0.1"
         },
         "ta": {
           "hash": "sha512-Y1r9or/uPpTkXbH/HtwxdvWIqmBalLagoIjtdHPJop+40jJV/yb9M5gaBizNuvnxQaZEFZ/smWPlVNM6OXBehg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-Uh4wRT5kTypUK4tQshpQhzQE0VrBVem9rk3bKIVI3oqIyKgscUdjKUn23SD+JhewDeIu+IehnoYUEoFKMKL32A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ta.xpi",
           "version": "101.0.1"
         },
         "te": {
           "hash": "sha512-yk85fYeek/5yr4w2llVxxougBrKH9zq/HcEWTOEPrOx8noPv5+XXx7sxjVgMA6COt3sfg9LnF4vKhOxJdaPUcQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-d1zFGJh6rcCtQx/mf/D3vR6RtYSFIId8UDIH83KtE/opNd5Ei27DdNFapF4hv/l/AjKnkLLAo23jaR9zAMfLmA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/te.xpi",
           "version": "101.0.1"
         },
         "th": {
           "hash": "sha512-nhhCqnxVFskVc0Brz8VFrdt/DfSyFzgwoIC9S3xIjCsFVHmY3t/7kTn09481uiGRq2DhJwJ60LXG/Hgcsf/Xtw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-0w7F3Hqh0dumb7NMzxqPvbmHzlA1wcp1F1WwSRUWP9Qz0XGUftvAqTKW9tMNYYSBhLXn6zWaGJvV4qp3lgGWHw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/th.xpi",
           "version": "101.0.1"
         },
         "tl": {
           "hash": "sha512-PnwGbMv9mj+VTQk0AwHwbvJhoVqO5F7XReh3OAPLhABgcKc2lnjxVxlG8z806Loxq15XdSnDQ4mpIzHG67RewA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-/UdberFGHsJGcG/YYdoDBN4U9eRMHSq/dfhDrThmb7EumSZdeZfN0kiOeR89NiOzhcBv9JBNbgkiwMVnQ932bQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/tl.xpi",
           "version": "101.0.1"
         },
         "tr": {
           "hash": "sha512-3mCjYYNek8qXssANZdrWlFRsVSsdvkGfdo7+xtOgGSMz0BMINJN2SovdtdzgfCKJIFw7rQEUYUT5UhZbgPaHwg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-w9XrdQXhXbs9tdpCK6CvQ7YYh1CXgqUIrh9SYp1p9IvcxuO4gg69uIgkbE8cPh3wF3lKtE2GCLJTPobyY//j2Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/tr.xpi",
           "version": "101.0.1"
         },
         "trs": {
           "hash": "sha512-DoAf4bPi+bm6U7KfUFiDbH6jbTpeQ1z4K/cLEYWwKkTfCRDNZnTUbRmeUiiceo+J2u4UMg54oVg8ASQ5bJ/ZYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-qtsgAkiSNMGzQlzOW9sg1Q1VitWGjvFWKUl9J3vdG9Tnie6U8hrucVIHjm4Pwe828+0H9XWAMNkZyrARPt+jZg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/trs.xpi",
           "version": "101.0.1"
         },
         "uk": {
           "hash": "sha512-R0kAC159cqHMNFped+XBkdSuuSg+mZ1VIIHSC5Nqt3dtRAnMdzJ1rXSYCoiKv1X5GrCcLoIwkM5m+ZQVzvYSQA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-qlBwCB06wwlBAvdaifMwiX4b/uPBDWBJ/EZXlZjJJG2CR2sLP32poMHzCdZI64Qm34/kFQo91vhfCclVnCkPpA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/uk.xpi",
           "version": "101.0.1"
         },
         "ur": {
           "hash": "sha512-I5uPe1nmaAmdl+RrDzS8lKBqcP/cjocgjRc5mwxJEs9jYR84UxprMI2IVB6kBg4WIiXIAf/mD0PDliVOpvr+Rw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-AAOPCuRVz2TWc9FrdTqBTj52ThnnOOoe3RbtHjUrzrJAqE3omK77I0OITbUdptxjHlm24an34treJdVYWkHgQA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/ur.xpi",
           "version": "101.0.1"
         },
         "uz": {
           "hash": "sha512-dHifXoqydpmxM9D0IZsPAXqrih6ZRFP31iLnL5sNT+N1Q5+s7kL14pqMqHQyQTpyIGbmjrSgwaB/e2xBcmrJuQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-R7VajBI8LXlx2Wr0NMsJ1L2T4/qzeyAb8nteKyf05DlkW31W2XUPNr7OZfE+YlG0QQNfylL5onNe7s3r77uTXg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/uz.xpi",
           "version": "101.0.1"
         },
         "vi": {
           "hash": "sha512-QpkYQfOKCyUvCa5EWSgw0KI2T+6nxAGFbwRb7QUKh012SC0vZmj53niFCJmuT8gskjzZFs9u/tpLQca6po/uTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-PtqyKZSJcEN/f/21Kmy3bk/+YzHSp0GNrz3poEkCOycLmso/+buC7DS+SRJ67a/0QnOcb6Gfo77c9lg0zHc0Sg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/vi.xpi",
           "version": "101.0.1"
         },
         "xh": {
           "hash": "sha512-LN0NypBHOFRBqCCKhGCbF3KAYeS2mOwgZtHNL1RmJAnuRhu0RLPYveYwNIZ8++9EjgT4X0UgS60CLfWOibj3Tw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-6D9esd9zB1Ui2newZtgrsoTj9DtgZAqdN6lWKH2jJgueT2EeLVTcRFbTjK/UsbJQ8tfkPGk9uodwQ4bJlme9qw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/xh.xpi",
           "version": "101.0.1"
         },
         "zh-CN": {
           "hash": "sha512-hIRirhjaYteaphY9yw5TrbSsD+AxqA3R86C5QxAgYFSGgviSGwJDHfVS/YF7vSRrrFZj4JF2LrHsBAMI80/mOQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-4+H1F4r3VhsKcNUheNA2cwRTnIJZ2QKcTHGo7nTJmz7j/BH+Jsw9Ao1ZTTJsfWBG1kGz2egE9ozokQdd9BNo+g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/zh-CN.xpi",
           "version": "101.0.1"
         },
         "zh-TW": {
           "hash": "sha512-IvqHJgQhiVgT9bMmnooyDSS0R3utXGEI0LaPgK/qrqLZDTZ8Q2pJ1kNSOgC/+99MVwx9VUTT5vGXehxbBHOztQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-+0CKDh73EGxR7IyHdLK9lE5MkLXCiQqFOgAixXZuIheLAXb3V3jbP89zgDq+kwmzoMJWokBBgH81q6mn1OCLXA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/101.0.1/linux-x86_64/xpi/zh-TW.xpi",
           "version": "101.0.1"
         }
@@ -990,491 +1578,785 @@
       "linux-i686": {
         "ach": {
           "hash": "sha512-1wMz8tb1N/WgAYehZqA+OhJ+hrJ2G7nA3PUyW0OneKw0z1lqqkcjysQaDoRXFJsgCDo6smLB9uRkWJPZMiUEDA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-bLM0YxABJTojY04jB7FNO19L9hTcBURGsQtrI5lb2TbBR/jDJeyjcEZFwpXR/nb76Em3IZvmrCkV426PyU5pLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ach.xpi",
           "version": "102.0.1"
         },
         "af": {
           "hash": "sha512-PWkQuA9PtwoZklTqd1UIrwj9PJgSYgR6gS94KkQQinmRUP2tN6faBbHHoj9eJ/+GgSST8DzqplGPr55ivo9Zlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-hkQ3njxsnF4hyJcfwDqT9hMEyp/8XlWqmQU57DYKMI0CU84smpT1/Po5u2Iy+cZTAA9UdSoQWY22F14/+GfTdg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/af.xpi",
           "version": "102.0.1"
         },
         "an": {
           "hash": "sha512-8yEe21AGF2gV/pLirSVepmpdWOJgDARMSKHEtJdlTol+qGk+feWA3nMZAvjtXVLpakH6OkFprDasuKm2BL0UQg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-8w0EGHS4LvVeXB3namBtTcqlqCYQoquGu6DQ4sLFu9lETVqVWXEsznjSA2L69E7H9aDgh5EjYYWCb+osVDYh4g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/an.xpi",
           "version": "102.0.1"
         },
         "ar": {
           "hash": "sha512-XooVTJMZGJgcAWFEPgr89XzY8rNKU8/E2feD2optztbIJ1UEMqhvMsnNWq/sl6tedDp6+0AdpPkzwjT+j19DYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-fxf01Gex6GANtb5B0+3+zx2Lk6Kh+QEmE+NKsRVw5xSTPVMJpgE1Q5/INXCBhfY+Fjv9G5zAd30o73GpBM2mUg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ar.xpi",
           "version": "102.0.1"
         },
         "ast": {
           "hash": "sha512-PgoABB/375ZoLP9bd2cGWNUHIyu3iMgiGbgzoBRSx5s/W8bwirj6sA/x9JRgF08NUA7bMv7rrf9pac2A9/F76A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-caR/9AVwQKgYlfeZ/LXqJ/oTQolGE9tkZNfzL3bH4/UX8CrscMVE8NplyzHD7UG35zezxGvsr+q5fIH8JebvoQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ast.xpi",
           "version": "102.0.1"
         },
         "az": {
           "hash": "sha512-QO7per+zRx1iyijEJG8PlXteCMOYQGj3GazFBIwgO5nHZPMKaLsUs+f5gMg4ilxZ8NpCxO7L6lHuXI51+Dr1rg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-LyzAcOV6bx+Cp/0bQJVAUh0JhUCfqFzujO2OV0lct9K8uSqT6aJuy0xBoaHB8kgQEBhEMMVmuQXYTVf2bpsttQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/az.xpi",
           "version": "102.0.1"
         },
         "be": {
           "hash": "sha512-FSmlnQoSbe+pL0RDAZid5hLLxVd25P1jkxXj1wV2fYHuD+saV2ntnaTIHxLLo0CwbjgUiFeaW8uUqh9y9YNFuw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-2ueVAjZW8yugk1/T8iK+KSPjYSU4aXiTlJjC/ygwTuz+9gn9JHkRbIqD4u213pBYExagtErT3G3Pyt0snhG4ew=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/be.xpi",
           "version": "102.0.1"
         },
         "bg": {
           "hash": "sha512-3AoQlIeQZ63sTUuHVrr8hTN1kWF10oFB7c7P6sVrgirFphMneL6QL8IxVXlzY3ADSM3OD672RQP/D8Rt9In/cg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-3V6qdBxN39oz7i/blMu+eWHfXG8wJ+PIa2bX+UTDP+nXWy7UNbj1hgDRLo7v5mIF5+DI6HRtexATzkhqg7X17g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/bg.xpi",
           "version": "102.0.1"
         },
         "bn": {
           "hash": "sha512-4p9uBEaCLrHk1IJs6IkF41eU/f01/JhaZWqOCiC9zNCADuNtzarHLzdhplrK3Ow+dsW0ncLP+4wCgcCTdJkqPg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-xX79Wn03SZ9YzcN5j11dkCnpaPiPVQuxKDyhxfvJzHIJq6AJ2InhcpnQ7RZAiSEV6CRBWGuC26hPXlXegkfBeA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/bn.xpi",
           "version": "102.0.1"
         },
         "br": {
           "hash": "sha512-Oo/N7O7vsAYCY021+t05cK4pvsPeElYQ1y9MvAMiFB3dUZhyzY3zob3f4W8LQKgPuiMvx7m9vdBldEYk4EoReA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-mXh2LiSBs1wcNSx2dEXj/OB7zW61hNORM+KGr7Y3keJufnDxqq//o4HIsTc0hgPYXpZQWMKni4EHoXkPOSSFqw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/br.xpi",
           "version": "102.0.1"
         },
         "bs": {
           "hash": "sha512-tkgXYF3ztMTRp85hTLN72zjRw9cOpZvHJubV/ailTAkwjjgSxmLAAwbYc+aMNjDZyirQik9j7Qd/rVBCvcCBaQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-jzJl9ZuwJrqFoEwXV2OTT+o8QLt5DfKi1EHmn+01eTmqwboie+KC3Zh+GK1HLjBsOx6S5kZn39iNo5lzmW/jrA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/bs.xpi",
           "version": "102.0.1"
         },
         "ca": {
           "hash": "sha512-096VAUzmi9uULul8FOKFkOtAr/C80SbuD9+E5aJESY8cRzSZXgn+2avfJFRDXtWbIxQpeHsXfE6CDu8fhCjneA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-hnZjjyc0sam38vvRZTtlRSuz5OqvvrlALJSjPd5HL/JrqOpHRqgBr9OEgie1nd0/ZZRuuy/Ik2Bv8ppg0RaEtg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ca.xpi",
           "version": "102.0.1"
         },
         "ca-valencia": {
           "hash": "sha512-t8pre2OUGvNviVlR9ZUnVU3zvZJYxv3oWzdsNlffzVSgG8GHsrQACYJOM/I0WiZgVq5QkiOMMPie3lXx11zhAw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-NRcybXtB2C0RGYkZASQ75Lqj16FRkKmYj5L5AHIX1B4YkW+uquP+OZSWx6fLjzExdRL7MjeR8mOnV0J0mnyFJw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ca-valencia.xpi",
           "version": "102.0.1"
         },
         "cak": {
           "hash": "sha512-603PnXxiv8C6FmVKqHAYzmbq0fcsuvEBM2XOJI1082T2gJNbuBTvlZ2IzQ+NMEdDaR+5H1nEF4Zo9JmIPPmRUQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-E17HuIF8K2pDQJqkccHd3Pc1wBdz7wmctbiLycRKrNDfDMPS0I8wbBr+GiKJzufjCESWwJ9WSQeoCvj1ij1cJA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/cak.xpi",
           "version": "102.0.1"
         },
         "cs": {
           "hash": "sha512-KqWTKRjQE+qoXFyFULMFvSbpQQkYJC39DQvemoU2YcBPv1gBhR6vU1qrNVFEozv+X+DOZQ0cIJ2ao9hh506Kvg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-K99lCYmLSmWHL4E+1awTyyWaHcium6w+TD22taJJCMqEAyhyqVYaEQ/qGL9ZahjAvCOmEZCnzzTBHGmGzxDhcg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/cs.xpi",
           "version": "102.0.1"
         },
         "cy": {
           "hash": "sha512-XtcBH1L0Vy5uHJEn1ix970RuQXaLPwytGoDv7NuNr63aVEQKezOz0h5goEJrXHhBSjwE4RuQ8EJkvoaTAFwTbA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-453ACWRDfmhYZ1v0zCoQZ7Wqaq1wSipmp3QsCu5mR+sEmPlgDuLuNdhzNKxaJttED8itzXmRbqQQ9Xrzwd6wnQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/cy.xpi",
           "version": "102.0.1"
         },
         "da": {
           "hash": "sha512-hLuYkETlxNe7SFkK7wNs5f5unqNq/2/E9f4gxee1XZTsVA/iHK7UdMNqFyxgimVghDt2mg3Ns3p9fd1O4muBig==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-VdmWDGSj+aTWNVx0Fbu7eyTfpiR6OATuOx1T/8zwObsBoPM/Zg7Qhf8jQm16+Hq0es4xl3Cy+zqNWlQ5rIJ7Aw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/da.xpi",
           "version": "102.0.1"
         },
         "de": {
           "hash": "sha512-yanOY99XoXDO6JSfja2EzstkSZ8D5dDPZCXody1R0OK965h8sXz7sTYyPNkb+CEmIC9PAZFa9WUMuYZkAhUpfg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-aHrPMsqQSpZM5L+6lsJNTbK+qGIYaLJyOEB9v4JhhYx4/qmRCcL9fJ9g3gqRrpnOqvw0LLEjW1egDPeDTmVPSQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/de.xpi",
           "version": "102.0.1"
         },
         "dsb": {
           "hash": "sha512-SwpPgJb1eAq1bdnqpNKi9yRtAqkERkiHgoDJplWNLxanRzEDOvkLdGFyJsek+gpDe9DvI+gT8N+c69TZYovtHQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-te63e+CtRwRXptHgnSIGP2KNgjRW3eMYb1WQFARg41PPuDIaDJmpscrnXtYa99tQINjXDFTbjawHeP0GpRdmVg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/dsb.xpi",
           "version": "102.0.1"
         },
         "el": {
           "hash": "sha512-D7o0jhlUnGSwf2EeHa9fNSyJU7u7oCMM6eVkZjN9pEs5JptNJ1/lSL4Ienkbd/NYWQpTtFpNJyLD2IrqG8bCNg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-LfXde++z1edJ8nTOJrZMxtnFwIzMNu6X2R3fTctUQAVZprEAc7OHWZKT5L6W+oYLzBlCiHU5KrFOVt8shEBezg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/el.xpi",
           "version": "102.0.1"
         },
         "en-CA": {
           "hash": "sha512-Z9L+rAKxkC9Sexs5AlCVZ3jFH5hbJpBQ+TAY0riF0D9NwBg/ymxG9HeBZKNYcS7/VxLUMTuk2kZu/r4sB7KcpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-Qi62e/Su5JIDzcyNLxevKOsscoDonIw7ok8+Af8ZokUoyNrQ8MdW9muWr1CS1pE0fbwfqLXne0tnD6T/oW3iog=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/en-CA.xpi",
           "version": "102.0.1"
         },
         "en-GB": {
           "hash": "sha512-a/kWCuGWzpbqLDiMKcYUMFAYVR7jglQwRsiRoHFFGJnoFk3tGbl2bODoYc0LVY85bDn8vxPKuBtJkXPt59yWqA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-qkm8lzsYKHWDJ8R70Se+bdIpmczQG51UA3AG8qkq+Rc94r3NHIAN8oI4bdfXdi2CnMF1iZhPAagBu6qad4LMzw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/en-GB.xpi",
           "version": "102.0.1"
         },
         "en-US": {
           "hash": "sha512-569lWsRSKDA/DrSMEppQeHU+L5XEJXMonJ2qNvyr4cHYxzPGryk/R8i4h8U0QX4P/rIAl6DAf1XSVbGMxbvq5g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-+JI7umHeTnmtTOA6jmkQq5uWJZN3VTd6LlN1x4n2jGsdkxjJRkBm3/DULbw31WEGWEUDrcTk62l2q57+GfGJPg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/en-US.xpi",
           "version": "102.0.1"
         },
         "eo": {
           "hash": "sha512-9mAejQrFnMkt9P1gFbIMox8NycwW2GiW1lXcyutB79eijGm+HmXwCnF+6Ccd+MyB3t4x0ExITpun/pC0HmwrZQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-iEXilZUbQ2bbGcT5BAk3WIxZw9fJOp8ZbbKN3T61d7OHJkFDP8Rzu61TWYlKpVBm9UXxqTNPvlvjH+rm/O8Q5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/eo.xpi",
           "version": "102.0.1"
         },
         "es-AR": {
           "hash": "sha512-njwtU8wiF8mH0CKfuRx1VNu/WdS/Jb1nl3P1RXYjib8gBudL5OtFTDaktfdisrk60lFUfKBPLbt3L85VtXXSUg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-PW+JWrGG8myODZ1H++9nYMredVmdoq/rTQDIgaNUHHM7cG/vs2FYJ5SOoVwVXSVZ6IA8rq7ZAKP9TIEWXgcL6g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-AR.xpi",
           "version": "102.0.1"
         },
         "es-CL": {
           "hash": "sha512-d8NAwXuOggHr8N39T6Y9D4gDR5PQ3WWPTBZUv3fyuubNcozflnnqXeamcjDJ+POLKqv2mJinrbBvF6hyjzy30Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-lGTUFjPvQChsPplYWFF7mseF92r/q+eOcNL3yF3Y/B+2NdP9aK0BLneIAsEkx38lshg5MQNfqc0IVDG+f8GpYA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-CL.xpi",
           "version": "102.0.1"
         },
         "es-ES": {
           "hash": "sha512-XtBcm4Ur1bDU/nH1esbJ7jOmRYI+yiBqt4t/5BldNY/aCoNn/9qnGVYOKdJGKQ8+qACAx3v3Ldj44veRD+mqeg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-rTCEzwr2R3ajgHHPb6z/hdrIH+H/kFyixrex7Q/VFYyUo2mGaPAt+avxe68aU5+7A8qvAYptNpBVIWXU+Ab1/w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-ES.xpi",
           "version": "102.0.1"
         },
         "es-MX": {
           "hash": "sha512-pp22eKGufcryJMbptb7dSIhEVc8QvidpJoBxTr7diP6wOoy6JImdCmxS2n1DjskczViBhr3KsLUfv7xgaafTig==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-tItRzCda9FINi3iTt+ED+eKDGuBg4n8aQ1k+7/NUDeuChv9r195nEmGt4Ncmv4upk12/Vgr1qmRT5SPtgAHHYg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/es-MX.xpi",
           "version": "102.0.1"
         },
         "et": {
           "hash": "sha512-mEJr+trFgdOJ6gSwKpDHFUQFHbPxD7hu7HCYK9yUmsbqJRHVdYvMtZjSi2F2+mOhFhuvQORahp/v8w4/mcaybA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-iDASyqbsXuaTPpRLLK5LA/GvJbxCSO3muCpuw6NaP1ztGnb0FDtXRpR04Pnzd3tzg8X8HLZAtxjdl5yHTCJtYQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/et.xpi",
           "version": "102.0.1"
         },
         "eu": {
           "hash": "sha512-oXTAeYLRMp4lVpP/4g9aUAi8iv0s+Tt6E0RPW/iJXWPbtXClp56WiPvfT61puT8+Yo/ZpULdfseaAoWmNuqtWQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-HFPQ/VC5EZitLmquBIKxTsTF11SHWDVGg6Qk6B5jInB0kvYcAmkAabmYAAUU1lEwkswW18A0PJ/FPSftpqrNVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/eu.xpi",
           "version": "102.0.1"
         },
         "fa": {
           "hash": "sha512-t+gOJWuMZIBsMtvAy+Bnrprgqq1OCPNtphygicDUAl6ZvPWQMJZgweNuD6/R1y66R9hUHHZ71lxWl2fVWvjFvg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-7XvbEFedzHRwBGPgEJKOgOkP6H9g+hZ73Ul/9Ydumz1KBiv+82wClZDMbW0m/YF0nk15M6hmyRsF56VoygpQnQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fa.xpi",
           "version": "102.0.1"
         },
         "ff": {
           "hash": "sha512-7tPNwtRrRJrBKPSLibM0zWvKyetqDhNA42nRtiJXruLjEJv2OaUaFubFzxV8NMCnGjEJ0Ergw3n9hivqJKDOKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-QvevGA9FcW/+rVxFg8cJL8LWZzgTNMphwf+sVM4PerGBO8bjHvwgeXwVysCC/Dw49Rm1gdevL/4e8BYiATP9yQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ff.xpi",
           "version": "102.0.1"
         },
         "fi": {
           "hash": "sha512-42QTMp57qSQglPPF2WFzViwf6nubnIPU32tdkVjmeMlFQ4O/S5c08mlWUbwuQ/19vrfwQv2b6vSz+u20QGJ1zw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-5Ii6AZb+obZdsPqZSnri4vO1vmPpoy7xFkpAvrMbUQ6MtkpG2OUynYEq6jk/gPTW9veRpmOVH9FVnSQc26OiVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fi.xpi",
           "version": "102.0.1"
         },
         "fr": {
           "hash": "sha512-wFjkGRk9AHbv8yvB1ZRB+5Q1SN2MJUB0wFJpOafNasDWQiqVQo3HravB5d7tEspCivwi/uaPPZEWJOoPeFSyEw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-Uqc/byyVmZ86OfGG9nov6e+9vH8S1ST2kCBhlFiJ94dIC2boO+k2a3RVsWZLVc88EHe8XAxINVZq8Vds0zUGig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fr.xpi",
           "version": "102.0.1"
         },
         "fy-NL": {
           "hash": "sha512-SeKPJXWV4XxuD1cEKWWbPVhI4olMfzhqqMARA0LTla/czEpB601v5u7gEr4KeC4eamsbUmm7J5zGtq2l81cQvw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-55IplfI7v6s1o0cU1S+yqFVRn6QyRW3dBPeOTFX5rNsnxt7qqAn85xJ5QDIksCF7TQS8OWHrLRtoo70dcN77tA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/fy-NL.xpi",
           "version": "102.0.1"
         },
         "ga-IE": {
           "hash": "sha512-zG3uwCNtY9hMvaHuOHKyyNMHUxcqNe5nQYBqtEa7zL/ReHMYzC2UmVHjv+1SwJCQwa7GxZk2dXThAc/ncCrrEw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-iY+pFgh16AKMKdKGOU1ZOloxCZYatsQzkTHX4qy/4D4Q3ssRpLBgaZwgrnv0CS6+mCa9jn2f8KYKIgp7sPKlHg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ga-IE.xpi",
           "version": "102.0.1"
         },
         "gd": {
           "hash": "sha512-Ovcn7EHqJzcrraAXZlJQMriwIA1lx0ed3GL/XZhOi+nKCrZebcLe7Eg7xk5JmFIlWZFDdFf+OxgbS7dmM2HuuQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-2hclmq9SxtufguvyUSYMQMA5FsFcGMS9nWkFAvMKaxGjPD+kEHLBIuzYXG4gYVxTZZl5gsp9Skr+iwkk3dwABw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gd.xpi",
           "version": "102.0.1"
         },
         "gl": {
           "hash": "sha512-eMvGfmwYTHSKNWF/qWDyvqhaTePkqwEwkTYsSfuXjrxHl5QzDB9B3bkGeOcBplh8B/jT4zzhvhRgczzRKZ7nzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-yKP9E9lpkVXSyxMPYDKqNfJtLLYOkxQvh44WdCgDsd+GtZUf4teNzIb+AVq911YM079efHTG/GncvyycaVe0Nw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gl.xpi",
           "version": "102.0.1"
         },
         "gn": {
           "hash": "sha512-/y0tshuSeDMPuLsyoUZptGygh2SmDB7vu352H/v/QnNcYHRSgQU4UxuEvEBUfcQkoTrArAktYWR5T27jNIURlg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-KARPOl7CGbAWwTjzlsuZZMQ01o5aO6PzLeEOaU5EwktH494/Nu1akr1AOm6FcrFekTLLaQ7pI2LyotTgRqJqUA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gn.xpi",
           "version": "102.0.1"
         },
         "gu-IN": {
           "hash": "sha512-ljY6m7P+aNCb8KoCQzTKDkaU77VDL4E0AjJAQF4S3xr3EHc8QMCL1+L1fuVbzUKXfl6ySpPFN95wHXqMibOcyQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-eXji7xFdYdr3lzKG08/ekO8sL+fY5oRJMQuKciJSP+AYqE38Zkz1I9hjCafJ8U0yvUAY2yzecdFe0oyJO/FJxw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/gu-IN.xpi",
           "version": "102.0.1"
         },
         "he": {
           "hash": "sha512-IaCbKjssqcSKInnLUxtWDKrECCEIjNq9ut7RsfNM98GKDAIcBCXfHmKAhjox6pdDWAbPtzhZW/X8XHB29sCLCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-lnNPxi5u2FoIPVL65DLuc2IY7CqAVkkGnFq7XPvUZ9IHNZlnQP/EgzPxRbrQqs12++JASKTxZ0XfjlifK9yC5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/he.xpi",
           "version": "102.0.1"
         },
         "hi-IN": {
           "hash": "sha512-eYGOdMqyNyZvN2OnJnJgWXlSgFNJnW1YQQ5VYhh/Gcexr/xmTohcaXwzN3jS/OPDuptXwzsgaje2/1hHpaC7yQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-Mk/qKuoOPPMomDY2YfL/b6hbjBUbHvbamNFixWzoY2AQY3DsgInK2PcJCHpDpl8g469Iavakz9I0EUnbBwdPig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hi-IN.xpi",
           "version": "102.0.1"
         },
         "hr": {
           "hash": "sha512-sLnX4ZghgtPT1QoA6IUIdtF6gJk1fQe+4mE5VXJkspNFXaw7/3W0pvk8YtmG18t31gRKir5z8Fr5tTujm/LqiA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-t3RNHRPCHj2gDYDnQ7o8tkleuogje/jMrd5NebU7bdIW8FqROh35y8VcmYmL97vlBz7drHH7EMFrFC4ge4PUSA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hr.xpi",
           "version": "102.0.1"
         },
         "hsb": {
           "hash": "sha512-Ktm3HRnpxJt+643peTXhPzSx+3R5fRSIfNBm1XzSorR/Aw5FWBTsLFXKpDNe5AvMJgnR6HyhRModQgEucpwTDQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-EFkzRD3JimahMhSw+wTyD4wl6WM72u7DAwwKDlGnI48E43/a0pddVLwGsJEqLSBoqWUNWapWJAouJZimTWUQXg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hsb.xpi",
           "version": "102.0.1"
         },
         "hu": {
           "hash": "sha512-82CpWC5p9MAUY+OgGqf0K2A6ZALaNOsFNI78PnAMGkc9H9WcSdpr9BDr9ofi4oAMegAHboPqYenI1UYGxuTfYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-uxAVWo5/JIW2JB/ydMTQ2OW0D8qiOCWFrv3Ln9PxxLEf59+oLLjMrvOL7FVH1IKU7DyszoKjPZVgbHAUTE8jLg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hu.xpi",
           "version": "102.0.1"
         },
         "hy-AM": {
           "hash": "sha512-FgxxkY7Rop5DctgW5vwugUaGO4/T1hV4zG5NBA3iTJTooNa6A69YPNGGhOwXtSWI8J49/cL6rNiqOnrE1jyHVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-hB2Qj+OjaVicWbOFO0O43sXWEvD94kT0Y/gFhyXASoQMaOfwOteUIvsBIV67RapV16Hqy6D0/eorF14INvASTA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/hy-AM.xpi",
           "version": "102.0.1"
         },
         "ia": {
           "hash": "sha512-9X4uBVia6ysLfBUu2cWUSMTyRuVISAAfHLmJ6+EV+9Kl9cx03qZ/vd878crWjvV9FjURjUi1diMEiArzn5qz8w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-MC4AlFoG+/4xy1G1pHMtE+UQgZvhNmkDXlWhQ+UCK6sWdWeNRYCDNXXT4lIQhz7WyvBKe0+igGdVdJDSVtb6aQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ia.xpi",
           "version": "102.0.1"
         },
         "id": {
           "hash": "sha512-w5Dmou3NIFhGmkT0BPgaeenGnHj37MMS9sPuh3uDQsWhG7W+/XM/ky0BLDW68BujpcPOZ7FARbLGVRq0Lirdtg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-fz7YVWCm2iuAxl8dlhP+B2Guhia0rKTNnQwnLYXk899WoQOFxrNGUlcGtpyuv/AWBWrOz+S0y1jWCXueT1xXWg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/id.xpi",
           "version": "102.0.1"
         },
         "is": {
           "hash": "sha512-/T7wUz36Zw1ukjNEgIRWYuzPaBgyyecruqP15y41qvcu2Og+HJYJWCTn6OnTv+k2Ft4trDohQ76uEbFS1GZw5A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-COZTfZ+zmOq0548C5lCr1+7wyFGbTTvaF1STUHGPFXjzbMhP3yn2U0yRinZiKv19If5k4MqTQbBYL4Op+NM7tQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/is.xpi",
           "version": "102.0.1"
         },
         "it": {
           "hash": "sha512-gHJd4ISo2+5qifYwJXUps7FxpEo8acuziiJ83OkvwLfRcC54N+5Y9cA8xRa9T4EgJznctaQjZ5i/AWeRY7MGpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-0LavIOdEuf+a9agQxWkKtzimixI+ilq2iYmfkwXF9lWfjIfW9jMPlFh22fvmoMdd+KMsnW1Rx1mPj8diVEzcOw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/it.xpi",
           "version": "102.0.1"
         },
         "ja": {
           "hash": "sha512-IDyCk+HNfwvu2oyjks365Dte56t2/PK+HN3KxNjWhssb0m6CKDAZ5a37au5K6MfetvZT91qpid/z6kklqnIi/w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-BKLTXQSgKta8/RXNBjCiy9PJfUX0PG5ZoiaSL9FAdyJb3gaMkEy3/Q5IWHLv0+JW/jNE1SpzT7uwMoDYBAcGSw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ja.xpi",
           "version": "102.0.1"
         },
         "ka": {
           "hash": "sha512-E5jhk77zZzkKK82XVTYW8GucB+P++ezhzGd8VqgrhfnUxndGzNIVIV0gblPJh5CZm98/hzNGdqKkokWD/y9uSg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-xSr/SXbm0kEZSM8XlVJZIYPAfZo6yf8ej6fECJ4U59SLCrE6QyGIUlSuDlR9imLiAQwcMtS69Cd3SZ0wh2DLgg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ka.xpi",
           "version": "102.0.1"
         },
         "kab": {
           "hash": "sha512-p9tjEQaySttcC1Rq1zOwn59vzzcddIpCQYgeHlKI9S+WzvbpHuqXrkYYAevD9tYaPgdtmaxYEGSFg2HzGNGKgw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-cI2YIzLKhmtvPWv6CN0JbwJg7btpLxtht2ilIW71mpouuDIdrLjTZizfa6vCz9nJHNnOK5tMfvPb6J2YD3D6iQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/kab.xpi",
           "version": "102.0.1"
         },
         "kk": {
           "hash": "sha512-XdNAHxMM6DqKHd13lo6XFxDDt21dftHsRT8te6DqPtBBbEKcHvrdrjMvPXVdHmd0AiQ+APpT5zcFblZOdIT7qQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-/kdNRXv/AtWqyqRT41Pka2MzRXMPAO5HDaBhbzjl2cgWW38f5v4fMaUsUEuB60Q8lIKMklTtIU8kIXV/zXX7Zw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/kk.xpi",
           "version": "102.0.1"
         },
         "km": {
           "hash": "sha512-Mn6Iq83qpKGiGI/O0ZZsxailCMLBL+Ey8OPkSvUzniTBLVIlCZW6Cxt2BIJ+Yc1WWj9VsrQfwr1WDifR7k1HVQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-Ouq95aDRl9FL9wi7djzt6QsSJg66nzVaupW7hqIbJySsNg+Y1kZxV1Xyg1ZFVcIyUsk9b23hwrABfRiqxkgPnQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/km.xpi",
           "version": "102.0.1"
         },
         "kn": {
           "hash": "sha512-v7WcUAQLx8ZCb6Zz8uQIPktNTRSr7emrVaVSkB3nWsHzlL15YTFARPjxBhw0sarXTq8qGVsR2SYVsDzS4mo2Mg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-+faE8HOK/fsSk+YVFIrFPfJIRkyYT7zwJewccqWvT5R6IDdOGJHq+9CZNVvpCOPtl20p7RWIifHyRqzwZeNtmg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/kn.xpi",
           "version": "102.0.1"
         },
         "ko": {
           "hash": "sha512-MODi9//qZYgfymyhY6eJ4j26/jmWjAeQ+NUIcYk/WqfADR5OtwlhRnuxqTB1PGQ2+OBuam+Ane4I8aoiPa/weg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-XwOr8KTdRgnQgPNIqsSHqL+faAU9g71ZhPdPiocJG4LZEWgAb1f3K3AN0LzKSECFfSJLpX8nIHagViZz4Vu1lg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ko.xpi",
           "version": "102.0.1"
         },
         "lij": {
           "hash": "sha512-bq07DBLSoYvPJy0B/A9jMNAB6PgrvCzTX8FbQSMM1jKOpgyhDrPdYGf5oCRL3q+jT4hlgH0M6Fyr0l1mAJpofw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-Mity91VMiaGB5x/xl+5gBxwqkbWOvh/cyF0BV8gF1wTuawHG6JMMhOFRoO8dPhjwcgjkxHkJH0A3OW44eckwnw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/lij.xpi",
           "version": "102.0.1"
         },
         "lt": {
           "hash": "sha512-GA+O344AllnFopFdKIzOnTldg+Ff/2vCb7xj+aehyZ54YCOJadV8As2unSzqghSXhpVashQ1sbVY7PFqn+e00Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-U269mGbsJsrAGP5f5QzfV1mpmFb0uWKYNTPmjTGY+IodudPFGJOiOyAvF3CFiUi/7YvNUM+PKjcQ0z6JXk1zjw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/lt.xpi",
           "version": "102.0.1"
         },
         "lv": {
           "hash": "sha512-F/14cY64RQjQOAM1rB+mSCfuCOhnfzoNlFrLBgamqjbIAy8zHqrMvp4+p8OwyQJRL874f3/EbWhsBmwUOogGFA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-RMUAcbr3Z9EcZIcULcA/qF91URsGs6Q14V7ul9WnyRzE427WwOtxu9PbauUnY0MU68+Dk5VEm37rplXlgP81ww=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/lv.xpi",
           "version": "102.0.1"
         },
         "mk": {
           "hash": "sha512-MA+rOm3mUzmhTgo2Vwq3iGXxYKCa/m15VgHDXfIYakiEavYlgjPjRFcLQn+pNWIWXMRrutnS0bquFbim894Wlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-KGu5f7SNxo8UNApMNpBh9USMqRyU9rm1K6mBojVwkOzerusfgo+nSMQmSMflLeDlzR782D53qXrYB2+pN6+Hjg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/mk.xpi",
           "version": "102.0.1"
         },
         "mr": {
           "hash": "sha512-hRHFwihJC/fmb2ISjH4tjb/2WdWnKEehKGmZNFj1K+Q6wrmBmgDVsD9v4VoF68RR4Rji32vHEEE+IyLB48GRrQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-du9c4c3RXEICv/Cbf17AklY0f5twvQpZxNUjw4IV2JdczP3+YjVJF6PCZPrFCbTOl9ppTPG8l2vJa3Z0NleCwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/mr.xpi",
           "version": "102.0.1"
         },
         "ms": {
           "hash": "sha512-3a1m9tNUrMJ9DhB+1idcDZtmU/BrIX6tcm/uWL4RDUmjP6kPuPYuaRBHWKjs9MZdQPMsFpsaYMiVgjUJ2s+enA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-ONnGP1W4EMub4mu/gff1sW6wl1opOKjOH1WOxuSa7z03cTou19D5OO+pPu1r/20FSsWy2eX6pipvWP2k9ekdaQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ms.xpi",
           "version": "102.0.1"
         },
         "my": {
           "hash": "sha512-5noERpeXv1SVHF7hC4eEd32QqEbIxt48y0pXrSwv3j1RintqLsJlSARRSPk2b+RwGh0snfvmFP281COWzh6ROQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-c3TWMpfqfvK4SZgWgL09Ykxd9ZDTYYr4MkPPy+zD5oIyFnTJBCl2BJ2E8VHwGsaESaSAFrro8duP5mBqxYTC8g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/my.xpi",
           "version": "102.0.1"
         },
         "nb-NO": {
           "hash": "sha512-PGi8yW44Z1tDMaSSnampIsGwvYAy8ikVhklVUIqMnmivNe6pNok3qAsKLwOcFNjCwuNwcTtuW4JQjiDSMZgtHw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-S5QghSe9PB92QQ/eapwLoe25BNCWWuy81X5EVwJfqp9CbEZllsbSZh7m9BblDLUQzTwEYq5yssKsu4tvDgLqzQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/nb-NO.xpi",
           "version": "102.0.1"
         },
         "ne-NP": {
           "hash": "sha512-+a50NXUOZFmqTDLR5mg8R6GVtC1Sm9SOgGVs4ulqT+tu1dLETNtXGrG0HhCf1mNQ1PdtcMzATiypcEJeUTFgPQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-y70vEgQLVYaVNaKrbhz03xlrHCUY/c1P8Yt4OOphTJqe9yjN+R9YIk67jvT4fkoUW0jRrxpWF33KoGhHbtdqkw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ne-NP.xpi",
           "version": "102.0.1"
         },
         "nl": {
           "hash": "sha512-cibfgFY81lWTcgr5e+RHUGKP0NOCbco7UQyv/jmohmdQWm+eBAIDZevaUkWitIzyJLl8VyZZirj2LWl9ygAr2g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-GtZLVCLRuiWVVZLl/nGtJk6nRk9XQX3R6nMR+IvdTbYjW+e6TU8/28rJeJQjfTCIuGsKfTHV7VvId0KienX9lA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/nl.xpi",
           "version": "102.0.1"
         },
         "nn-NO": {
           "hash": "sha512-ALEC1Gyz00/9V1shCCTzQK4/l25tZ1lXDIyCU24DQfIwH2URMjuaWeMYNNR+8g1xWXqzReytCG76paNLMUg7ZA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-kFl5eOUZ8Xf/7s48gD+uK3Tt2v2YQ7gis/tKSCQTgNKta5x5XuTRn1ZMRiczu70Bp3mdNctGwM9C6JR191kgPQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/nn-NO.xpi",
           "version": "102.0.1"
         },
         "oc": {
           "hash": "sha512-H3Ju57kgnhufu2nSQ2mnCW4SkhuQXCVj9Z4CIWcyKGe/RnD1s6I+Q8BMXz6Q5mccAZPSpBtkWt22giYC86oqtw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-3Gx+TVHaLAXrRQpNw+mRE31k1qzRbiwKijeSPWfz+WnYdap9WhRTsK1Dcfo+Y0VapebqcUjtj68Btzov9pDkpw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/oc.xpi",
           "version": "102.0.1"
         },
         "pa-IN": {
           "hash": "sha512-t/LfjhrTorb85MbtPQiryUuFy1Cn0h0r0WMsERHMxMa5ivJkM0S0zkkXEQA4zCb6I1Nf+lAo8w4BiM94Q8AIoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-tPEmarO6UPe10prCVov0XXkhtKdHeLfTlwx3XIYIHZclItMm71q2RdOj6Gdqsgg7GHyDCZWK2J116Sgu9d3HNQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pa-IN.xpi",
           "version": "102.0.1"
         },
         "pl": {
           "hash": "sha512-zUQpOQcK8d5wPTBNETlVxklc8ISrIXcJRcae6Fg7umi2Y+tYWyPJb+QDJ3loNbSDtd67Y6Kl5QWIEzMjfAo2HA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-4Srvg9YDJTToPt0I37MlH6SI9+q7/5A5LiplydNovJ5AUElxmLbqbSmlOE7KZq3rxYZ6U27+xI2gG7zKT2pW2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pl.xpi",
           "version": "102.0.1"
         },
         "pt-BR": {
           "hash": "sha512-FiwH6/knN5DxpwNLIk0Bfln8ZnXegjJzGmzAY5Lyg6Z93QXPHdBl5SLP7ZzQDwky+pygopRr+vesummHU6OFUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-YFQGGz8V6skQj+7WcmGVIIg0aMmxOLUXqSGcPuOO3d/KhnSWFfxHy1n881Q34rtQGcZqx/N1AjIBu9irgnUENA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pt-BR.xpi",
           "version": "102.0.1"
         },
         "pt-PT": {
           "hash": "sha512-q6vxpJjkfO5GLgYg8PolmNeYB7Z4vf0tZe5buUblnoxhBF/R1AISGnpV5wg7SWk+9ckNHZHEIY5Y5AkfgyKLXg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-kg0ZJhLAhYn64Sa3mTWlZ16trD4oO63In+aDiSCKzXRJkDWQIZirioW2wVjT9hnD0CpzjZdfveEwTj96ht6Z0g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/pt-PT.xpi",
           "version": "102.0.1"
         },
         "rm": {
           "hash": "sha512-YJ1osmKqD/Lm+8anlcfGCJ+yYS+E3CTxK1LBob52c7CVubKh+3pmo6iLGQRHcjey+H6lEdEPO9TrUHoIUwRVxg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-H3e/Xgm5qVi2RvPAyfvbPEVMwTWPzDjpOZOXZA3PUr96f6D2DkfkUABioKlm63wHXlK/FYg45uD+hJy5kU5DIQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/rm.xpi",
           "version": "102.0.1"
         },
         "ro": {
           "hash": "sha512-yiEVGGVZMsbwxPxZfqSQ6afuS7lwfsNkwKa1F6mn5pURHpCJgdF3J8JU+s1JszdJSgxahWbqb7j6imlR6pIvlA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-e3237nLKSHT7L827b2HR3nWRl2zyukDWwcdEYPdIWhqtZ9yXxVBYBC7PwnIODlZZUZMB02dYdJcTSnJUw0aR0Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ro.xpi",
           "version": "102.0.1"
         },
         "ru": {
           "hash": "sha512-skRWytxjtkI5L+FIp+//FPH6g1tOoa2iFV40kTwiOxruun5m9Jc/4pI+7ktJzhUT7iarfXyOWKsv/5NlMPo6Vg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-WATeKJKtk5etlnriNezDStK654SnCR1PB/FcUHmvAz+YshJ3Oa/X4isLbws3u/rdIZ6SDCCu+lq8VE0IZNkvYw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ru.xpi",
           "version": "102.0.1"
         },
         "sco": {
           "hash": "sha512-VNXouIrPp2J0Uv2RsFcaZYF3i2n6yReBYz4cKG+7QdBHFJu/kWS23akc8/rZv8uupJOeszIQr7p1845HU2N2MA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-xCX8L5trka7E1yYRVLQq7a914iDqEV3LX3oLaMQ18u42QER9Llc21sx6mtSvkDo0PuruCaZzc+2DnePlsSQz3Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sco.xpi",
           "version": "102.0.1"
         },
         "si": {
           "hash": "sha512-UsxfskZaA96dn1VbcF69xqCOXbJq5iMQlk1jHzXW9V8T97GGMLq4hCWp4sTQUd7wzJ5fPv3dOrbnpRzJblBPVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-zChcW8p3ZHKuqT+9OjuouKEHMLySs/m0Cf+VLRG11YejzArN7VLP4euRaHfziv0/3N2e4Ce34wMn34o6M/ccbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/si.xpi",
           "version": "102.0.1"
         },
         "sk": {
           "hash": "sha512-lx/hXGgV9Y4uIeAtM8laEata2lksc62iRYoMJWzYybEc+cZgLL/iIz/JDezEYSkfab807ibtANaEe+yrYtBOAA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-WtR7PoiPTkkuJ2LqLc04CcBpY1xbMZfCCvWF3J2o2KoH2tsDPW2lRPd7tQ7s55/QndyCHGQzoGKp8DNxpcM9uw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sk.xpi",
           "version": "102.0.1"
         },
         "sl": {
           "hash": "sha512-OjeCSogm/nXwcYfsAz9Ah+RLD6VncWlTGVh8MM4W7wmFpEvmumPIEdvp+XX+h/kisbFLdN4qYHPOm8GGHzLSFQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-RXWA6gfQY6ek6ltKFIENgO9dq6swpqpF4VqGQh7b6g+igMcjl+TWgKZ75u7ZDBvjBKj3fIwKd90xOar3j+fMRA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sl.xpi",
           "version": "102.0.1"
         },
         "son": {
           "hash": "sha512-71HXnGEBNzpDq77ghwGIevm1kppwvxOuPCdsZol031I17Qp9J8Qznbt06piBn22QgQAu4OsL6D2TSb4ZWHdH+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-Fh1sbo9OSrk54Nol5Urtf/8Q+nc4XOBz2QKW3wUppdFF32H0t19u19TKn7dLwjVoX9Aq74Dh0/OQKPSfa+YNDA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/son.xpi",
           "version": "102.0.1"
         },
         "sq": {
           "hash": "sha512-qELnJUw9Hk2/3gezY/l9lPI6PfXDrzqLg5c5FfAp50Dpzc/VgKSG2O8Gk/u1jyi3dEFXdTlGlY2UVLcw9lSyPw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-ajGZGCn/frPIc0iPaMMVyxb7Gfq6/rrJRFirzekUGV68qr8rh2LGjnmUVS7uvgM7Sxt8JPX3KfBAdfEdmwHxDA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sq.xpi",
           "version": "102.0.1"
         },
         "sr": {
           "hash": "sha512-klbQ9xR0v5v2u6LfF+ffkOq9kq24NXyHXCDNztd0cWcPKo9+hh8Q2MhRJxQ6lMsI7ycFenysd3HNEWkoigNW2Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-GmOk0zFVNWpyL0ViioNdBbDiQPQcSmFBxfjVmBgAEVVRJLvPJotPyOTOsPqHmc3iXd6rCu6Y/l4djsaf4SXO9w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sr.xpi",
           "version": "102.0.1"
         },
         "sv-SE": {
           "hash": "sha512-DyMRWARA022eFZb/KH220BlhDXhCyFoNYlp3RwebSanOWU04woXhMZ64D2nG7kSTuyY2aetOun9+aOhg3QeLGw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-6EQxS0oT7rjbvEK+Zj07w7Vez06AnN/WX1EAj/+fXMu+ptPnJjTnXPE+l1BAQFGU4V9rd6Z4r7L162Fob7Aqzw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/sv-SE.xpi",
           "version": "102.0.1"
         },
         "szl": {
           "hash": "sha512-3DBmZrvVMxdk4o84lup3/KiYq1C54Rh66TUXKOAqpx02pFm3FII0qqTs0bZk13jaNk80xtyug80PedDXYk2IGg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-UM7FKbV+JiKnUTizP0DSAo84xSQZAPlwow4DSExbFFjIxCtN3KBeDNhVHRWkBE9v+rR7cizwYUsgnTyyRBEC6A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/szl.xpi",
           "version": "102.0.1"
         },
         "ta": {
           "hash": "sha512-rXBVrxlyQpHDwZDkcK7eqKuULqB1s5pZM30I1VgL1Iev0KUhG2uHIFQ08rYK8bPMdq8/6fS4ymyuIaFEXmmiYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-O1bt1Fhhh9DE7g6/mmQ3kKBSPd79sbc3h12oSwwOhZybT8uIxSI84gi++azNrqy+iFuXF5fmXU4y4+/MJ/cXKA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ta.xpi",
           "version": "102.0.1"
         },
         "te": {
           "hash": "sha512-u9oWStf26IFFZsLrfwKpzcSd5WEHHXin7uCFWXrrHgSSrEXdWSDGetSaeDV9WIvxClA3PQ4uw5TQnoVpsqIm9g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-hyucqd/4OInHvLlssgjw4SKavpRy7rVT/3aIhUTv2j2g2XAbOOe56N3UvTcrT7Oux4aMhW1u32wGaN6T5XrS3w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/te.xpi",
           "version": "102.0.1"
         },
         "th": {
           "hash": "sha512-InS/D9uTItNCqorKfR8ubga5MAReOy8aUXGYa3ab/KtM5RNVmakKBcDeD1n1b2HWD492pHSD7f+pbD/1R7pcng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-NTDt6LTixB9czeZDyh0rP2Ri+xBlXqt/mIGUZKf1PLQbfHq+PjTIUAP9KvoRaLRpSVrpfvD4eM+JPJVStq417Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/th.xpi",
           "version": "102.0.1"
         },
         "tl": {
           "hash": "sha512-Qxn/2c05Fx8+IMSIhnLs/84qAPkZx2ibQu33TpKRQcDndF179xY9O0LYvUfwE+TLexV0AOpfJZz/qsntMLiG3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-Vw5ogzv6ORRFASCi8E3UrcZ4h0RfpGBe6FqNWSSomeILtsZRTcwYh8C6QkvMMxt8qOXEYTfVJjbSADhkaUQSVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/tl.xpi",
           "version": "102.0.1"
         },
         "tr": {
           "hash": "sha512-hBi45TGZllPGgcDxPCZz1cv0/WVWZTuRv03vxnznuJzthiWKWVlUMvZ0yQrYT0rX7UF9xEv49XjGlVfzyOxQ8g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-0Ihns2KWEjUVugBMNJey6nxvSThhJSsY9v/ZhOkV9gfWi7olLvVt7zF7fX8xsAkguM5aiTQfPbEDPxmnovYBaQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/tr.xpi",
           "version": "102.0.1"
         },
         "trs": {
           "hash": "sha512-da4sIHhPCL+y9z7g9Ov4lFlBAWgjrDMBnHIKZ18b/CIjixo3lxS4dx4uC9jcgPMpuZj8XgzxTlm+MahMTveJ9g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-UClFGYhlCI8p+OKJgzdfrLMFW09ljkILyQ+xAdpRwFlBPCWUzIv2Q4BS+iJsLWM63KrHkd80nYyo3DlFu8trTA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/trs.xpi",
           "version": "102.0.1"
         },
         "uk": {
           "hash": "sha512-2UjAtuF85D8gnTUwCCcIKkk75YWlSQyhtsEUjmJu22hQCHqAW5zLnwE9ik17nOWgFBo2UWVq/HvFlv+lRE6zkg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-IEcP6WGGdjUnAmdktz9DQ6+KA2Fhsjm+qqKD4vhKCqkMFTlm13xCIDU3FZq7hhK1qqX21VVIeCY4IL5Zbdz7Og=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/uk.xpi",
           "version": "102.0.1"
         },
         "ur": {
           "hash": "sha512-zWMUfI3KU0Y14Ia+zukaH2GKsU35FoBP0TVfJwe/ko5xAhECNjSPHBK5qcRQj5Cyf2MLXM2ql0rysEFzs1eIgg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-HOP6B44xWFqOciqOHhUCakMAfOn/xip0fUbbgW9fgTelUi9gwdSnKzo5oouJ5X0V54HX3385S2+s3duMjr1IkQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/ur.xpi",
           "version": "102.0.1"
         },
         "uz": {
           "hash": "sha512-G8NP1POT1odyO5d0BjVYE/kVsugrPMZHDWmm7VB8LVoaGcTJrFpVPxAHm7rUuhQD0YhADU5v37F9i+YX77WDrQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-BgloPY5ghQlnMNo5dmZ23MGXtuQ2Iii8nn6jAeC2TR9I+l7FrLg5Tppu2Fw/8WA0nvW8iCSYX3CAaXUaPy0KOg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/uz.xpi",
           "version": "102.0.1"
         },
         "vi": {
           "hash": "sha512-UdMr7OwirJdpFt3pUC4wvmUw4mLxATSZ6o9hr3DEXS+K62aF3+hYvjFJTKRdzrVRHPjAO+nKNFJL62i3c9UDUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-ovxuXuhbFomyP1AezY0n2fpWsio5DLWq27DJ/YvXbgB2ULhmzSj91iMvN6mx27yLJNlgbtfeyptDCHuFrz/9YA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/vi.xpi",
           "version": "102.0.1"
         },
         "xh": {
           "hash": "sha512-BguzJ2bM9lEi4+A5V9dmHvvfg6pr9t5cuMZ1BCNGc4AG6U6IdCdCd83NjYanoV4BJQy28PlHrx6NXhjmK4PdbQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-dnkq0gUuP+a9Lpk+7rVNvXPcfgjjabjVG4c4plW+ioReof6kmOuYk5kamzRUS4SzCQMq6eTOX5J9IXxCMN48NA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/xh.xpi",
           "version": "102.0.1"
         },
         "zh-CN": {
           "hash": "sha512-9Ai4latfveY/12SgMMprVMOHqrK/0QbrFGgCN4EwoV+oZ+3kfp56+1k0SIpkh3eyHtpJPpqiGJs6A7O0N48CDw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-A/eYj67IrzZAWsFoofsIOE0RpUjmzjXCU03H1UNqFSQjTgQAReztYYsDr4ZAyTLDNGCnenXGfBRDLVpgcQ21Jw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/zh-CN.xpi",
           "version": "102.0.1"
         },
         "zh-TW": {
           "hash": "sha512-/ThJDr+NTOJHnZQ+hAowskb1So/EzIBLOacoY1Xze1WiDIV61HUrcdEmZ4T/9afNGWBIqUR/nmX9wlgMJSz6HQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-1J9rFhsjDAiL0BwJEzOv6I+l8mudOVGKqdnvWmwwSfyKFgbovTj89DYja2mWWVo3lhMe/vRfAUN1BOrD2VVy4w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-i686/xpi/zh-TW.xpi",
           "version": "102.0.1"
         }
@@ -1482,491 +2364,785 @@
       "linux-x86_64": {
         "ach": {
           "hash": "sha512-1wMz8tb1N/WgAYehZqA+OhJ+hrJ2G7nA3PUyW0OneKw0z1lqqkcjysQaDoRXFJsgCDo6smLB9uRkWJPZMiUEDA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-bLM0YxABJTojY04jB7FNO19L9hTcBURGsQtrI5lb2TbBR/jDJeyjcEZFwpXR/nb76Em3IZvmrCkV426PyU5pLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ach.xpi",
           "version": "102.0.1"
         },
         "af": {
           "hash": "sha512-PWkQuA9PtwoZklTqd1UIrwj9PJgSYgR6gS94KkQQinmRUP2tN6faBbHHoj9eJ/+GgSST8DzqplGPr55ivo9Zlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-hkQ3njxsnF4hyJcfwDqT9hMEyp/8XlWqmQU57DYKMI0CU84smpT1/Po5u2Iy+cZTAA9UdSoQWY22F14/+GfTdg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/af.xpi",
           "version": "102.0.1"
         },
         "an": {
           "hash": "sha512-8yEe21AGF2gV/pLirSVepmpdWOJgDARMSKHEtJdlTol+qGk+feWA3nMZAvjtXVLpakH6OkFprDasuKm2BL0UQg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-8w0EGHS4LvVeXB3namBtTcqlqCYQoquGu6DQ4sLFu9lETVqVWXEsznjSA2L69E7H9aDgh5EjYYWCb+osVDYh4g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/an.xpi",
           "version": "102.0.1"
         },
         "ar": {
           "hash": "sha512-XooVTJMZGJgcAWFEPgr89XzY8rNKU8/E2feD2optztbIJ1UEMqhvMsnNWq/sl6tedDp6+0AdpPkzwjT+j19DYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-fxf01Gex6GANtb5B0+3+zx2Lk6Kh+QEmE+NKsRVw5xSTPVMJpgE1Q5/INXCBhfY+Fjv9G5zAd30o73GpBM2mUg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ar.xpi",
           "version": "102.0.1"
         },
         "ast": {
           "hash": "sha512-PgoABB/375ZoLP9bd2cGWNUHIyu3iMgiGbgzoBRSx5s/W8bwirj6sA/x9JRgF08NUA7bMv7rrf9pac2A9/F76A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-caR/9AVwQKgYlfeZ/LXqJ/oTQolGE9tkZNfzL3bH4/UX8CrscMVE8NplyzHD7UG35zezxGvsr+q5fIH8JebvoQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ast.xpi",
           "version": "102.0.1"
         },
         "az": {
           "hash": "sha512-QO7per+zRx1iyijEJG8PlXteCMOYQGj3GazFBIwgO5nHZPMKaLsUs+f5gMg4ilxZ8NpCxO7L6lHuXI51+Dr1rg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-LyzAcOV6bx+Cp/0bQJVAUh0JhUCfqFzujO2OV0lct9K8uSqT6aJuy0xBoaHB8kgQEBhEMMVmuQXYTVf2bpsttQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/az.xpi",
           "version": "102.0.1"
         },
         "be": {
           "hash": "sha512-FSmlnQoSbe+pL0RDAZid5hLLxVd25P1jkxXj1wV2fYHuD+saV2ntnaTIHxLLo0CwbjgUiFeaW8uUqh9y9YNFuw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-2ueVAjZW8yugk1/T8iK+KSPjYSU4aXiTlJjC/ygwTuz+9gn9JHkRbIqD4u213pBYExagtErT3G3Pyt0snhG4ew=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/be.xpi",
           "version": "102.0.1"
         },
         "bg": {
           "hash": "sha512-3AoQlIeQZ63sTUuHVrr8hTN1kWF10oFB7c7P6sVrgirFphMneL6QL8IxVXlzY3ADSM3OD672RQP/D8Rt9In/cg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-3V6qdBxN39oz7i/blMu+eWHfXG8wJ+PIa2bX+UTDP+nXWy7UNbj1hgDRLo7v5mIF5+DI6HRtexATzkhqg7X17g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/bg.xpi",
           "version": "102.0.1"
         },
         "bn": {
           "hash": "sha512-4p9uBEaCLrHk1IJs6IkF41eU/f01/JhaZWqOCiC9zNCADuNtzarHLzdhplrK3Ow+dsW0ncLP+4wCgcCTdJkqPg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-xX79Wn03SZ9YzcN5j11dkCnpaPiPVQuxKDyhxfvJzHIJq6AJ2InhcpnQ7RZAiSEV6CRBWGuC26hPXlXegkfBeA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/bn.xpi",
           "version": "102.0.1"
         },
         "br": {
           "hash": "sha512-Oo/N7O7vsAYCY021+t05cK4pvsPeElYQ1y9MvAMiFB3dUZhyzY3zob3f4W8LQKgPuiMvx7m9vdBldEYk4EoReA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-mXh2LiSBs1wcNSx2dEXj/OB7zW61hNORM+KGr7Y3keJufnDxqq//o4HIsTc0hgPYXpZQWMKni4EHoXkPOSSFqw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/br.xpi",
           "version": "102.0.1"
         },
         "bs": {
           "hash": "sha512-tkgXYF3ztMTRp85hTLN72zjRw9cOpZvHJubV/ailTAkwjjgSxmLAAwbYc+aMNjDZyirQik9j7Qd/rVBCvcCBaQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-jzJl9ZuwJrqFoEwXV2OTT+o8QLt5DfKi1EHmn+01eTmqwboie+KC3Zh+GK1HLjBsOx6S5kZn39iNo5lzmW/jrA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/bs.xpi",
           "version": "102.0.1"
         },
         "ca": {
           "hash": "sha512-096VAUzmi9uULul8FOKFkOtAr/C80SbuD9+E5aJESY8cRzSZXgn+2avfJFRDXtWbIxQpeHsXfE6CDu8fhCjneA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-hnZjjyc0sam38vvRZTtlRSuz5OqvvrlALJSjPd5HL/JrqOpHRqgBr9OEgie1nd0/ZZRuuy/Ik2Bv8ppg0RaEtg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ca.xpi",
           "version": "102.0.1"
         },
         "ca-valencia": {
           "hash": "sha512-t8pre2OUGvNviVlR9ZUnVU3zvZJYxv3oWzdsNlffzVSgG8GHsrQACYJOM/I0WiZgVq5QkiOMMPie3lXx11zhAw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-NRcybXtB2C0RGYkZASQ75Lqj16FRkKmYj5L5AHIX1B4YkW+uquP+OZSWx6fLjzExdRL7MjeR8mOnV0J0mnyFJw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ca-valencia.xpi",
           "version": "102.0.1"
         },
         "cak": {
           "hash": "sha512-603PnXxiv8C6FmVKqHAYzmbq0fcsuvEBM2XOJI1082T2gJNbuBTvlZ2IzQ+NMEdDaR+5H1nEF4Zo9JmIPPmRUQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-E17HuIF8K2pDQJqkccHd3Pc1wBdz7wmctbiLycRKrNDfDMPS0I8wbBr+GiKJzufjCESWwJ9WSQeoCvj1ij1cJA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/cak.xpi",
           "version": "102.0.1"
         },
         "cs": {
           "hash": "sha512-KqWTKRjQE+qoXFyFULMFvSbpQQkYJC39DQvemoU2YcBPv1gBhR6vU1qrNVFEozv+X+DOZQ0cIJ2ao9hh506Kvg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-K99lCYmLSmWHL4E+1awTyyWaHcium6w+TD22taJJCMqEAyhyqVYaEQ/qGL9ZahjAvCOmEZCnzzTBHGmGzxDhcg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/cs.xpi",
           "version": "102.0.1"
         },
         "cy": {
           "hash": "sha512-XtcBH1L0Vy5uHJEn1ix970RuQXaLPwytGoDv7NuNr63aVEQKezOz0h5goEJrXHhBSjwE4RuQ8EJkvoaTAFwTbA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-453ACWRDfmhYZ1v0zCoQZ7Wqaq1wSipmp3QsCu5mR+sEmPlgDuLuNdhzNKxaJttED8itzXmRbqQQ9Xrzwd6wnQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/cy.xpi",
           "version": "102.0.1"
         },
         "da": {
           "hash": "sha512-hLuYkETlxNe7SFkK7wNs5f5unqNq/2/E9f4gxee1XZTsVA/iHK7UdMNqFyxgimVghDt2mg3Ns3p9fd1O4muBig==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-VdmWDGSj+aTWNVx0Fbu7eyTfpiR6OATuOx1T/8zwObsBoPM/Zg7Qhf8jQm16+Hq0es4xl3Cy+zqNWlQ5rIJ7Aw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/da.xpi",
           "version": "102.0.1"
         },
         "de": {
           "hash": "sha512-yanOY99XoXDO6JSfja2EzstkSZ8D5dDPZCXody1R0OK965h8sXz7sTYyPNkb+CEmIC9PAZFa9WUMuYZkAhUpfg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-aHrPMsqQSpZM5L+6lsJNTbK+qGIYaLJyOEB9v4JhhYx4/qmRCcL9fJ9g3gqRrpnOqvw0LLEjW1egDPeDTmVPSQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/de.xpi",
           "version": "102.0.1"
         },
         "dsb": {
           "hash": "sha512-SwpPgJb1eAq1bdnqpNKi9yRtAqkERkiHgoDJplWNLxanRzEDOvkLdGFyJsek+gpDe9DvI+gT8N+c69TZYovtHQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-te63e+CtRwRXptHgnSIGP2KNgjRW3eMYb1WQFARg41PPuDIaDJmpscrnXtYa99tQINjXDFTbjawHeP0GpRdmVg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/dsb.xpi",
           "version": "102.0.1"
         },
         "el": {
           "hash": "sha512-D7o0jhlUnGSwf2EeHa9fNSyJU7u7oCMM6eVkZjN9pEs5JptNJ1/lSL4Ienkbd/NYWQpTtFpNJyLD2IrqG8bCNg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-LfXde++z1edJ8nTOJrZMxtnFwIzMNu6X2R3fTctUQAVZprEAc7OHWZKT5L6W+oYLzBlCiHU5KrFOVt8shEBezg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/el.xpi",
           "version": "102.0.1"
         },
         "en-CA": {
           "hash": "sha512-Z9L+rAKxkC9Sexs5AlCVZ3jFH5hbJpBQ+TAY0riF0D9NwBg/ymxG9HeBZKNYcS7/VxLUMTuk2kZu/r4sB7KcpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-Qi62e/Su5JIDzcyNLxevKOsscoDonIw7ok8+Af8ZokUoyNrQ8MdW9muWr1CS1pE0fbwfqLXne0tnD6T/oW3iog=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/en-CA.xpi",
           "version": "102.0.1"
         },
         "en-GB": {
           "hash": "sha512-a/kWCuGWzpbqLDiMKcYUMFAYVR7jglQwRsiRoHFFGJnoFk3tGbl2bODoYc0LVY85bDn8vxPKuBtJkXPt59yWqA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-qkm8lzsYKHWDJ8R70Se+bdIpmczQG51UA3AG8qkq+Rc94r3NHIAN8oI4bdfXdi2CnMF1iZhPAagBu6qad4LMzw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/en-GB.xpi",
           "version": "102.0.1"
         },
         "en-US": {
           "hash": "sha512-569lWsRSKDA/DrSMEppQeHU+L5XEJXMonJ2qNvyr4cHYxzPGryk/R8i4h8U0QX4P/rIAl6DAf1XSVbGMxbvq5g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-+JI7umHeTnmtTOA6jmkQq5uWJZN3VTd6LlN1x4n2jGsdkxjJRkBm3/DULbw31WEGWEUDrcTk62l2q57+GfGJPg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/en-US.xpi",
           "version": "102.0.1"
         },
         "eo": {
           "hash": "sha512-9mAejQrFnMkt9P1gFbIMox8NycwW2GiW1lXcyutB79eijGm+HmXwCnF+6Ccd+MyB3t4x0ExITpun/pC0HmwrZQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-iEXilZUbQ2bbGcT5BAk3WIxZw9fJOp8ZbbKN3T61d7OHJkFDP8Rzu61TWYlKpVBm9UXxqTNPvlvjH+rm/O8Q5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/eo.xpi",
           "version": "102.0.1"
         },
         "es-AR": {
           "hash": "sha512-njwtU8wiF8mH0CKfuRx1VNu/WdS/Jb1nl3P1RXYjib8gBudL5OtFTDaktfdisrk60lFUfKBPLbt3L85VtXXSUg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-PW+JWrGG8myODZ1H++9nYMredVmdoq/rTQDIgaNUHHM7cG/vs2FYJ5SOoVwVXSVZ6IA8rq7ZAKP9TIEWXgcL6g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-AR.xpi",
           "version": "102.0.1"
         },
         "es-CL": {
           "hash": "sha512-d8NAwXuOggHr8N39T6Y9D4gDR5PQ3WWPTBZUv3fyuubNcozflnnqXeamcjDJ+POLKqv2mJinrbBvF6hyjzy30Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-lGTUFjPvQChsPplYWFF7mseF92r/q+eOcNL3yF3Y/B+2NdP9aK0BLneIAsEkx38lshg5MQNfqc0IVDG+f8GpYA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-CL.xpi",
           "version": "102.0.1"
         },
         "es-ES": {
           "hash": "sha512-XtBcm4Ur1bDU/nH1esbJ7jOmRYI+yiBqt4t/5BldNY/aCoNn/9qnGVYOKdJGKQ8+qACAx3v3Ldj44veRD+mqeg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-rTCEzwr2R3ajgHHPb6z/hdrIH+H/kFyixrex7Q/VFYyUo2mGaPAt+avxe68aU5+7A8qvAYptNpBVIWXU+Ab1/w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-ES.xpi",
           "version": "102.0.1"
         },
         "es-MX": {
           "hash": "sha512-pp22eKGufcryJMbptb7dSIhEVc8QvidpJoBxTr7diP6wOoy6JImdCmxS2n1DjskczViBhr3KsLUfv7xgaafTig==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-tItRzCda9FINi3iTt+ED+eKDGuBg4n8aQ1k+7/NUDeuChv9r195nEmGt4Ncmv4upk12/Vgr1qmRT5SPtgAHHYg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/es-MX.xpi",
           "version": "102.0.1"
         },
         "et": {
           "hash": "sha512-mEJr+trFgdOJ6gSwKpDHFUQFHbPxD7hu7HCYK9yUmsbqJRHVdYvMtZjSi2F2+mOhFhuvQORahp/v8w4/mcaybA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-iDASyqbsXuaTPpRLLK5LA/GvJbxCSO3muCpuw6NaP1ztGnb0FDtXRpR04Pnzd3tzg8X8HLZAtxjdl5yHTCJtYQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/et.xpi",
           "version": "102.0.1"
         },
         "eu": {
           "hash": "sha512-oXTAeYLRMp4lVpP/4g9aUAi8iv0s+Tt6E0RPW/iJXWPbtXClp56WiPvfT61puT8+Yo/ZpULdfseaAoWmNuqtWQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-HFPQ/VC5EZitLmquBIKxTsTF11SHWDVGg6Qk6B5jInB0kvYcAmkAabmYAAUU1lEwkswW18A0PJ/FPSftpqrNVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/eu.xpi",
           "version": "102.0.1"
         },
         "fa": {
           "hash": "sha512-t+gOJWuMZIBsMtvAy+Bnrprgqq1OCPNtphygicDUAl6ZvPWQMJZgweNuD6/R1y66R9hUHHZ71lxWl2fVWvjFvg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-7XvbEFedzHRwBGPgEJKOgOkP6H9g+hZ73Ul/9Ydumz1KBiv+82wClZDMbW0m/YF0nk15M6hmyRsF56VoygpQnQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fa.xpi",
           "version": "102.0.1"
         },
         "ff": {
           "hash": "sha512-7tPNwtRrRJrBKPSLibM0zWvKyetqDhNA42nRtiJXruLjEJv2OaUaFubFzxV8NMCnGjEJ0Ergw3n9hivqJKDOKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-QvevGA9FcW/+rVxFg8cJL8LWZzgTNMphwf+sVM4PerGBO8bjHvwgeXwVysCC/Dw49Rm1gdevL/4e8BYiATP9yQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ff.xpi",
           "version": "102.0.1"
         },
         "fi": {
           "hash": "sha512-42QTMp57qSQglPPF2WFzViwf6nubnIPU32tdkVjmeMlFQ4O/S5c08mlWUbwuQ/19vrfwQv2b6vSz+u20QGJ1zw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-5Ii6AZb+obZdsPqZSnri4vO1vmPpoy7xFkpAvrMbUQ6MtkpG2OUynYEq6jk/gPTW9veRpmOVH9FVnSQc26OiVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fi.xpi",
           "version": "102.0.1"
         },
         "fr": {
           "hash": "sha512-wFjkGRk9AHbv8yvB1ZRB+5Q1SN2MJUB0wFJpOafNasDWQiqVQo3HravB5d7tEspCivwi/uaPPZEWJOoPeFSyEw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-Uqc/byyVmZ86OfGG9nov6e+9vH8S1ST2kCBhlFiJ94dIC2boO+k2a3RVsWZLVc88EHe8XAxINVZq8Vds0zUGig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fr.xpi",
           "version": "102.0.1"
         },
         "fy-NL": {
           "hash": "sha512-SeKPJXWV4XxuD1cEKWWbPVhI4olMfzhqqMARA0LTla/czEpB601v5u7gEr4KeC4eamsbUmm7J5zGtq2l81cQvw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-55IplfI7v6s1o0cU1S+yqFVRn6QyRW3dBPeOTFX5rNsnxt7qqAn85xJ5QDIksCF7TQS8OWHrLRtoo70dcN77tA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/fy-NL.xpi",
           "version": "102.0.1"
         },
         "ga-IE": {
           "hash": "sha512-zG3uwCNtY9hMvaHuOHKyyNMHUxcqNe5nQYBqtEa7zL/ReHMYzC2UmVHjv+1SwJCQwa7GxZk2dXThAc/ncCrrEw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-iY+pFgh16AKMKdKGOU1ZOloxCZYatsQzkTHX4qy/4D4Q3ssRpLBgaZwgrnv0CS6+mCa9jn2f8KYKIgp7sPKlHg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ga-IE.xpi",
           "version": "102.0.1"
         },
         "gd": {
           "hash": "sha512-Ovcn7EHqJzcrraAXZlJQMriwIA1lx0ed3GL/XZhOi+nKCrZebcLe7Eg7xk5JmFIlWZFDdFf+OxgbS7dmM2HuuQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-2hclmq9SxtufguvyUSYMQMA5FsFcGMS9nWkFAvMKaxGjPD+kEHLBIuzYXG4gYVxTZZl5gsp9Skr+iwkk3dwABw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gd.xpi",
           "version": "102.0.1"
         },
         "gl": {
           "hash": "sha512-eMvGfmwYTHSKNWF/qWDyvqhaTePkqwEwkTYsSfuXjrxHl5QzDB9B3bkGeOcBplh8B/jT4zzhvhRgczzRKZ7nzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-yKP9E9lpkVXSyxMPYDKqNfJtLLYOkxQvh44WdCgDsd+GtZUf4teNzIb+AVq911YM079efHTG/GncvyycaVe0Nw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gl.xpi",
           "version": "102.0.1"
         },
         "gn": {
           "hash": "sha512-/y0tshuSeDMPuLsyoUZptGygh2SmDB7vu352H/v/QnNcYHRSgQU4UxuEvEBUfcQkoTrArAktYWR5T27jNIURlg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-KARPOl7CGbAWwTjzlsuZZMQ01o5aO6PzLeEOaU5EwktH494/Nu1akr1AOm6FcrFekTLLaQ7pI2LyotTgRqJqUA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gn.xpi",
           "version": "102.0.1"
         },
         "gu-IN": {
           "hash": "sha512-ljY6m7P+aNCb8KoCQzTKDkaU77VDL4E0AjJAQF4S3xr3EHc8QMCL1+L1fuVbzUKXfl6ySpPFN95wHXqMibOcyQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-eXji7xFdYdr3lzKG08/ekO8sL+fY5oRJMQuKciJSP+AYqE38Zkz1I9hjCafJ8U0yvUAY2yzecdFe0oyJO/FJxw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/gu-IN.xpi",
           "version": "102.0.1"
         },
         "he": {
           "hash": "sha512-IaCbKjssqcSKInnLUxtWDKrECCEIjNq9ut7RsfNM98GKDAIcBCXfHmKAhjox6pdDWAbPtzhZW/X8XHB29sCLCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-lnNPxi5u2FoIPVL65DLuc2IY7CqAVkkGnFq7XPvUZ9IHNZlnQP/EgzPxRbrQqs12++JASKTxZ0XfjlifK9yC5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/he.xpi",
           "version": "102.0.1"
         },
         "hi-IN": {
           "hash": "sha512-eYGOdMqyNyZvN2OnJnJgWXlSgFNJnW1YQQ5VYhh/Gcexr/xmTohcaXwzN3jS/OPDuptXwzsgaje2/1hHpaC7yQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-Mk/qKuoOPPMomDY2YfL/b6hbjBUbHvbamNFixWzoY2AQY3DsgInK2PcJCHpDpl8g469Iavakz9I0EUnbBwdPig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hi-IN.xpi",
           "version": "102.0.1"
         },
         "hr": {
           "hash": "sha512-sLnX4ZghgtPT1QoA6IUIdtF6gJk1fQe+4mE5VXJkspNFXaw7/3W0pvk8YtmG18t31gRKir5z8Fr5tTujm/LqiA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-t3RNHRPCHj2gDYDnQ7o8tkleuogje/jMrd5NebU7bdIW8FqROh35y8VcmYmL97vlBz7drHH7EMFrFC4ge4PUSA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hr.xpi",
           "version": "102.0.1"
         },
         "hsb": {
           "hash": "sha512-Ktm3HRnpxJt+643peTXhPzSx+3R5fRSIfNBm1XzSorR/Aw5FWBTsLFXKpDNe5AvMJgnR6HyhRModQgEucpwTDQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-EFkzRD3JimahMhSw+wTyD4wl6WM72u7DAwwKDlGnI48E43/a0pddVLwGsJEqLSBoqWUNWapWJAouJZimTWUQXg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hsb.xpi",
           "version": "102.0.1"
         },
         "hu": {
           "hash": "sha512-82CpWC5p9MAUY+OgGqf0K2A6ZALaNOsFNI78PnAMGkc9H9WcSdpr9BDr9ofi4oAMegAHboPqYenI1UYGxuTfYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-uxAVWo5/JIW2JB/ydMTQ2OW0D8qiOCWFrv3Ln9PxxLEf59+oLLjMrvOL7FVH1IKU7DyszoKjPZVgbHAUTE8jLg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hu.xpi",
           "version": "102.0.1"
         },
         "hy-AM": {
           "hash": "sha512-FgxxkY7Rop5DctgW5vwugUaGO4/T1hV4zG5NBA3iTJTooNa6A69YPNGGhOwXtSWI8J49/cL6rNiqOnrE1jyHVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-hB2Qj+OjaVicWbOFO0O43sXWEvD94kT0Y/gFhyXASoQMaOfwOteUIvsBIV67RapV16Hqy6D0/eorF14INvASTA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/hy-AM.xpi",
           "version": "102.0.1"
         },
         "ia": {
           "hash": "sha512-9X4uBVia6ysLfBUu2cWUSMTyRuVISAAfHLmJ6+EV+9Kl9cx03qZ/vd878crWjvV9FjURjUi1diMEiArzn5qz8w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-MC4AlFoG+/4xy1G1pHMtE+UQgZvhNmkDXlWhQ+UCK6sWdWeNRYCDNXXT4lIQhz7WyvBKe0+igGdVdJDSVtb6aQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ia.xpi",
           "version": "102.0.1"
         },
         "id": {
           "hash": "sha512-w5Dmou3NIFhGmkT0BPgaeenGnHj37MMS9sPuh3uDQsWhG7W+/XM/ky0BLDW68BujpcPOZ7FARbLGVRq0Lirdtg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-fz7YVWCm2iuAxl8dlhP+B2Guhia0rKTNnQwnLYXk899WoQOFxrNGUlcGtpyuv/AWBWrOz+S0y1jWCXueT1xXWg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/id.xpi",
           "version": "102.0.1"
         },
         "is": {
           "hash": "sha512-/T7wUz36Zw1ukjNEgIRWYuzPaBgyyecruqP15y41qvcu2Og+HJYJWCTn6OnTv+k2Ft4trDohQ76uEbFS1GZw5A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-COZTfZ+zmOq0548C5lCr1+7wyFGbTTvaF1STUHGPFXjzbMhP3yn2U0yRinZiKv19If5k4MqTQbBYL4Op+NM7tQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/is.xpi",
           "version": "102.0.1"
         },
         "it": {
           "hash": "sha512-gHJd4ISo2+5qifYwJXUps7FxpEo8acuziiJ83OkvwLfRcC54N+5Y9cA8xRa9T4EgJznctaQjZ5i/AWeRY7MGpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-0LavIOdEuf+a9agQxWkKtzimixI+ilq2iYmfkwXF9lWfjIfW9jMPlFh22fvmoMdd+KMsnW1Rx1mPj8diVEzcOw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/it.xpi",
           "version": "102.0.1"
         },
         "ja": {
           "hash": "sha512-IDyCk+HNfwvu2oyjks365Dte56t2/PK+HN3KxNjWhssb0m6CKDAZ5a37au5K6MfetvZT91qpid/z6kklqnIi/w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-BKLTXQSgKta8/RXNBjCiy9PJfUX0PG5ZoiaSL9FAdyJb3gaMkEy3/Q5IWHLv0+JW/jNE1SpzT7uwMoDYBAcGSw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ja.xpi",
           "version": "102.0.1"
         },
         "ka": {
           "hash": "sha512-E5jhk77zZzkKK82XVTYW8GucB+P++ezhzGd8VqgrhfnUxndGzNIVIV0gblPJh5CZm98/hzNGdqKkokWD/y9uSg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-xSr/SXbm0kEZSM8XlVJZIYPAfZo6yf8ej6fECJ4U59SLCrE6QyGIUlSuDlR9imLiAQwcMtS69Cd3SZ0wh2DLgg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ka.xpi",
           "version": "102.0.1"
         },
         "kab": {
           "hash": "sha512-p9tjEQaySttcC1Rq1zOwn59vzzcddIpCQYgeHlKI9S+WzvbpHuqXrkYYAevD9tYaPgdtmaxYEGSFg2HzGNGKgw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-cI2YIzLKhmtvPWv6CN0JbwJg7btpLxtht2ilIW71mpouuDIdrLjTZizfa6vCz9nJHNnOK5tMfvPb6J2YD3D6iQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/kab.xpi",
           "version": "102.0.1"
         },
         "kk": {
           "hash": "sha512-XdNAHxMM6DqKHd13lo6XFxDDt21dftHsRT8te6DqPtBBbEKcHvrdrjMvPXVdHmd0AiQ+APpT5zcFblZOdIT7qQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-/kdNRXv/AtWqyqRT41Pka2MzRXMPAO5HDaBhbzjl2cgWW38f5v4fMaUsUEuB60Q8lIKMklTtIU8kIXV/zXX7Zw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/kk.xpi",
           "version": "102.0.1"
         },
         "km": {
           "hash": "sha512-Mn6Iq83qpKGiGI/O0ZZsxailCMLBL+Ey8OPkSvUzniTBLVIlCZW6Cxt2BIJ+Yc1WWj9VsrQfwr1WDifR7k1HVQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-Ouq95aDRl9FL9wi7djzt6QsSJg66nzVaupW7hqIbJySsNg+Y1kZxV1Xyg1ZFVcIyUsk9b23hwrABfRiqxkgPnQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/km.xpi",
           "version": "102.0.1"
         },
         "kn": {
           "hash": "sha512-v7WcUAQLx8ZCb6Zz8uQIPktNTRSr7emrVaVSkB3nWsHzlL15YTFARPjxBhw0sarXTq8qGVsR2SYVsDzS4mo2Mg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-+faE8HOK/fsSk+YVFIrFPfJIRkyYT7zwJewccqWvT5R6IDdOGJHq+9CZNVvpCOPtl20p7RWIifHyRqzwZeNtmg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/kn.xpi",
           "version": "102.0.1"
         },
         "ko": {
           "hash": "sha512-MODi9//qZYgfymyhY6eJ4j26/jmWjAeQ+NUIcYk/WqfADR5OtwlhRnuxqTB1PGQ2+OBuam+Ane4I8aoiPa/weg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-XwOr8KTdRgnQgPNIqsSHqL+faAU9g71ZhPdPiocJG4LZEWgAb1f3K3AN0LzKSECFfSJLpX8nIHagViZz4Vu1lg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ko.xpi",
           "version": "102.0.1"
         },
         "lij": {
           "hash": "sha512-bq07DBLSoYvPJy0B/A9jMNAB6PgrvCzTX8FbQSMM1jKOpgyhDrPdYGf5oCRL3q+jT4hlgH0M6Fyr0l1mAJpofw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-Mity91VMiaGB5x/xl+5gBxwqkbWOvh/cyF0BV8gF1wTuawHG6JMMhOFRoO8dPhjwcgjkxHkJH0A3OW44eckwnw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/lij.xpi",
           "version": "102.0.1"
         },
         "lt": {
           "hash": "sha512-GA+O344AllnFopFdKIzOnTldg+Ff/2vCb7xj+aehyZ54YCOJadV8As2unSzqghSXhpVashQ1sbVY7PFqn+e00Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-U269mGbsJsrAGP5f5QzfV1mpmFb0uWKYNTPmjTGY+IodudPFGJOiOyAvF3CFiUi/7YvNUM+PKjcQ0z6JXk1zjw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/lt.xpi",
           "version": "102.0.1"
         },
         "lv": {
           "hash": "sha512-F/14cY64RQjQOAM1rB+mSCfuCOhnfzoNlFrLBgamqjbIAy8zHqrMvp4+p8OwyQJRL874f3/EbWhsBmwUOogGFA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-RMUAcbr3Z9EcZIcULcA/qF91URsGs6Q14V7ul9WnyRzE427WwOtxu9PbauUnY0MU68+Dk5VEm37rplXlgP81ww=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/lv.xpi",
           "version": "102.0.1"
         },
         "mk": {
           "hash": "sha512-MA+rOm3mUzmhTgo2Vwq3iGXxYKCa/m15VgHDXfIYakiEavYlgjPjRFcLQn+pNWIWXMRrutnS0bquFbim894Wlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-KGu5f7SNxo8UNApMNpBh9USMqRyU9rm1K6mBojVwkOzerusfgo+nSMQmSMflLeDlzR782D53qXrYB2+pN6+Hjg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/mk.xpi",
           "version": "102.0.1"
         },
         "mr": {
           "hash": "sha512-hRHFwihJC/fmb2ISjH4tjb/2WdWnKEehKGmZNFj1K+Q6wrmBmgDVsD9v4VoF68RR4Rji32vHEEE+IyLB48GRrQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-du9c4c3RXEICv/Cbf17AklY0f5twvQpZxNUjw4IV2JdczP3+YjVJF6PCZPrFCbTOl9ppTPG8l2vJa3Z0NleCwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/mr.xpi",
           "version": "102.0.1"
         },
         "ms": {
           "hash": "sha512-3a1m9tNUrMJ9DhB+1idcDZtmU/BrIX6tcm/uWL4RDUmjP6kPuPYuaRBHWKjs9MZdQPMsFpsaYMiVgjUJ2s+enA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-ONnGP1W4EMub4mu/gff1sW6wl1opOKjOH1WOxuSa7z03cTou19D5OO+pPu1r/20FSsWy2eX6pipvWP2k9ekdaQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ms.xpi",
           "version": "102.0.1"
         },
         "my": {
           "hash": "sha512-5noERpeXv1SVHF7hC4eEd32QqEbIxt48y0pXrSwv3j1RintqLsJlSARRSPk2b+RwGh0snfvmFP281COWzh6ROQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-c3TWMpfqfvK4SZgWgL09Ykxd9ZDTYYr4MkPPy+zD5oIyFnTJBCl2BJ2E8VHwGsaESaSAFrro8duP5mBqxYTC8g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/my.xpi",
           "version": "102.0.1"
         },
         "nb-NO": {
           "hash": "sha512-PGi8yW44Z1tDMaSSnampIsGwvYAy8ikVhklVUIqMnmivNe6pNok3qAsKLwOcFNjCwuNwcTtuW4JQjiDSMZgtHw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-S5QghSe9PB92QQ/eapwLoe25BNCWWuy81X5EVwJfqp9CbEZllsbSZh7m9BblDLUQzTwEYq5yssKsu4tvDgLqzQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/nb-NO.xpi",
           "version": "102.0.1"
         },
         "ne-NP": {
           "hash": "sha512-+a50NXUOZFmqTDLR5mg8R6GVtC1Sm9SOgGVs4ulqT+tu1dLETNtXGrG0HhCf1mNQ1PdtcMzATiypcEJeUTFgPQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-y70vEgQLVYaVNaKrbhz03xlrHCUY/c1P8Yt4OOphTJqe9yjN+R9YIk67jvT4fkoUW0jRrxpWF33KoGhHbtdqkw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ne-NP.xpi",
           "version": "102.0.1"
         },
         "nl": {
           "hash": "sha512-cibfgFY81lWTcgr5e+RHUGKP0NOCbco7UQyv/jmohmdQWm+eBAIDZevaUkWitIzyJLl8VyZZirj2LWl9ygAr2g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-GtZLVCLRuiWVVZLl/nGtJk6nRk9XQX3R6nMR+IvdTbYjW+e6TU8/28rJeJQjfTCIuGsKfTHV7VvId0KienX9lA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/nl.xpi",
           "version": "102.0.1"
         },
         "nn-NO": {
           "hash": "sha512-ALEC1Gyz00/9V1shCCTzQK4/l25tZ1lXDIyCU24DQfIwH2URMjuaWeMYNNR+8g1xWXqzReytCG76paNLMUg7ZA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-kFl5eOUZ8Xf/7s48gD+uK3Tt2v2YQ7gis/tKSCQTgNKta5x5XuTRn1ZMRiczu70Bp3mdNctGwM9C6JR191kgPQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/nn-NO.xpi",
           "version": "102.0.1"
         },
         "oc": {
           "hash": "sha512-H3Ju57kgnhufu2nSQ2mnCW4SkhuQXCVj9Z4CIWcyKGe/RnD1s6I+Q8BMXz6Q5mccAZPSpBtkWt22giYC86oqtw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-3Gx+TVHaLAXrRQpNw+mRE31k1qzRbiwKijeSPWfz+WnYdap9WhRTsK1Dcfo+Y0VapebqcUjtj68Btzov9pDkpw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/oc.xpi",
           "version": "102.0.1"
         },
         "pa-IN": {
           "hash": "sha512-t/LfjhrTorb85MbtPQiryUuFy1Cn0h0r0WMsERHMxMa5ivJkM0S0zkkXEQA4zCb6I1Nf+lAo8w4BiM94Q8AIoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-tPEmarO6UPe10prCVov0XXkhtKdHeLfTlwx3XIYIHZclItMm71q2RdOj6Gdqsgg7GHyDCZWK2J116Sgu9d3HNQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pa-IN.xpi",
           "version": "102.0.1"
         },
         "pl": {
           "hash": "sha512-zUQpOQcK8d5wPTBNETlVxklc8ISrIXcJRcae6Fg7umi2Y+tYWyPJb+QDJ3loNbSDtd67Y6Kl5QWIEzMjfAo2HA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-4Srvg9YDJTToPt0I37MlH6SI9+q7/5A5LiplydNovJ5AUElxmLbqbSmlOE7KZq3rxYZ6U27+xI2gG7zKT2pW2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pl.xpi",
           "version": "102.0.1"
         },
         "pt-BR": {
           "hash": "sha512-FiwH6/knN5DxpwNLIk0Bfln8ZnXegjJzGmzAY5Lyg6Z93QXPHdBl5SLP7ZzQDwky+pygopRr+vesummHU6OFUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-YFQGGz8V6skQj+7WcmGVIIg0aMmxOLUXqSGcPuOO3d/KhnSWFfxHy1n881Q34rtQGcZqx/N1AjIBu9irgnUENA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pt-BR.xpi",
           "version": "102.0.1"
         },
         "pt-PT": {
           "hash": "sha512-q6vxpJjkfO5GLgYg8PolmNeYB7Z4vf0tZe5buUblnoxhBF/R1AISGnpV5wg7SWk+9ckNHZHEIY5Y5AkfgyKLXg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-kg0ZJhLAhYn64Sa3mTWlZ16trD4oO63In+aDiSCKzXRJkDWQIZirioW2wVjT9hnD0CpzjZdfveEwTj96ht6Z0g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/pt-PT.xpi",
           "version": "102.0.1"
         },
         "rm": {
           "hash": "sha512-YJ1osmKqD/Lm+8anlcfGCJ+yYS+E3CTxK1LBob52c7CVubKh+3pmo6iLGQRHcjey+H6lEdEPO9TrUHoIUwRVxg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-H3e/Xgm5qVi2RvPAyfvbPEVMwTWPzDjpOZOXZA3PUr96f6D2DkfkUABioKlm63wHXlK/FYg45uD+hJy5kU5DIQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/rm.xpi",
           "version": "102.0.1"
         },
         "ro": {
           "hash": "sha512-yiEVGGVZMsbwxPxZfqSQ6afuS7lwfsNkwKa1F6mn5pURHpCJgdF3J8JU+s1JszdJSgxahWbqb7j6imlR6pIvlA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-e3237nLKSHT7L827b2HR3nWRl2zyukDWwcdEYPdIWhqtZ9yXxVBYBC7PwnIODlZZUZMB02dYdJcTSnJUw0aR0Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ro.xpi",
           "version": "102.0.1"
         },
         "ru": {
           "hash": "sha512-skRWytxjtkI5L+FIp+//FPH6g1tOoa2iFV40kTwiOxruun5m9Jc/4pI+7ktJzhUT7iarfXyOWKsv/5NlMPo6Vg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-WATeKJKtk5etlnriNezDStK654SnCR1PB/FcUHmvAz+YshJ3Oa/X4isLbws3u/rdIZ6SDCCu+lq8VE0IZNkvYw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ru.xpi",
           "version": "102.0.1"
         },
         "sco": {
           "hash": "sha512-VNXouIrPp2J0Uv2RsFcaZYF3i2n6yReBYz4cKG+7QdBHFJu/kWS23akc8/rZv8uupJOeszIQr7p1845HU2N2MA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-xCX8L5trka7E1yYRVLQq7a914iDqEV3LX3oLaMQ18u42QER9Llc21sx6mtSvkDo0PuruCaZzc+2DnePlsSQz3Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sco.xpi",
           "version": "102.0.1"
         },
         "si": {
           "hash": "sha512-UsxfskZaA96dn1VbcF69xqCOXbJq5iMQlk1jHzXW9V8T97GGMLq4hCWp4sTQUd7wzJ5fPv3dOrbnpRzJblBPVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-zChcW8p3ZHKuqT+9OjuouKEHMLySs/m0Cf+VLRG11YejzArN7VLP4euRaHfziv0/3N2e4Ce34wMn34o6M/ccbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/si.xpi",
           "version": "102.0.1"
         },
         "sk": {
           "hash": "sha512-lx/hXGgV9Y4uIeAtM8laEata2lksc62iRYoMJWzYybEc+cZgLL/iIz/JDezEYSkfab807ibtANaEe+yrYtBOAA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-WtR7PoiPTkkuJ2LqLc04CcBpY1xbMZfCCvWF3J2o2KoH2tsDPW2lRPd7tQ7s55/QndyCHGQzoGKp8DNxpcM9uw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sk.xpi",
           "version": "102.0.1"
         },
         "sl": {
           "hash": "sha512-OjeCSogm/nXwcYfsAz9Ah+RLD6VncWlTGVh8MM4W7wmFpEvmumPIEdvp+XX+h/kisbFLdN4qYHPOm8GGHzLSFQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-RXWA6gfQY6ek6ltKFIENgO9dq6swpqpF4VqGQh7b6g+igMcjl+TWgKZ75u7ZDBvjBKj3fIwKd90xOar3j+fMRA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sl.xpi",
           "version": "102.0.1"
         },
         "son": {
           "hash": "sha512-71HXnGEBNzpDq77ghwGIevm1kppwvxOuPCdsZol031I17Qp9J8Qznbt06piBn22QgQAu4OsL6D2TSb4ZWHdH+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-Fh1sbo9OSrk54Nol5Urtf/8Q+nc4XOBz2QKW3wUppdFF32H0t19u19TKn7dLwjVoX9Aq74Dh0/OQKPSfa+YNDA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/son.xpi",
           "version": "102.0.1"
         },
         "sq": {
           "hash": "sha512-qELnJUw9Hk2/3gezY/l9lPI6PfXDrzqLg5c5FfAp50Dpzc/VgKSG2O8Gk/u1jyi3dEFXdTlGlY2UVLcw9lSyPw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-ajGZGCn/frPIc0iPaMMVyxb7Gfq6/rrJRFirzekUGV68qr8rh2LGjnmUVS7uvgM7Sxt8JPX3KfBAdfEdmwHxDA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sq.xpi",
           "version": "102.0.1"
         },
         "sr": {
           "hash": "sha512-klbQ9xR0v5v2u6LfF+ffkOq9kq24NXyHXCDNztd0cWcPKo9+hh8Q2MhRJxQ6lMsI7ycFenysd3HNEWkoigNW2Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-GmOk0zFVNWpyL0ViioNdBbDiQPQcSmFBxfjVmBgAEVVRJLvPJotPyOTOsPqHmc3iXd6rCu6Y/l4djsaf4SXO9w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sr.xpi",
           "version": "102.0.1"
         },
         "sv-SE": {
           "hash": "sha512-DyMRWARA022eFZb/KH220BlhDXhCyFoNYlp3RwebSanOWU04woXhMZ64D2nG7kSTuyY2aetOun9+aOhg3QeLGw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-6EQxS0oT7rjbvEK+Zj07w7Vez06AnN/WX1EAj/+fXMu+ptPnJjTnXPE+l1BAQFGU4V9rd6Z4r7L162Fob7Aqzw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/sv-SE.xpi",
           "version": "102.0.1"
         },
         "szl": {
           "hash": "sha512-3DBmZrvVMxdk4o84lup3/KiYq1C54Rh66TUXKOAqpx02pFm3FII0qqTs0bZk13jaNk80xtyug80PedDXYk2IGg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-UM7FKbV+JiKnUTizP0DSAo84xSQZAPlwow4DSExbFFjIxCtN3KBeDNhVHRWkBE9v+rR7cizwYUsgnTyyRBEC6A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/szl.xpi",
           "version": "102.0.1"
         },
         "ta": {
           "hash": "sha512-rXBVrxlyQpHDwZDkcK7eqKuULqB1s5pZM30I1VgL1Iev0KUhG2uHIFQ08rYK8bPMdq8/6fS4ymyuIaFEXmmiYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-O1bt1Fhhh9DE7g6/mmQ3kKBSPd79sbc3h12oSwwOhZybT8uIxSI84gi++azNrqy+iFuXF5fmXU4y4+/MJ/cXKA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ta.xpi",
           "version": "102.0.1"
         },
         "te": {
           "hash": "sha512-u9oWStf26IFFZsLrfwKpzcSd5WEHHXin7uCFWXrrHgSSrEXdWSDGetSaeDV9WIvxClA3PQ4uw5TQnoVpsqIm9g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-hyucqd/4OInHvLlssgjw4SKavpRy7rVT/3aIhUTv2j2g2XAbOOe56N3UvTcrT7Oux4aMhW1u32wGaN6T5XrS3w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/te.xpi",
           "version": "102.0.1"
         },
         "th": {
           "hash": "sha512-InS/D9uTItNCqorKfR8ubga5MAReOy8aUXGYa3ab/KtM5RNVmakKBcDeD1n1b2HWD492pHSD7f+pbD/1R7pcng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-NTDt6LTixB9czeZDyh0rP2Ri+xBlXqt/mIGUZKf1PLQbfHq+PjTIUAP9KvoRaLRpSVrpfvD4eM+JPJVStq417Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/th.xpi",
           "version": "102.0.1"
         },
         "tl": {
           "hash": "sha512-Qxn/2c05Fx8+IMSIhnLs/84qAPkZx2ibQu33TpKRQcDndF179xY9O0LYvUfwE+TLexV0AOpfJZz/qsntMLiG3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-Vw5ogzv6ORRFASCi8E3UrcZ4h0RfpGBe6FqNWSSomeILtsZRTcwYh8C6QkvMMxt8qOXEYTfVJjbSADhkaUQSVA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/tl.xpi",
           "version": "102.0.1"
         },
         "tr": {
           "hash": "sha512-hBi45TGZllPGgcDxPCZz1cv0/WVWZTuRv03vxnznuJzthiWKWVlUMvZ0yQrYT0rX7UF9xEv49XjGlVfzyOxQ8g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-0Ihns2KWEjUVugBMNJey6nxvSThhJSsY9v/ZhOkV9gfWi7olLvVt7zF7fX8xsAkguM5aiTQfPbEDPxmnovYBaQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/tr.xpi",
           "version": "102.0.1"
         },
         "trs": {
           "hash": "sha512-da4sIHhPCL+y9z7g9Ov4lFlBAWgjrDMBnHIKZ18b/CIjixo3lxS4dx4uC9jcgPMpuZj8XgzxTlm+MahMTveJ9g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-UClFGYhlCI8p+OKJgzdfrLMFW09ljkILyQ+xAdpRwFlBPCWUzIv2Q4BS+iJsLWM63KrHkd80nYyo3DlFu8trTA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/trs.xpi",
           "version": "102.0.1"
         },
         "uk": {
           "hash": "sha512-2UjAtuF85D8gnTUwCCcIKkk75YWlSQyhtsEUjmJu22hQCHqAW5zLnwE9ik17nOWgFBo2UWVq/HvFlv+lRE6zkg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-IEcP6WGGdjUnAmdktz9DQ6+KA2Fhsjm+qqKD4vhKCqkMFTlm13xCIDU3FZq7hhK1qqX21VVIeCY4IL5Zbdz7Og=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/uk.xpi",
           "version": "102.0.1"
         },
         "ur": {
           "hash": "sha512-zWMUfI3KU0Y14Ia+zukaH2GKsU35FoBP0TVfJwe/ko5xAhECNjSPHBK5qcRQj5Cyf2MLXM2ql0rysEFzs1eIgg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-HOP6B44xWFqOciqOHhUCakMAfOn/xip0fUbbgW9fgTelUi9gwdSnKzo5oouJ5X0V54HX3385S2+s3duMjr1IkQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/ur.xpi",
           "version": "102.0.1"
         },
         "uz": {
           "hash": "sha512-G8NP1POT1odyO5d0BjVYE/kVsugrPMZHDWmm7VB8LVoaGcTJrFpVPxAHm7rUuhQD0YhADU5v37F9i+YX77WDrQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-BgloPY5ghQlnMNo5dmZ23MGXtuQ2Iii8nn6jAeC2TR9I+l7FrLg5Tppu2Fw/8WA0nvW8iCSYX3CAaXUaPy0KOg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/uz.xpi",
           "version": "102.0.1"
         },
         "vi": {
           "hash": "sha512-UdMr7OwirJdpFt3pUC4wvmUw4mLxATSZ6o9hr3DEXS+K62aF3+hYvjFJTKRdzrVRHPjAO+nKNFJL62i3c9UDUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-ovxuXuhbFomyP1AezY0n2fpWsio5DLWq27DJ/YvXbgB2ULhmzSj91iMvN6mx27yLJNlgbtfeyptDCHuFrz/9YA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/vi.xpi",
           "version": "102.0.1"
         },
         "xh": {
           "hash": "sha512-BguzJ2bM9lEi4+A5V9dmHvvfg6pr9t5cuMZ1BCNGc4AG6U6IdCdCd83NjYanoV4BJQy28PlHrx6NXhjmK4PdbQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-dnkq0gUuP+a9Lpk+7rVNvXPcfgjjabjVG4c4plW+ioReof6kmOuYk5kamzRUS4SzCQMq6eTOX5J9IXxCMN48NA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/xh.xpi",
           "version": "102.0.1"
         },
         "zh-CN": {
           "hash": "sha512-9Ai4latfveY/12SgMMprVMOHqrK/0QbrFGgCN4EwoV+oZ+3kfp56+1k0SIpkh3eyHtpJPpqiGJs6A7O0N48CDw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-A/eYj67IrzZAWsFoofsIOE0RpUjmzjXCU03H1UNqFSQjTgQAReztYYsDr4ZAyTLDNGCnenXGfBRDLVpgcQ21Jw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/zh-CN.xpi",
           "version": "102.0.1"
         },
         "zh-TW": {
           "hash": "sha512-/ThJDr+NTOJHnZQ+hAowskb1So/EzIBLOacoY1Xze1WiDIV61HUrcdEmZ4T/9afNGWBIqUR/nmX9wlgMJSz6HQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-1J9rFhsjDAiL0BwJEzOv6I+l8mudOVGKqdnvWmwwSfyKFgbovTj89DYja2mWWVo3lhMe/vRfAUN1BOrD2VVy4w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1/linux-x86_64/xpi/zh-TW.xpi",
           "version": "102.0.1"
         }
@@ -1976,491 +3152,785 @@
       "linux-i686": {
         "ach": {
           "hash": "sha512-fOT9MkGxBBXFMB83rgFkXCI+dZ5iPmIpO+n2s23NSI3oJ+nrP7h8AMiblhEcMXVG0C1RdnlwKnD564KYKGPvVA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-R3tCCjLl1LfH0uCdWA/NRq9MpmyXOm/aAVW14cYp3lzoGcYbbvSMQBNe1E6TD21rKmaQNWz2gS1lnTe5c8WY/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ach.xpi",
           "version": "102.0.1esr"
         },
         "af": {
           "hash": "sha512-90rxRRAiyDHjuPp/U1+KaS8nlhnD2doqa2H0tdoADolu1d+j8zr6i4mPW6OgFn9NZFotubGQ2nu7fNBd08nxhw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-wJVYRDOwn/wvw4YjRpFTLXJAibEVHpWu31psVD2UNs1vlyDcJahQAU4esEBd6oI0XeP5tgMbIE5ZPVK1c6rVTQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/af.xpi",
           "version": "102.0.1esr"
         },
         "an": {
           "hash": "sha512-4CVHCWVi9j5TC8+QQsD9opx6PyndDUa8v3j4Yt5SaSnmkYAB0j+jp4AZorhGQv9g2NOgaXO2v8wSplXWTORjEQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-vtYYVKG7WZr0ytFMLYt4Y92zzkr7XYZkdmkw4RsPvzvhR5G3BgreW9CuyNObI+y3ylStSjfalPXURkcAUeDHHw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/an.xpi",
           "version": "102.0.1esr"
         },
         "ar": {
           "hash": "sha512-/Coe4lkTx7u+Jxs1Vg66Ues47GGU+8UqqKmaWGZGzVxXOO8QqrNngAnU5FL9sKr63/f/dnjp6YGMkbVH8mHbJg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-3ug1dpHqkODHRwM7Suv2Mjt4tBk174MDE9j4SlmmYW+si9qRyMTxC/yMa6hPfCx58CGVQsWjzBzm0GXUpjJHBg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ar.xpi",
           "version": "102.0.1esr"
         },
         "ast": {
           "hash": "sha512-U++RYOpk8JlZEdXW5IkAWzU8Bn2FptJYeeaEQrQO4cMCWtDk7j5InZHaC9G76BZDNgE9jDxpwZGJqWKJ72UVmw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-NDO0Psm18ixm4kiKSaXmU8aqVhaBBY9Fh+g8J0HR2nQIsR2aZ4CeCZl2lnMRziw3cH+8bgKsy9GgSqBwBSRL9g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ast.xpi",
           "version": "102.0.1esr"
         },
         "az": {
           "hash": "sha512-Vprb8wlkMDVtW89ubh04QuNGZvLZlqSftxmOXqeTAtBSlQTV05s2Vry0Y5W+bLznI/jinUIuxh7nIG1ExOgjhg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-eqHhe2pWz/gddgim6pJ4pLmrDxG1Q7qOYkVGtJ7NP3tYCcOU2hzIKd79TJwkBpGBNCmv3O2sgux/PE6Y9jUisA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/az.xpi",
           "version": "102.0.1esr"
         },
         "be": {
           "hash": "sha512-edhCuW04GUwiaBCHbgP0FeCW/rYRAuNQL/sIqQmtHDEfA6VIEEAavJ5f1x1FNM8cFerUa2oERLm0lB0V2nG8oA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-JkUXI2aHS2o2MRkZnuCzk4DB+2ZpzFwCyyAqMaUNFiSLumx8EW9a7ZRQ2+1dVBaM/lX1Cobv1TdiTCGSMbinpg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/be.xpi",
           "version": "102.0.1esr"
         },
         "bg": {
           "hash": "sha512-Lg6nAvGabGex9VL1+EB/baBzQ04UZyBCuYbANhNrVfG6NGrzYqmHRYR7Q4Q3g1P7zE3zS2Pu7S7lCvJWO3opzg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-E63y5Wpvaf/p4LepnULi5wF/hQLHduyDJ49NmyxQr/bHRHLW0kEOWoCvJYi6u0SsyuGGt6RjjICWt8sy+n0pwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/bg.xpi",
           "version": "102.0.1esr"
         },
         "bn": {
           "hash": "sha512-1grP1QxbgtRQp+EjECjwkhKVg+5eQL0kZ0Ean+nS1Dw/DfK0iktwkFjnbVyV4FGsJ96nSeHdpZBtVY7Buoef+g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-T18+Xq2E8pYqxG8Zn3JQFXdKN6DbhnP748aQ5zK1QJP5lnWMR4NT3FxDAB6KvC4xi47lbxNmvEoHOL3tsbynZw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/bn.xpi",
           "version": "102.0.1esr"
         },
         "br": {
           "hash": "sha512-jdIvoHOWWYzAdBbTXfvjH4dWFLiGX64XKkYtFqn6KltWFff752tnP4iUhpdeqzuV7OzDNocKpoHHo4Ooa1l28A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-9ZoNcUhdSa6EUJJrisg3vXvj93MEPElVm3xSGpXzxtemmpezjcIfukps6DBV0MZiM7TbfR5PWm+Qn+I1azAA+w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/br.xpi",
           "version": "102.0.1esr"
         },
         "bs": {
           "hash": "sha512-PfXMFg7HvsnJjv3OOW3FYywXjpOrFT0trOMWp06TgRXaYDDaKYiubFcDoMwRgXbNqn/igt81BwqCL3kv+CYA4Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-X/p65KU/hua81n/dihCmpx6ate2E3vXWWl2afaNavMrk8+RUsYudVdLqyBl92mWVXRuZob6SkToorknHiyv1Wg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/bs.xpi",
           "version": "102.0.1esr"
         },
         "ca": {
           "hash": "sha512-yrEXD3+JTNAGpQNrqqn1g+sxQ4Cw5/5kN5Bz5l5PO3eZXRvKRpEkiM3ydKRMhJ8DzdLWzsCSdUqVtvOokKacng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-kK8tI+Wb6IPV+NV00sFbHBVTNarFTR1ZmHRGFR/l+D8qcxvJolLtxmj5akMG2VhcEBQINyn6CGWI+PE9V5LyxA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ca.xpi",
           "version": "102.0.1esr"
         },
         "ca-valencia": {
           "hash": "sha512-jq3DXf30OHftz/wwOb3wmvGrITMBPUPW4g1//pcBHyMuHDFr0N1BjiWPS3tb3jEbwHY21qEbgtMNfMvfNq4EoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-itnloucnW01tDGEjlN26ze2UgeRyBgcV49lOPAq9fMGlYWegQp+KSbzlRlaAn1+iNcrvB1KsVytK/EQYQ+Pr4g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ca-valencia.xpi",
           "version": "102.0.1esr"
         },
         "cak": {
           "hash": "sha512-ud/JmOJLXW0K277njWx7Gbj+81QLwwrI1oVxZ4KR8zae3ZNrlW/Az8X/B+9dKvufg9KyGt+YA2jfcoVeMErNoA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-6O1/yUwcOetK0qQT9xbihCf4JN9tG9xzP31gfdOxdf8Qu8ecn7Athn25ijM8sAM/wAWIS9eF/+oSAqQY5Wo0WA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/cak.xpi",
           "version": "102.0.1esr"
         },
         "cs": {
           "hash": "sha512-fR6Ea7U6QZpMRj31mSA8TD+un71aLLs2fjfOOLCAX1mv31Uil3PDX4N9IxD4XJWehPnpGzOa56sluRNiTbi/6Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-eh1r6msUQsU/vc6vpso/RnB/adtsbjutl2mt4W/ftPOp0T0B+cKhIrgr+PknfPut5PMAyKApV5BYdvrlHLaNcw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/cs.xpi",
           "version": "102.0.1esr"
         },
         "cy": {
           "hash": "sha512-6ss2va/hZTHAIvQTDY6A1gQXWsmfWh2YMsxutjITmz/VqfqGXTncjMwyZE36CpPUFdKX7iFqtanIAdyhzg2iYw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-On5GT33wYTluXaNhBzo1/9ARwJGnuH6eRVusrBIvAtucsCZ5oQYMtKf+EmgdmUQRTLCbL+ROQeseYg5We7TKBQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/cy.xpi",
           "version": "102.0.1esr"
         },
         "da": {
           "hash": "sha512-Zv+sDKjaj3mqbFUhPkJkPoVVfxAYDK2K+G1lMcKhbp0D60dUodLavUTUzTjtjSVAYnvJjvbBP8Ea6N836ymWoA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-f0bR49stME9SeySkNZF30YApjZ/tRNUttANwy8QFw/fdjG5N456hfhrWNhce5YZ7wgqtzWHd/7S7eJju/dOKkw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/da.xpi",
           "version": "102.0.1esr"
         },
         "de": {
           "hash": "sha512-DPGxDbgh0ZWUDAf4Cx+KKTIHc1z7j+T4VeSMdmLf3NIbOtjij9PWWkwlS6vXeu29VP58SnaJ6tCH/cNc33guAw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-d5HERvbUVlx14K/oABRxv871QL2/7qCh0rFepzJB15rU/U3hZYt4OVDeU1hr3EZO2GGsK4j/zi5NnfkjGpIRbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/de.xpi",
           "version": "102.0.1esr"
         },
         "dsb": {
           "hash": "sha512-TmcIDdyR4atcx+4Nz+2G9xqmE0E3/aV+CmKuKw7Xv8MruArkomMl2B/664TLf7LvQARGlBoxOLAaelkt0hSzuA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-pKImlOIv0FdcckqQtFUTC7Txs88LpwrRJ9X+Yky5P+4NZiWAGyrJ5u1011ylkQyw8yQlbUPkyBYOwzGKFVkdcw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/dsb.xpi",
           "version": "102.0.1esr"
         },
         "el": {
           "hash": "sha512-0M2Bl1oESP8nBjHDhgfyekz7+Lx+snklJgYQlZQWGYFSBIeIeg1+yEUth/OCxctkQxPN/7NV+E5P9tbjvt9ARw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-N9qZziL0c38yZHqUhtLp5CH97cKUqS7NgGGIIGSlnazDaA+pRxQgjNNxqRDKgj7l1kPlThlGGCQEGlDDKakWMQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/el.xpi",
           "version": "102.0.1esr"
         },
         "en-CA": {
           "hash": "sha512-Ih6zQrX6amMMYnexzV/kooC9hdDno6VuwbgW+PKQT3lrZfk45TRGRUdRsV/QGTcl4PAsh+A0u0ZS+xTzoEPXng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-aiKGFt7XJd87GQymcZGjMNg7UFy7N2rkclq78rkz765/xjzqYbKaR7ixsShOXmmc0Ed+3L+Gf3ArnsMQ/RPVuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/en-CA.xpi",
           "version": "102.0.1esr"
         },
         "en-GB": {
           "hash": "sha512-gMV/IKCDsRxzuApouQDRXDaqPl6pxlp2gkrZsz7BjgruLqy8A9r1jupbpdezdPEyPnQ0ItgAbMZ4otg3CWKg4g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-aUUMlV6yNyoYNklKtN9oCLxr4ZCujcLI/oUZNZT+11dlMBPmsL0idsBT/C5DVeHsez+0EqpX5HmjHYE2NYF1Kg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/en-GB.xpi",
           "version": "102.0.1esr"
         },
         "en-US": {
           "hash": "sha512-LcTovySgqLbyoXKXNwLSF7PPhVcJA8UXOh/wEyWHWamGCTozNJGDxWtTW4LuSDpklnSsNpIC2rl1c3FnDzmy3g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-BC2xVzPWGVNnoZB69WaUbWkYK7IIE+7ahBKQ8B9VzDb3x0JKQaFk8JQ362/laKaMmo0HPlhY6Lvc27gMQ9BMCA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/en-US.xpi",
           "version": "102.0.1esr"
         },
         "eo": {
           "hash": "sha512-NoyjpXNWiWHAlYWaW/PT5vaEQRA0WaiNivtypHuJm4rbwT4rQNJ0+9ZBBXSdmQE7Mn36y3eMSVEsyQHITHiehA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-cLMsu0P+IPOAqfcUOknklrxnuJZgiOkud49b52MNZxXA+5cpAWv3/Rs8cOX8MlCEw4ryE4FaCm1J2D56r33k/g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/eo.xpi",
           "version": "102.0.1esr"
         },
         "es-AR": {
           "hash": "sha512-qaPae3LSc4sqBJuriwB+Bi1ISZO9SxPqExfcbhTz/1kbMiP/QeDQ3IZL/GQW3dhawukwVLzdxZTBM9hCp5ebXw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-2IXdKpnbPR46Ud4x/f4SwFpqBFYTCPTrlSAgOmbUx8cKiBHeBGuH8DBMg4s4uqn9uecpZjCbFleoRCEYb4gp7A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/es-AR.xpi",
           "version": "102.0.1esr"
         },
         "es-CL": {
           "hash": "sha512-e/tFmCAKKGqSsSVoSHzrT+kgmIx5Qe3S4ifEcs/SdoyiChDaAuJHDSr75ztoKdmu7/guP1FrJnus4rYA6H8obw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-so90uOZvsld3JCpXWbIeUfAE6Aarz8+zRg7ZxAi4V/nWao5whiBAQUaDFL/Na9mFsKVvuroCXrhM5xNW4/5Eng=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/es-CL.xpi",
           "version": "102.0.1esr"
         },
         "es-ES": {
           "hash": "sha512-uppeihopwdYQEWQJ/rOoRx0Gw0MDn757MnB3OP7y5cB4gvA/RqRHkADvudINdug4yIGkOt31wZESuJogC8Kshw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-o7i+yo0wFulFdgoqVNhtDTZ1cQBovgwEPFtvykrFWuzfRQgeBI+J0Jpkp0xbAkcdHucmKTqZVLRsyLpPOgY0jw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/es-ES.xpi",
           "version": "102.0.1esr"
         },
         "es-MX": {
           "hash": "sha512-Qi+8OTLHdya1rbzoFo1kR3BoREcG1qJS8hzAsDidJkRKGu3baWpa+cY9myEV0Nkk+mKvafNYkEhAuHUrMes4uA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-fD5k/B7c4MMGDXVt+gxETavuVcQfXB56wr2YoztmGv+7g4Lz+ZQ3yuMxmdI3V+Jtywfdr2sPNJAWsYyir67hOQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/es-MX.xpi",
           "version": "102.0.1esr"
         },
         "et": {
           "hash": "sha512-JXL22hB1I9e9O4dbCW9qJSb9gfTPI/3sTcKYdnIq183eyDAWXbHk8ChhVH8MJFnOnn+3tdLBI/V7V21F/EApTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-vXPKTjaE7OPLK11CFuQGtxBTv/LvIYCS504aHIxclytDcCRW8nz+JgRxtj4o1WvtvRItlV96VcCO3msxd8eO4A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/et.xpi",
           "version": "102.0.1esr"
         },
         "eu": {
           "hash": "sha512-Lf+7GkuD3sFWL+CMKLVTeosDkihqpWdmGfhPf+Od85NLd8czEoHCt5IM6Is2mZBDKz6BZlv8JsrgQFnoFswOlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-u4axBE6Gg2ZlZKefGipKSxA5O9DLJcY+JShD/IAcY+EDzrSKbB4XCkI0YizwfLhUTD5n6Z3ZmsOWWuj0/KbL1Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/eu.xpi",
           "version": "102.0.1esr"
         },
         "fa": {
           "hash": "sha512-8PPFs8dVFRs69NmGlBdfmphMFOTZCzfWBWpRVI8woFXfcnoWPxdaq5NzLDapoAw4KnaE7QwjLELzBYvc6Jv0iw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-u4wG2SvpZo7q/niPFZqOkT+SohxGG6PII0AvgcF4+fyVxtS0hw/gsaLGjZD69JQcWb6UdA56YHhQ6BWg/+SI9A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/fa.xpi",
           "version": "102.0.1esr"
         },
         "ff": {
           "hash": "sha512-DeggBpnm2/x1DRjIrfRARgx+FRTPh8uIhLstWtmKo9O7MmDglk6fQj6BydECZ7wFKZ0PjiYMVEeR/GFI4k1DZg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-pBDvbBAM4+/dQ6DVHkzX30KKo1CBttjUZaWjFsIPa7KJfLxGbUuUK0oa44rXAyrW/4RpPtE+KZIOM/XrlAIj1g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ff.xpi",
           "version": "102.0.1esr"
         },
         "fi": {
           "hash": "sha512-/m9LtJcnETTAvflskqFGE2za3R8k7nEKTouNZIRFvyfIk11bV5aIP7syXURgyc0Eo0c2HtQA1CjOKlH4QkIv6A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-Askj/jc8fWgN3nPhFKFdA/ec7VSxIh24JAxMDb1JPjAYpRwM4baKvgqx5WS2My7h63uMvJnI2YHiOCvzaXPrQg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/fi.xpi",
           "version": "102.0.1esr"
         },
         "fr": {
           "hash": "sha512-oSfKdbNkmxv91t72FL3nGhyMsjj8THSj0dZnRoxk+5izK7FuiHuUzrMXR/vRJL+t3CBZjSly4CULbpo0HoRw+w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-h+aypUP9dKRzNUa2NMWU9n6lSRipSOPRJe3qdCDatjuOiNg4e4BfInCog/Km4tFkHWE3CVcqPhWhzEsa8xHIlA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/fr.xpi",
           "version": "102.0.1esr"
         },
         "fy-NL": {
           "hash": "sha512-SoNM32fJRQJDQjjnFJJWQuYcmELUcb4AfTJfD4cCBHZVr3/hrX+B/V/wI43Bdlt6QoiaZSrHV71/f0oneUER7A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-JZ9k3IfOvJGCzr0dFOyxEA65uEA2plrCINckNf5vPJ83X94zII3jGBzcP08ffyA4274eaUwYLzuD1HZmw9hFJA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/fy-NL.xpi",
           "version": "102.0.1esr"
         },
         "ga-IE": {
           "hash": "sha512-0s/g0tcfxyUsD2BGkAmx0EEbjlhCx8oMncoDBjJGCJandQ4sOc+MhNEAobvIDHk7pQFat4NyMZl0BD1XO9JT/g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-JpNLHQvSExiklR8KorVb9LleWEOG8cYKBZU6kTgZiG5ieOh8ccYmypd0B4AoSLultgRwb0rOBXNNRzM2FWUkGQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ga-IE.xpi",
           "version": "102.0.1esr"
         },
         "gd": {
           "hash": "sha512-2BSPSPfRSMPo7ujOoJ+bx7Rv447HZ0snxg2SOISoUwFT020EXk/+19kJpaYpLhDDpr1DzeaJcybtL8zZlZaTdw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-0lEuKOqxkK0PYDCSLv56+rcxOFkGAQa+xDRvKoQ6qFrL4U9miexwRvO14cPhXwglnLMkTeVG93QxvXEPtRsLMg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/gd.xpi",
           "version": "102.0.1esr"
         },
         "gl": {
           "hash": "sha512-RzMaenmTwbX/lOlnkqrHhSzHWprRwgaZtnHPpX6y4tp5CbnWxHEwdkQ+aO56cxB+eBQhKJ+jVIuWBSboX3DJtw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-t3QaiPLSiFQlOv5YnHlp+8RbI76WUBm8aYPwjZD+O2nlH9JFJY497XCRCV7kjPryYy1Z/7GsQpxPbO+U7aoeHQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/gl.xpi",
           "version": "102.0.1esr"
         },
         "gn": {
           "hash": "sha512-dwEgAJHgCzln/6ccy3iZ+EJvv4AGLfW0QeleXo48b+HqC4q0XP30rYlydwE0R6j4AKS4B8ngd4SAj+q/UhdV8w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-PHM6NbQdrKoTDOzZ8TWXOTYx5N5gxEOZDQZl4LLKu/2kjcjU//IxoBz2LcL7tkSi6I7Xi4hmFQtLBdDOwvixOQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/gn.xpi",
           "version": "102.0.1esr"
         },
         "gu-IN": {
           "hash": "sha512-B4oLEhsg5sEZxRUhn0ylmkYqD1TiMH0roDi7+koFaMCluIuPOPsknDVkqLlLx5C57TeTNqCwDjIFhi2wC8Wg3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-xEzsLpj+AzOxHmysGvADY/lp7dvev5DBhxNmf/1UhkbQib1EyvasmphF9bA5UgL5RQHN/3yC/g7hoOTGthHUmA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/gu-IN.xpi",
           "version": "102.0.1esr"
         },
         "he": {
           "hash": "sha512-N/29ZWG9mWLC/9gwZg4dEcsyprh4SJU/8luaMHHRQpYKjGvIZggHS5dqjoSXjnzErHoeKCEi/cUYzxmfZOyoCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-q1cb7SD2hjNe4diErylIcS6m3yO/JvfTfIiT2HxJsErDR3tc3O3U0DMcaAQiHbTbJPx/K14nNbBH8n3pqBGKuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/he.xpi",
           "version": "102.0.1esr"
         },
         "hi-IN": {
           "hash": "sha512-HDvjSkHFH9ggeN//DtlhDjir+zf6vpy+kWn71DD4cer0CaZWWye0D8c4KmBsNCgS44vbhdBhEuabCeUpjB6Mug==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-R3vrYihReLuin2dbL/ETiUGG80Bur3NW2N6pIaFrDXM0OeMIzdfuD1q4NDYyCE4eB/K0SS9s4YGHIxZzieHCMQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/hi-IN.xpi",
           "version": "102.0.1esr"
         },
         "hr": {
           "hash": "sha512-6a0cu5EQho6YThBdrvAzynrNOicjFc7QH1jOuy/+IP1a6vh1qy3qLN2TXYQ9LWh/t6IWswByyF9cBWHJ258fqA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-BcbopuRPUpDpVczkY5r6c0uxCD28trXXrDd909oUssF+NhtZ9WgSyRYdsAf4tm33ecrlxfk9uMhQKhnNNcC1EQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/hr.xpi",
           "version": "102.0.1esr"
         },
         "hsb": {
           "hash": "sha512-QVOLK/z3z4vuBxPvqsuAFqprnNYXkUwH/Dy189FyAFJrNXst6qmVnMB9AxUSlsWANB0fZVtp7xIXGwJSLLq9cg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-BU5m8w2bbnsCt9sbYnDe8QfgH655OX1sL7u99ytGUqF7d7NGGAcw5TbMw9rc+d8FWyetqNcvsbfIhpHPGx/2NQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/hsb.xpi",
           "version": "102.0.1esr"
         },
         "hu": {
           "hash": "sha512-PG2+SZYUHd8JkK+gpfxp6kapTVAnWYEA5QkhLl+n8ufI7WGgnQbbshag7HZDgLj1ivfR97x52PZFuxXu/Rl/Yg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-ZnLRPH8S7inoZTd27DpNgLxzILAFPfkbWxrxPLxNeg2HNTfbfihL4WmYd2738vwG/Dkxgq6J1Vt6QPgyQiMf9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/hu.xpi",
           "version": "102.0.1esr"
         },
         "hy-AM": {
           "hash": "sha512-h2PZY+3ezPVlz3z5NPdk7XNP5Hyup0k+Igi2JiS7r6sRGIJvUP1XUfSl8YKIymEVIR1mK9QazDYCt8OvmONeVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-4pBF7ZDrviEYEZ6HxElVbhF+R+ed2HJ3yWnzuExaf6xREYaf+2O7a51e0hM+SUiY7ac14KcH48u279QobzqPPw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/hy-AM.xpi",
           "version": "102.0.1esr"
         },
         "ia": {
           "hash": "sha512-9HJ6qexKZA8/opo+aGt+8RVJR3rn2PeW18UJD1HfX2UkrCzFcHqPmAszCJVfAwD9LOKZkwqPEgDM/4MuHFmbMw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-D8+SbzLSlCl7o18HMlS13hRC3CoNdLQGilaqeBKyxadQQStkvq6OQm+kokcrdTLJIXmRN5tyNovAHm2mh/gLjw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ia.xpi",
           "version": "102.0.1esr"
         },
         "id": {
           "hash": "sha512-s5np0ZMslMtvPwvRLhpIVu/ZS2xw2YBNdCct4EOvck14ti7qSuwT+WB9uKwlLhV4wiXKKXm+FDla1Mc3POAnAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-vVPHvTJdvgn8X/EwAbEj0L8GYcd3tyxv8DLdxJJcxjLDR6oSmqhwmF8vnegLS3/HbCf4ajT2Oh+uMOSR83XuzA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/id.xpi",
           "version": "102.0.1esr"
         },
         "is": {
           "hash": "sha512-SmQK3rrerXmnGVQbQ2wbeKZ7oEHM5MGSdBO0VMSA6mhpx92kgtAi/VTilWwZwT++myYwICbcf0q4E69hzbLQng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-/KGuXXQcCT3tasKFFBd4YhSrEN4GyDHcyqof6ZS9wUA9RRqOT+Pv3l9LpkgImWKhx4S9VrX/ESPBReLGEYSZ0g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/is.xpi",
           "version": "102.0.1esr"
         },
         "it": {
           "hash": "sha512-EekXEc9sbcJ747ffnM7DgtOb0xmMk27fzgfjUei0c5h5/l9iQt1HEuEe6JiA/CXsQiXX7hgl3b2IxaQwnizi5A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-QcaYCk86GLTam1ylOUAsWQSKNXp/Gphwl2SK25fjuYQu5ml/BnsEAjHu28I6qPu1Ff6oSzCt2HzimO+ZxGpK7g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/it.xpi",
           "version": "102.0.1esr"
         },
         "ja": {
           "hash": "sha512-EdwBfZBJzY5ecwuNJxb4X9yjEIrFJWkxGlAxkU5DD9y27eTNyhXbtl5bl4c4PXE8/UEtQ/NJGdXMJkGTFs9LgA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-yllFrOch0KWAtW76eu/YYo8BhJFmjg7XjYIcDGb5vepLiPt9KImMorlFzPZIWRfOJMEmLtlzfMGNXAHnaJzwjg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ja.xpi",
           "version": "102.0.1esr"
         },
         "ka": {
           "hash": "sha512-aw6i53LWpzQlMNjDQtemXF6U8e3uymRse3E+gJGktG+CYdqqSKnRB+b/5kwScfe8LLphGY1zutLjQ2UC87jcfA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-NA2bd4BCnpokQKP8cbBYH2/7o5nZh8P8S7SGrnMkIIi5QR4I6H036wQXqoMUIeOc4QNmfETVTCZt6Ri5AhwtIQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ka.xpi",
           "version": "102.0.1esr"
         },
         "kab": {
           "hash": "sha512-ZgGDk0KS87gbIYbTCUu6VWPS9NnwnIcwmCbV6sjBw/ZhAF2Ie0Kw4nceNO1/uXkVqrIOUHOaHJXQOVk2nPdt/Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-fkXLv/W7Jq7FbvWEoTjDzd4z34mn3EYb+67PK063JBKEn0tOc1y3yQNOwV1XjaqdMg3a3s0/bbUG6lkBleETZA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/kab.xpi",
           "version": "102.0.1esr"
         },
         "kk": {
           "hash": "sha512-7z0vgI4GnhOo4tiEmTIVPTWvF3zQUqEATXiwB+IJfj6SP1NsBV73f834KQTeA6OW5Yj88XQiLeQd+dbhNrDWvQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-56icWOgpprBmGTuL3DRmghVqcn0obHiO3RlTRFoiHKVsuvviMrfM/A5RfUpgePNuFIE2IcHBb96VN7N1WX9hSA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/kk.xpi",
           "version": "102.0.1esr"
         },
         "km": {
           "hash": "sha512-2/cizMro1JGb8E/LzJVoiSvPCj4DbZjqIHl4NIb+X4oVcT1wWRH2Ky20Vu4RZRvvt++mcsG3le6Q7IcxCEir1Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-/YNBgO1zZEakvz2nKvpwFuGVJMRY6YsnJQ5ihniHLaeflt1jqiF/iBs66BStFGh6iI1yqf/tY+iHbWEo/Eg5vA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/km.xpi",
           "version": "102.0.1esr"
         },
         "kn": {
           "hash": "sha512-ecv5sb6PK3sRU3KWG3LksDXe31FQMrLBjeagOAHic+yTGChM2mbyYlMgp1kv5CZcmuQUZF6xTC8TeN0IluWo+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-jeEBBFgzXzLg4bz2AjvmyvgZPiPPEl319mdql0tAukoNgvnp+7aQl1o2TXVlMN/bkpuPLdo8sbdUaC9gC0v9jA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/kn.xpi",
           "version": "102.0.1esr"
         },
         "ko": {
           "hash": "sha512-ad6IhmsQ4G1VszvPMpaeONuDiY1VM0nJtP1SKeaft6+3zy1SzO5ks4nSSSUrpxS1S5vmNceBmpNykhicCo9J3Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-hDTZfOXfdhM6wQyQJelCgGVwge4sxeiusXTYmmxzie0iNerqF43Rc32BPLdAWK24LCF3Ag4ZFKyPn7x5+666vQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ko.xpi",
           "version": "102.0.1esr"
         },
         "lij": {
           "hash": "sha512-BO0tRNxp+NjSkTxfIPT4kLX2MxsNmdU1972CKgbnXt81zze6pn7daa28UbGs3SU5iUR4iNFcg89qPLK71/Hedg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-8e/+AMAy1sh4tsC1O7TM/LErgVe3y2C8zZBxUqoWos3zwIPNLdsZYYIDJg2enXc3KSpbD4KpCLmZxVA1Os6c3w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/lij.xpi",
           "version": "102.0.1esr"
         },
         "lt": {
           "hash": "sha512-OAez3eZtBLKMAk1nWp9QE0YrnH/4jQQdLRcFVEmm6YbheFWMplJqMyeX2VGKxT7U3qGoMiFKUPJzbZ0tcLJ0RQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-TbqR3acRfc66T4MAok8r3f/f/1esD0sS85JX4IkOu1PoiBPOsfF6cMUtgdmuvkd+7MUmNq7HBOeTV5YlDGE9/w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/lt.xpi",
           "version": "102.0.1esr"
         },
         "lv": {
           "hash": "sha512-TCDAs7nQAE6Cr9JQM4XCSlWJN1n27oyr/LXnx+vBLRmP7lWDw3zOPYaYJDnsOLRukSgjFwCSYEb9uBUj5LweAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-GEY6gOu8jRg7NzEs3TAbL7C76a+wKh7gtAFPgEjOTmIYmFqB5PWNR6xxgJWBW1UMtbDpqMepQ0UIj6hi2MhCiw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/lv.xpi",
           "version": "102.0.1esr"
         },
         "mk": {
           "hash": "sha512-+cXAJUxsP7Bte97eGsSzuBdqvyqEtbsi3wMwhuxT8AUF4qmn7I9QecaSUmhKgTqMqTixiEO8vWdcEXQOTuVwNg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-710xVIfk/L0zUEHVDCkEUIsDhzxFX9ONfUizCZzApMDtGWoFtAZmUqg1eBiAlvnw41fGVA6gS+NdpGpU7BHKig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/mk.xpi",
           "version": "102.0.1esr"
         },
         "mr": {
           "hash": "sha512-r4hp+4eXQNtxdSrpsCjx7HoHG4+usKlkhSZjOLK0dY8ENp7D5tji7dP3vIQ50MP/PHXIJ8PqB3X1C2l4iOCtOw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-S8GwipG3sciy6c4MHtG881M/waN75FdasP1zczYCDn2Keh55kQZYaAcdzSIWnlVuyQgrDNLIQA3EGHAUPcVzyg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/mr.xpi",
           "version": "102.0.1esr"
         },
         "ms": {
           "hash": "sha512-zQr2sMqjGZW02e9x+V8jvt8Ri54+PwF+tTJvgr4lH2+8JbKVvKe90lQtVov3aumxmnZm0aveur4ZEasWhq3/bg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-Ks8t/Y3Y582AjDRzN120EhSN2Eqb+JI3pAYGx9vdJWkdVf3pjkZ1Vkmyf7loQDjuPyUXhAlisbNfm2NccOQorw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ms.xpi",
           "version": "102.0.1esr"
         },
         "my": {
           "hash": "sha512-C0oCn/eGT+rcunRRc1i7T8K4y3F0+giCdl4EZqzdhWbvd7AS9d920P3Paqyma20Vk4X+Pfb6/ckD+zQISGUtAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-tNsfv3Cs1Wxol86O1eWqvtrAxWLXBphAH64VtnpoJugsSS2N2g+ajnWEh2dcf5ai/R3/I1AUHSJ+Z/+C6verdw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/my.xpi",
           "version": "102.0.1esr"
         },
         "nb-NO": {
           "hash": "sha512-sNholbQJyoNFQyAEdoZ9oXSaB9+ryEha32Opmtuj3CVM/v89k5cmzVXalpH+Xo5tFxUEH0+rNiZfX5I5RCyU/g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-y4vcTEooMhdgvIIjmEbxNOhSU2OblCGES0zdSqQvmwf2PdISMFFEEf0sJVQbSbobtewu99t7CaeHVg6FtjTcnw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/nb-NO.xpi",
           "version": "102.0.1esr"
         },
         "ne-NP": {
           "hash": "sha512-dv9scSkz7omPOfAnmfGmvZcVmATyqfNUnbirCu1rMBY6mWrUbJglUyPtrATEHzGIC1MZIYPeUSorcR5q2+CLvw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-Jh8oVlUDW5gQh1Qcdlk4i4E+/iQfwzjH2emoACSF7Vg+1uDHA+0+6DEZWHMDbLUzV9Fehd0xnssKZo0XeWYjtA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ne-NP.xpi",
           "version": "102.0.1esr"
         },
         "nl": {
           "hash": "sha512-VEb6isjUYvs3vMgeGtTz6l2+xwwk11QhV/KtXjf/Nv9m6r6/lcby06CLffblu6pP+gP0ed7NBwcM5CSLXTnoVg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-eWW2mvm2detkbQj3pyyLGCCw/7mnMKDwcPQwGvNXVr+AizrgoKcUIrUQ4EAotWBX//HCEup+TTpXByfCxwkn1A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/nl.xpi",
           "version": "102.0.1esr"
         },
         "nn-NO": {
           "hash": "sha512-ElfDz5FKatbuFbBJFgFhG8pdN0zEn9RnudYkjm3w4MD4oIilUfYBoS+NKDzo06KkQS5S4hZsPGMPF8H5hO90dQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-jEsPgCxJcxU5v0G6+JZYaBjA4DIuZUB5WBD34SdPm086JaY2UiBjJauKLhwkmFUSMUnoU24saE6YHxl25Gno6Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/nn-NO.xpi",
           "version": "102.0.1esr"
         },
         "oc": {
           "hash": "sha512-Em7ZWsVkvXVRJ+Hr4YpX5QwBDFkAnGuwAUBaf0o3Q61rxPJkZLJtAbTo3vA/TOT4/tsirAvkISf9vEh7oyq5Ow==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-Cva/gKCz8AXSRJaHhOnsTpdTBeDyj9y6LrlPvB8bQGWPVrxIZKySpF3MUp1XgkKptR0nWcmaiBpQ4gVXHSSPyQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/oc.xpi",
           "version": "102.0.1esr"
         },
         "pa-IN": {
           "hash": "sha512-67IIC93An2qX6ey1rzCh1xjX2yC17QfDTPmKu6sucm9UMSB3+CLFbwGA7gt3DlgIV63EgkI1qJEtBKl9RgjjYw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-JUI0+PMe97Q5YHfDpjetPTZkGMbcSgHQ4lhrbMwnSCz129Q2wgmOdTXABUYY5aD/OX5Aa+7oH8XXmyIVtVDiwQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/pa-IN.xpi",
           "version": "102.0.1esr"
         },
         "pl": {
           "hash": "sha512-cFhtXsnW3J+VyhBTY7qIb44BFBm7Sb2oJ+uOCY5YXByX7AmWxhQB5EU8IwK+crbvycWccEljr7Wg5VK6ZsydBw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-04Ax+N5F1DbbTs9lVVv+usP7gRTal6YyyNrLbY7c2WjnR3ADzolaxw8AAT1regF4sTg8KxxqCIHiIotGzEor5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/pl.xpi",
           "version": "102.0.1esr"
         },
         "pt-BR": {
           "hash": "sha512-XGhIucPCDDieN/yk+E9B5rjo49C9QECyqm/+C/EM8pKupZTrK1adPEU5wmtSBpMnNF0jTvHKqs3VJSX6kbXdGA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-Nfs+bsOL0zg0hzWBXcvyiGTccbOh81FGO7oLVmTmBiARq5MwoQkhLS+BOdLcjZDeyHX3rQAWswnlLmb43p929Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/pt-BR.xpi",
           "version": "102.0.1esr"
         },
         "pt-PT": {
           "hash": "sha512-bkqW0hB3PeVbwAAvmBn9P/wy7+mS4zjbnZfh0J6sQKwD2J7NCIiDTRd92VOwRaAbIBLVRHyTZHj+yJHtE21kcw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-cvd2JFRG2PBkIPdyj6NRkqEhE6xj/yLKO/G05e6ylORE7ZQDw454WV9RMg/PjIK/PaoTLiFDEGlnGewOq95Ftg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/pt-PT.xpi",
           "version": "102.0.1esr"
         },
         "rm": {
           "hash": "sha512-LyLIusbY3Wl1oFjCxq1av2GKzpq8ZzSXunPNw0OL4+d2YSfPHDLF/p192ONtTrd5ihZDhpTLEQWiQ6FyRQ+SUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-l+mpAG9H3ED9uQbRVxbTaKsIDLfLPFPLLbowo7zKWgaQ8wjGPVDPZV+432giyos+RimSkGRLsG93EjTE/sF5zA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/rm.xpi",
           "version": "102.0.1esr"
         },
         "ro": {
           "hash": "sha512-g7x3sHsfY9TV5iT0Ob9BIKM+9ck9mJZVikVQYRXoNrdHeaQlpP+f/JHzu108DWzRft4+Zdik6/dLqsKwAqjqFQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-mzAlF+hCVBXWGLEpNMZJR2/L9JKTTQnfd2wMwOdK62HSlz72zOOh78KqjAXJ6K0HPvGJovvWOG2B9dNd6cR+9w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ro.xpi",
           "version": "102.0.1esr"
         },
         "ru": {
           "hash": "sha512-/NcWm/jGchI8wycvXERtiiAKfxs5eFenLZZvqE5xLHlA7r/o+4x05KzleMBnQU6w5kxYA+/ehTb+Y3Xe890S6Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-cKHJfOuG3jWU9CB1Nj/OtPLz9gw3NqX5QfsBERlrfASMCcL+BWtRAdnrRVEx9Dqb35EYwkmuveRvGf+fuGcvfQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ru.xpi",
           "version": "102.0.1esr"
         },
         "sco": {
           "hash": "sha512-7mHylcBbxN7cgZQdCmDK5/XaeoHU7WgueFyTRkRcRei+kxs/CqBX9TApN5iDThC+9GLtBefhtpOX5L4kIg3ttg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-U84i5THiKoSV2lqnFqLOjaSd3eTD/VlUff5FVzO7inRlB9iBCt7jSfdNXNrXg8jWnNp0LVI80ROrgFvsl6jAwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/sco.xpi",
           "version": "102.0.1esr"
         },
         "si": {
           "hash": "sha512-Y/DmyWFWZmKkfXbRUivI/c19w4CtTxzhs6tfM7fUAAEqKRu/jYVlQ9hh9F6hovH5Hhimbxj4mtbv4v/BcDvA+w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-OswtIYrTG2ZTcPTpZp0VHUoaPgTvQe8+k6/ADYY+3cG9rFUE1un5L0Ccizgd1xWLzKEyZwWKj6M0tGO+NUOwmw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/si.xpi",
           "version": "102.0.1esr"
         },
         "sk": {
           "hash": "sha512-2D7invDL/itl1ZdHOc79waZWpkwGimT2jB0zFHQ9Gl/a+vy7MfA9qV0Jv+HfeSlnn8ERBm2ktllAKZml/7YSzA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-JorLMAeHDJzuYadJom/Hj/nli/X3A7tqTgeSU7dB8qYAdlQM8byyN9LNqDA6vl5J6wJnofdjLqtgjVsahK16Kw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/sk.xpi",
           "version": "102.0.1esr"
         },
         "sl": {
           "hash": "sha512-07ssMPoC3EZ5/vmNQEDXdIxbLPKRkE7oJ425j3/+EBbD6GiRT04oBRGX9KH8CqYXepT27UQY7VkzR06MrkbFXQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-tnC/rlG14zt7umcTkgVHfZVFRxzXk1pgekzsLyc41gnEfYBMFicSdVNCbhO0UkZkiEIol6CmGQsqhqNXaVxWkQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/sl.xpi",
           "version": "102.0.1esr"
         },
         "son": {
           "hash": "sha512-4vx56jCgCeWjjLZjGNBQkZsy24xySuLcG9bkzSUfmN4XSfjVj6H+gF8KkNf00r07YTpZBebZBh1iBnxlf6I0vg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-bPp6TEW4XjHu07d4JDfaASQa4/+ke3R5wnvzxLQfSmerExa+Qd3nbxQ9FW7IKppZwJ1Su4E8H8XORH99tYxvTw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/son.xpi",
           "version": "102.0.1esr"
         },
         "sq": {
           "hash": "sha512-mU7ycschXBqMt222QHEJbNTl08pOMYe3sestlBpW6komthRhw0tK+AzZ4xgE1NM1aKXZZdyP5gy2/8QDH6akTA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-zZ2ay7QEUxy3vz/aZ1m90k/usAUXXo4f7ogTgmkQDzY4XN8QW5AuEnO7XaA3LSCvCwRktU3NxGuiK2hj8yPm/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/sq.xpi",
           "version": "102.0.1esr"
         },
         "sr": {
           "hash": "sha512-6yAxLRnuGBkhtcFEOwNjQOVggIx9VgPdx/mMe6JD2rrX587/IoyEYT0jtO4N42nYaQQd3dy7/M8VFBU6Yunf+g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-/o+3fNAdtMzxShAeEW/giwiKgbZzjKp/tcHra+uTVqsqDndvetmlztEIMFmnacRb3Pk4gtX0T6BV7HRhVTEnnA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/sr.xpi",
           "version": "102.0.1esr"
         },
         "sv-SE": {
           "hash": "sha512-TUdVWwuACjk8g/4rK5roE7vji4jv9SxDEzZHXiUVF7fb9AEmjNsNdZS8FAO1maybppvOca87Nfkfm1+WNvgvgA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-gzNX1NBocvPPjdu8Fd2ne36w51iFouwG7Rodvl9uiWsdP+nJeKlOp0U1QVuhgs3bTRJ14x6503zDZ9jDhJqdBA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/sv-SE.xpi",
           "version": "102.0.1esr"
         },
         "szl": {
           "hash": "sha512-CYdcP36qEzPLuI3dnGurFLxbUmA0GvqZPi4fIhaKzNZ+Td928Cb64HPArZbBPXUIssPK1oiUst3lKrAHF7tt4g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-dM8OBdzcsT7t1SsFcYDEQhMWD3moNvwdsv6n/683qO3R7suagNSe/TJ7+bKS9VSNxERL58GtDigO8qDO02dQXA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/szl.xpi",
           "version": "102.0.1esr"
         },
         "ta": {
           "hash": "sha512-Bje4660grt4LI6ZphCO/au6LmRAyD6J22e6UA8P8ut6sZlfOjnrkOvAy4e0tMUvFxi4sK1Ng3HtKujCP/s/xCQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-kDD/+Ra1NsJKlumF2oaNyFZtQ08V4GfJv5Urj2Ir4fA+07xzPjF7IgM28vxqvbBOWzhl6jgx6u01X/LcvIgy9w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ta.xpi",
           "version": "102.0.1esr"
         },
         "te": {
           "hash": "sha512-sVfGpNQF01oXVGFK0IBJNFAT46mb1aazrBU5aQgq5Z9HQ97j+YpS17sKOL5y3bPQc5GbfkCf8St0pPhLLerMDQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-pn/MwWi92J7fqr6jeFWftfo9xXFQLtyBCaHv6qGBNShdf273+tC6KJ4j+LLOtrMN3E4+bLHopuIFbjAQIHq1tQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/te.xpi",
           "version": "102.0.1esr"
         },
         "th": {
           "hash": "sha512-biZTkGx0l+OvmYsuEqh1zNobv3qIzQwL1NI/Un29B031WO2HQAAEXksgK8+cgQHx82HHdjwdXEevehQ23w/48w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-omcoWOJTyI9PwOj+B3glu6TCk69bhTGnXN46OBPZuKTEUh8MdICjQ0EE424KZfWdbi1FqTBOKGW1DRmh0Z/k5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/th.xpi",
           "version": "102.0.1esr"
         },
         "tl": {
           "hash": "sha512-K4pwYRa+whMNuSsaITEHMXQOa47qsqDyzTHxl06EpiJWxwy+MhOnu7yp7C18nPdnfY++8iPUBlK/z8rHMlqo2A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-cS8DHDtNonAETSLBMRKg7ElW+nVrfPjJN9HI2ySjBTO13dBtfQcSd0e9SXVNGCqZSuVUp0g6qovFaxKkBGeKsA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/tl.xpi",
           "version": "102.0.1esr"
         },
         "tr": {
           "hash": "sha512-24JCeYZLtoDvimhEfqjqyrdrKykTktXgDda9dVzEbjN+4gYY2soHtlDS2DEdDs3FyGj2VhyMBK6DhO18KHG3cw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-H8Tow8W2LV+R6blyKE2y8uPKe+fVWosKTJPfNhdvHasUnMMgiTsnozzZfLl8iCEX58g9HVxBLvOHySvizXhjow=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/tr.xpi",
           "version": "102.0.1esr"
         },
         "trs": {
           "hash": "sha512-8Se2FfK6tgd82uMb7waogZjf/xVK1K7lWGywdSEosr5nmqjF3ZAFpwX25RcVmQD2PkylACvNXArD7tKffp5rXg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-fL40uCnS8kIN982mOKMWmfdtvE3aUiExWJvSJj1T6cFJBqVWLlc93ZXHfKjcMh/6Qe+7d2Qf8/hNdVeT1LHtNg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/trs.xpi",
           "version": "102.0.1esr"
         },
         "uk": {
           "hash": "sha512-WfL9pxM12+Z4I4vWPsKpRn7aRXDhUEOeWezyLCGTe/6r/a4TUUej12F0rE6dLjtITwHAxF86trwwRkpQjGqdVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-nsIZRFPEBV20fbus/k1c/hpVBMOz6t05icA8BxgtShf6+BdyrMm1vQTXhU0EskBMr8Fm7X70aROU4GABZ8YyGw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/uk.xpi",
           "version": "102.0.1esr"
         },
         "ur": {
           "hash": "sha512-CMHzrj0PQ7OSGGy7NCCysgWJf/tIHqYp2ydSTHfuW6wAZFoW+9kpeigHMO1mP7HrldxSOVIlX7FBz64ZSSzNKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-2lbZuK0FfAwRp6LPCCMKNjl7hnnIe30Y1wikm28HJKN0Qpp3Q4Z/+JQ26xXT4Q6xntEchmvQFQlQkRbjj1Nxdg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/ur.xpi",
           "version": "102.0.1esr"
         },
         "uz": {
           "hash": "sha512-JWS98LUNAz89JfK1/VjAAa7dDzB75hxH3R9/RImQqsoahmwVqA7QEDZSFSusL2DF0vCvo7Ames3gW4vMvt9VFw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-DbFKTnqxByDnHQZ6a9nUYm8CWdd8UtunQucKRB/jiOBsmZuN0xyVaFEUVXSQYCDU2TCD6Ay6zLE5FUnBqT+ncg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/uz.xpi",
           "version": "102.0.1esr"
         },
         "vi": {
           "hash": "sha512-qZdbuZCMvgSWkkquSrRz/nUS2jG5/9T2Os6LvTwfAsrbnC1OMgyaopD3O5JfQQkRVPyf384VhaNTKMVAkIILnA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-2uAt5nV8mN/BADE4kXX4F0DPOSHyPYzx//IzHM+P3Bx500dsggsjb+I6IZOqEdsjdr0beLsXF12nwro1GRECKA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/vi.xpi",
           "version": "102.0.1esr"
         },
         "xh": {
           "hash": "sha512-+Z6y6Lo4cFMtAUWbco8+oyhxPDMQIoLBtyHnwpBi+Orh5Hrpuc4jJXOd38r+/9mrmSLHbi+q3MG5mHum/v4zJQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-hVyOUpXszS+jJgN1STghD/ELFBU9JWvS03oulwriN7naSRpSCPh5rcl7SiVOP6q2tlBYa6JTTc32g+inKoehLQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/xh.xpi",
           "version": "102.0.1esr"
         },
         "zh-CN": {
           "hash": "sha512-LGSRzAgWqofP+9qffJTsOgnEcAJERM2CSrqFNDyV6lfn1le9QVdZ4+IwAbi2J7vK2Jd4H9IYo7OADk0AWZPjag==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-TnPJBU/pUGr/+s5ZgYDCS6IbPVK1lgfFj5ImMc4vnAPJbt4wgRBPrjrduP0Ds33pJIHtHzGwwyQzl7EFlIKm4g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/zh-CN.xpi",
           "version": "102.0.1esr"
         },
         "zh-TW": {
           "hash": "sha512-8qRGcQkGAHu3oVt9JDFVh4Pd0Jynhe4s+gdMyccDJSBspUIGCVPMXTdYulCUiYfy8NbtlDcjGwsBn4ZOu4yi+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-OHPZ1UchIlbt7QOVWxxSf3rob7VAp8yiHJJPuCdQwnHekb0piveOQx9qdHmjflWqcaHwWuuqev7/KnsP5trmMw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-i686/xpi/zh-TW.xpi",
           "version": "102.0.1esr"
         }
@@ -2468,491 +3938,785 @@
       "linux-x86_64": {
         "ach": {
           "hash": "sha512-fOT9MkGxBBXFMB83rgFkXCI+dZ5iPmIpO+n2s23NSI3oJ+nrP7h8AMiblhEcMXVG0C1RdnlwKnD564KYKGPvVA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-R3tCCjLl1LfH0uCdWA/NRq9MpmyXOm/aAVW14cYp3lzoGcYbbvSMQBNe1E6TD21rKmaQNWz2gS1lnTe5c8WY/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ach.xpi",
           "version": "102.0.1esr"
         },
         "af": {
           "hash": "sha512-90rxRRAiyDHjuPp/U1+KaS8nlhnD2doqa2H0tdoADolu1d+j8zr6i4mPW6OgFn9NZFotubGQ2nu7fNBd08nxhw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-wJVYRDOwn/wvw4YjRpFTLXJAibEVHpWu31psVD2UNs1vlyDcJahQAU4esEBd6oI0XeP5tgMbIE5ZPVK1c6rVTQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/af.xpi",
           "version": "102.0.1esr"
         },
         "an": {
           "hash": "sha512-4CVHCWVi9j5TC8+QQsD9opx6PyndDUa8v3j4Yt5SaSnmkYAB0j+jp4AZorhGQv9g2NOgaXO2v8wSplXWTORjEQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-vtYYVKG7WZr0ytFMLYt4Y92zzkr7XYZkdmkw4RsPvzvhR5G3BgreW9CuyNObI+y3ylStSjfalPXURkcAUeDHHw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/an.xpi",
           "version": "102.0.1esr"
         },
         "ar": {
           "hash": "sha512-/Coe4lkTx7u+Jxs1Vg66Ues47GGU+8UqqKmaWGZGzVxXOO8QqrNngAnU5FL9sKr63/f/dnjp6YGMkbVH8mHbJg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-3ug1dpHqkODHRwM7Suv2Mjt4tBk174MDE9j4SlmmYW+si9qRyMTxC/yMa6hPfCx58CGVQsWjzBzm0GXUpjJHBg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ar.xpi",
           "version": "102.0.1esr"
         },
         "ast": {
           "hash": "sha512-U++RYOpk8JlZEdXW5IkAWzU8Bn2FptJYeeaEQrQO4cMCWtDk7j5InZHaC9G76BZDNgE9jDxpwZGJqWKJ72UVmw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-NDO0Psm18ixm4kiKSaXmU8aqVhaBBY9Fh+g8J0HR2nQIsR2aZ4CeCZl2lnMRziw3cH+8bgKsy9GgSqBwBSRL9g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ast.xpi",
           "version": "102.0.1esr"
         },
         "az": {
           "hash": "sha512-Vprb8wlkMDVtW89ubh04QuNGZvLZlqSftxmOXqeTAtBSlQTV05s2Vry0Y5W+bLznI/jinUIuxh7nIG1ExOgjhg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-eqHhe2pWz/gddgim6pJ4pLmrDxG1Q7qOYkVGtJ7NP3tYCcOU2hzIKd79TJwkBpGBNCmv3O2sgux/PE6Y9jUisA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/az.xpi",
           "version": "102.0.1esr"
         },
         "be": {
           "hash": "sha512-edhCuW04GUwiaBCHbgP0FeCW/rYRAuNQL/sIqQmtHDEfA6VIEEAavJ5f1x1FNM8cFerUa2oERLm0lB0V2nG8oA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-JkUXI2aHS2o2MRkZnuCzk4DB+2ZpzFwCyyAqMaUNFiSLumx8EW9a7ZRQ2+1dVBaM/lX1Cobv1TdiTCGSMbinpg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/be.xpi",
           "version": "102.0.1esr"
         },
         "bg": {
           "hash": "sha512-Lg6nAvGabGex9VL1+EB/baBzQ04UZyBCuYbANhNrVfG6NGrzYqmHRYR7Q4Q3g1P7zE3zS2Pu7S7lCvJWO3opzg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-E63y5Wpvaf/p4LepnULi5wF/hQLHduyDJ49NmyxQr/bHRHLW0kEOWoCvJYi6u0SsyuGGt6RjjICWt8sy+n0pwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/bg.xpi",
           "version": "102.0.1esr"
         },
         "bn": {
           "hash": "sha512-1grP1QxbgtRQp+EjECjwkhKVg+5eQL0kZ0Ean+nS1Dw/DfK0iktwkFjnbVyV4FGsJ96nSeHdpZBtVY7Buoef+g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-T18+Xq2E8pYqxG8Zn3JQFXdKN6DbhnP748aQ5zK1QJP5lnWMR4NT3FxDAB6KvC4xi47lbxNmvEoHOL3tsbynZw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/bn.xpi",
           "version": "102.0.1esr"
         },
         "br": {
           "hash": "sha512-jdIvoHOWWYzAdBbTXfvjH4dWFLiGX64XKkYtFqn6KltWFff752tnP4iUhpdeqzuV7OzDNocKpoHHo4Ooa1l28A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-9ZoNcUhdSa6EUJJrisg3vXvj93MEPElVm3xSGpXzxtemmpezjcIfukps6DBV0MZiM7TbfR5PWm+Qn+I1azAA+w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/br.xpi",
           "version": "102.0.1esr"
         },
         "bs": {
           "hash": "sha512-PfXMFg7HvsnJjv3OOW3FYywXjpOrFT0trOMWp06TgRXaYDDaKYiubFcDoMwRgXbNqn/igt81BwqCL3kv+CYA4Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-X/p65KU/hua81n/dihCmpx6ate2E3vXWWl2afaNavMrk8+RUsYudVdLqyBl92mWVXRuZob6SkToorknHiyv1Wg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/bs.xpi",
           "version": "102.0.1esr"
         },
         "ca": {
           "hash": "sha512-yrEXD3+JTNAGpQNrqqn1g+sxQ4Cw5/5kN5Bz5l5PO3eZXRvKRpEkiM3ydKRMhJ8DzdLWzsCSdUqVtvOokKacng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-kK8tI+Wb6IPV+NV00sFbHBVTNarFTR1ZmHRGFR/l+D8qcxvJolLtxmj5akMG2VhcEBQINyn6CGWI+PE9V5LyxA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ca.xpi",
           "version": "102.0.1esr"
         },
         "ca-valencia": {
           "hash": "sha512-jq3DXf30OHftz/wwOb3wmvGrITMBPUPW4g1//pcBHyMuHDFr0N1BjiWPS3tb3jEbwHY21qEbgtMNfMvfNq4EoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-itnloucnW01tDGEjlN26ze2UgeRyBgcV49lOPAq9fMGlYWegQp+KSbzlRlaAn1+iNcrvB1KsVytK/EQYQ+Pr4g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ca-valencia.xpi",
           "version": "102.0.1esr"
         },
         "cak": {
           "hash": "sha512-ud/JmOJLXW0K277njWx7Gbj+81QLwwrI1oVxZ4KR8zae3ZNrlW/Az8X/B+9dKvufg9KyGt+YA2jfcoVeMErNoA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-6O1/yUwcOetK0qQT9xbihCf4JN9tG9xzP31gfdOxdf8Qu8ecn7Athn25ijM8sAM/wAWIS9eF/+oSAqQY5Wo0WA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/cak.xpi",
           "version": "102.0.1esr"
         },
         "cs": {
           "hash": "sha512-fR6Ea7U6QZpMRj31mSA8TD+un71aLLs2fjfOOLCAX1mv31Uil3PDX4N9IxD4XJWehPnpGzOa56sluRNiTbi/6Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-eh1r6msUQsU/vc6vpso/RnB/adtsbjutl2mt4W/ftPOp0T0B+cKhIrgr+PknfPut5PMAyKApV5BYdvrlHLaNcw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/cs.xpi",
           "version": "102.0.1esr"
         },
         "cy": {
           "hash": "sha512-6ss2va/hZTHAIvQTDY6A1gQXWsmfWh2YMsxutjITmz/VqfqGXTncjMwyZE36CpPUFdKX7iFqtanIAdyhzg2iYw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-On5GT33wYTluXaNhBzo1/9ARwJGnuH6eRVusrBIvAtucsCZ5oQYMtKf+EmgdmUQRTLCbL+ROQeseYg5We7TKBQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/cy.xpi",
           "version": "102.0.1esr"
         },
         "da": {
           "hash": "sha512-Zv+sDKjaj3mqbFUhPkJkPoVVfxAYDK2K+G1lMcKhbp0D60dUodLavUTUzTjtjSVAYnvJjvbBP8Ea6N836ymWoA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-f0bR49stME9SeySkNZF30YApjZ/tRNUttANwy8QFw/fdjG5N456hfhrWNhce5YZ7wgqtzWHd/7S7eJju/dOKkw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/da.xpi",
           "version": "102.0.1esr"
         },
         "de": {
           "hash": "sha512-DPGxDbgh0ZWUDAf4Cx+KKTIHc1z7j+T4VeSMdmLf3NIbOtjij9PWWkwlS6vXeu29VP58SnaJ6tCH/cNc33guAw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-d5HERvbUVlx14K/oABRxv871QL2/7qCh0rFepzJB15rU/U3hZYt4OVDeU1hr3EZO2GGsK4j/zi5NnfkjGpIRbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/de.xpi",
           "version": "102.0.1esr"
         },
         "dsb": {
           "hash": "sha512-TmcIDdyR4atcx+4Nz+2G9xqmE0E3/aV+CmKuKw7Xv8MruArkomMl2B/664TLf7LvQARGlBoxOLAaelkt0hSzuA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-pKImlOIv0FdcckqQtFUTC7Txs88LpwrRJ9X+Yky5P+4NZiWAGyrJ5u1011ylkQyw8yQlbUPkyBYOwzGKFVkdcw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/dsb.xpi",
           "version": "102.0.1esr"
         },
         "el": {
           "hash": "sha512-0M2Bl1oESP8nBjHDhgfyekz7+Lx+snklJgYQlZQWGYFSBIeIeg1+yEUth/OCxctkQxPN/7NV+E5P9tbjvt9ARw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-N9qZziL0c38yZHqUhtLp5CH97cKUqS7NgGGIIGSlnazDaA+pRxQgjNNxqRDKgj7l1kPlThlGGCQEGlDDKakWMQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/el.xpi",
           "version": "102.0.1esr"
         },
         "en-CA": {
           "hash": "sha512-Ih6zQrX6amMMYnexzV/kooC9hdDno6VuwbgW+PKQT3lrZfk45TRGRUdRsV/QGTcl4PAsh+A0u0ZS+xTzoEPXng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-aiKGFt7XJd87GQymcZGjMNg7UFy7N2rkclq78rkz765/xjzqYbKaR7ixsShOXmmc0Ed+3L+Gf3ArnsMQ/RPVuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/en-CA.xpi",
           "version": "102.0.1esr"
         },
         "en-GB": {
           "hash": "sha512-gMV/IKCDsRxzuApouQDRXDaqPl6pxlp2gkrZsz7BjgruLqy8A9r1jupbpdezdPEyPnQ0ItgAbMZ4otg3CWKg4g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-aUUMlV6yNyoYNklKtN9oCLxr4ZCujcLI/oUZNZT+11dlMBPmsL0idsBT/C5DVeHsez+0EqpX5HmjHYE2NYF1Kg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/en-GB.xpi",
           "version": "102.0.1esr"
         },
         "en-US": {
           "hash": "sha512-LcTovySgqLbyoXKXNwLSF7PPhVcJA8UXOh/wEyWHWamGCTozNJGDxWtTW4LuSDpklnSsNpIC2rl1c3FnDzmy3g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-BC2xVzPWGVNnoZB69WaUbWkYK7IIE+7ahBKQ8B9VzDb3x0JKQaFk8JQ362/laKaMmo0HPlhY6Lvc27gMQ9BMCA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/en-US.xpi",
           "version": "102.0.1esr"
         },
         "eo": {
           "hash": "sha512-NoyjpXNWiWHAlYWaW/PT5vaEQRA0WaiNivtypHuJm4rbwT4rQNJ0+9ZBBXSdmQE7Mn36y3eMSVEsyQHITHiehA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-cLMsu0P+IPOAqfcUOknklrxnuJZgiOkud49b52MNZxXA+5cpAWv3/Rs8cOX8MlCEw4ryE4FaCm1J2D56r33k/g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/eo.xpi",
           "version": "102.0.1esr"
         },
         "es-AR": {
           "hash": "sha512-qaPae3LSc4sqBJuriwB+Bi1ISZO9SxPqExfcbhTz/1kbMiP/QeDQ3IZL/GQW3dhawukwVLzdxZTBM9hCp5ebXw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-2IXdKpnbPR46Ud4x/f4SwFpqBFYTCPTrlSAgOmbUx8cKiBHeBGuH8DBMg4s4uqn9uecpZjCbFleoRCEYb4gp7A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/es-AR.xpi",
           "version": "102.0.1esr"
         },
         "es-CL": {
           "hash": "sha512-e/tFmCAKKGqSsSVoSHzrT+kgmIx5Qe3S4ifEcs/SdoyiChDaAuJHDSr75ztoKdmu7/guP1FrJnus4rYA6H8obw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-so90uOZvsld3JCpXWbIeUfAE6Aarz8+zRg7ZxAi4V/nWao5whiBAQUaDFL/Na9mFsKVvuroCXrhM5xNW4/5Eng=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/es-CL.xpi",
           "version": "102.0.1esr"
         },
         "es-ES": {
           "hash": "sha512-uppeihopwdYQEWQJ/rOoRx0Gw0MDn757MnB3OP7y5cB4gvA/RqRHkADvudINdug4yIGkOt31wZESuJogC8Kshw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-o7i+yo0wFulFdgoqVNhtDTZ1cQBovgwEPFtvykrFWuzfRQgeBI+J0Jpkp0xbAkcdHucmKTqZVLRsyLpPOgY0jw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/es-ES.xpi",
           "version": "102.0.1esr"
         },
         "es-MX": {
           "hash": "sha512-Qi+8OTLHdya1rbzoFo1kR3BoREcG1qJS8hzAsDidJkRKGu3baWpa+cY9myEV0Nkk+mKvafNYkEhAuHUrMes4uA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-fD5k/B7c4MMGDXVt+gxETavuVcQfXB56wr2YoztmGv+7g4Lz+ZQ3yuMxmdI3V+Jtywfdr2sPNJAWsYyir67hOQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/es-MX.xpi",
           "version": "102.0.1esr"
         },
         "et": {
           "hash": "sha512-JXL22hB1I9e9O4dbCW9qJSb9gfTPI/3sTcKYdnIq183eyDAWXbHk8ChhVH8MJFnOnn+3tdLBI/V7V21F/EApTQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-vXPKTjaE7OPLK11CFuQGtxBTv/LvIYCS504aHIxclytDcCRW8nz+JgRxtj4o1WvtvRItlV96VcCO3msxd8eO4A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/et.xpi",
           "version": "102.0.1esr"
         },
         "eu": {
           "hash": "sha512-Lf+7GkuD3sFWL+CMKLVTeosDkihqpWdmGfhPf+Od85NLd8czEoHCt5IM6Is2mZBDKz6BZlv8JsrgQFnoFswOlw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-u4axBE6Gg2ZlZKefGipKSxA5O9DLJcY+JShD/IAcY+EDzrSKbB4XCkI0YizwfLhUTD5n6Z3ZmsOWWuj0/KbL1Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/eu.xpi",
           "version": "102.0.1esr"
         },
         "fa": {
           "hash": "sha512-8PPFs8dVFRs69NmGlBdfmphMFOTZCzfWBWpRVI8woFXfcnoWPxdaq5NzLDapoAw4KnaE7QwjLELzBYvc6Jv0iw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-u4wG2SvpZo7q/niPFZqOkT+SohxGG6PII0AvgcF4+fyVxtS0hw/gsaLGjZD69JQcWb6UdA56YHhQ6BWg/+SI9A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/fa.xpi",
           "version": "102.0.1esr"
         },
         "ff": {
           "hash": "sha512-DeggBpnm2/x1DRjIrfRARgx+FRTPh8uIhLstWtmKo9O7MmDglk6fQj6BydECZ7wFKZ0PjiYMVEeR/GFI4k1DZg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-pBDvbBAM4+/dQ6DVHkzX30KKo1CBttjUZaWjFsIPa7KJfLxGbUuUK0oa44rXAyrW/4RpPtE+KZIOM/XrlAIj1g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ff.xpi",
           "version": "102.0.1esr"
         },
         "fi": {
           "hash": "sha512-/m9LtJcnETTAvflskqFGE2za3R8k7nEKTouNZIRFvyfIk11bV5aIP7syXURgyc0Eo0c2HtQA1CjOKlH4QkIv6A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-Askj/jc8fWgN3nPhFKFdA/ec7VSxIh24JAxMDb1JPjAYpRwM4baKvgqx5WS2My7h63uMvJnI2YHiOCvzaXPrQg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/fi.xpi",
           "version": "102.0.1esr"
         },
         "fr": {
           "hash": "sha512-oSfKdbNkmxv91t72FL3nGhyMsjj8THSj0dZnRoxk+5izK7FuiHuUzrMXR/vRJL+t3CBZjSly4CULbpo0HoRw+w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-h+aypUP9dKRzNUa2NMWU9n6lSRipSOPRJe3qdCDatjuOiNg4e4BfInCog/Km4tFkHWE3CVcqPhWhzEsa8xHIlA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/fr.xpi",
           "version": "102.0.1esr"
         },
         "fy-NL": {
           "hash": "sha512-SoNM32fJRQJDQjjnFJJWQuYcmELUcb4AfTJfD4cCBHZVr3/hrX+B/V/wI43Bdlt6QoiaZSrHV71/f0oneUER7A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-JZ9k3IfOvJGCzr0dFOyxEA65uEA2plrCINckNf5vPJ83X94zII3jGBzcP08ffyA4274eaUwYLzuD1HZmw9hFJA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/fy-NL.xpi",
           "version": "102.0.1esr"
         },
         "ga-IE": {
           "hash": "sha512-0s/g0tcfxyUsD2BGkAmx0EEbjlhCx8oMncoDBjJGCJandQ4sOc+MhNEAobvIDHk7pQFat4NyMZl0BD1XO9JT/g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-JpNLHQvSExiklR8KorVb9LleWEOG8cYKBZU6kTgZiG5ieOh8ccYmypd0B4AoSLultgRwb0rOBXNNRzM2FWUkGQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ga-IE.xpi",
           "version": "102.0.1esr"
         },
         "gd": {
           "hash": "sha512-2BSPSPfRSMPo7ujOoJ+bx7Rv447HZ0snxg2SOISoUwFT020EXk/+19kJpaYpLhDDpr1DzeaJcybtL8zZlZaTdw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-0lEuKOqxkK0PYDCSLv56+rcxOFkGAQa+xDRvKoQ6qFrL4U9miexwRvO14cPhXwglnLMkTeVG93QxvXEPtRsLMg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/gd.xpi",
           "version": "102.0.1esr"
         },
         "gl": {
           "hash": "sha512-RzMaenmTwbX/lOlnkqrHhSzHWprRwgaZtnHPpX6y4tp5CbnWxHEwdkQ+aO56cxB+eBQhKJ+jVIuWBSboX3DJtw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-t3QaiPLSiFQlOv5YnHlp+8RbI76WUBm8aYPwjZD+O2nlH9JFJY497XCRCV7kjPryYy1Z/7GsQpxPbO+U7aoeHQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/gl.xpi",
           "version": "102.0.1esr"
         },
         "gn": {
           "hash": "sha512-dwEgAJHgCzln/6ccy3iZ+EJvv4AGLfW0QeleXo48b+HqC4q0XP30rYlydwE0R6j4AKS4B8ngd4SAj+q/UhdV8w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-PHM6NbQdrKoTDOzZ8TWXOTYx5N5gxEOZDQZl4LLKu/2kjcjU//IxoBz2LcL7tkSi6I7Xi4hmFQtLBdDOwvixOQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/gn.xpi",
           "version": "102.0.1esr"
         },
         "gu-IN": {
           "hash": "sha512-B4oLEhsg5sEZxRUhn0ylmkYqD1TiMH0roDi7+koFaMCluIuPOPsknDVkqLlLx5C57TeTNqCwDjIFhi2wC8Wg3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-xEzsLpj+AzOxHmysGvADY/lp7dvev5DBhxNmf/1UhkbQib1EyvasmphF9bA5UgL5RQHN/3yC/g7hoOTGthHUmA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/gu-IN.xpi",
           "version": "102.0.1esr"
         },
         "he": {
           "hash": "sha512-N/29ZWG9mWLC/9gwZg4dEcsyprh4SJU/8luaMHHRQpYKjGvIZggHS5dqjoSXjnzErHoeKCEi/cUYzxmfZOyoCw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-q1cb7SD2hjNe4diErylIcS6m3yO/JvfTfIiT2HxJsErDR3tc3O3U0DMcaAQiHbTbJPx/K14nNbBH8n3pqBGKuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/he.xpi",
           "version": "102.0.1esr"
         },
         "hi-IN": {
           "hash": "sha512-HDvjSkHFH9ggeN//DtlhDjir+zf6vpy+kWn71DD4cer0CaZWWye0D8c4KmBsNCgS44vbhdBhEuabCeUpjB6Mug==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-R3vrYihReLuin2dbL/ETiUGG80Bur3NW2N6pIaFrDXM0OeMIzdfuD1q4NDYyCE4eB/K0SS9s4YGHIxZzieHCMQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/hi-IN.xpi",
           "version": "102.0.1esr"
         },
         "hr": {
           "hash": "sha512-6a0cu5EQho6YThBdrvAzynrNOicjFc7QH1jOuy/+IP1a6vh1qy3qLN2TXYQ9LWh/t6IWswByyF9cBWHJ258fqA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-BcbopuRPUpDpVczkY5r6c0uxCD28trXXrDd909oUssF+NhtZ9WgSyRYdsAf4tm33ecrlxfk9uMhQKhnNNcC1EQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/hr.xpi",
           "version": "102.0.1esr"
         },
         "hsb": {
           "hash": "sha512-QVOLK/z3z4vuBxPvqsuAFqprnNYXkUwH/Dy189FyAFJrNXst6qmVnMB9AxUSlsWANB0fZVtp7xIXGwJSLLq9cg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-BU5m8w2bbnsCt9sbYnDe8QfgH655OX1sL7u99ytGUqF7d7NGGAcw5TbMw9rc+d8FWyetqNcvsbfIhpHPGx/2NQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/hsb.xpi",
           "version": "102.0.1esr"
         },
         "hu": {
           "hash": "sha512-PG2+SZYUHd8JkK+gpfxp6kapTVAnWYEA5QkhLl+n8ufI7WGgnQbbshag7HZDgLj1ivfR97x52PZFuxXu/Rl/Yg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-ZnLRPH8S7inoZTd27DpNgLxzILAFPfkbWxrxPLxNeg2HNTfbfihL4WmYd2738vwG/Dkxgq6J1Vt6QPgyQiMf9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/hu.xpi",
           "version": "102.0.1esr"
         },
         "hy-AM": {
           "hash": "sha512-h2PZY+3ezPVlz3z5NPdk7XNP5Hyup0k+Igi2JiS7r6sRGIJvUP1XUfSl8YKIymEVIR1mK9QazDYCt8OvmONeVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-4pBF7ZDrviEYEZ6HxElVbhF+R+ed2HJ3yWnzuExaf6xREYaf+2O7a51e0hM+SUiY7ac14KcH48u279QobzqPPw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/hy-AM.xpi",
           "version": "102.0.1esr"
         },
         "ia": {
           "hash": "sha512-9HJ6qexKZA8/opo+aGt+8RVJR3rn2PeW18UJD1HfX2UkrCzFcHqPmAszCJVfAwD9LOKZkwqPEgDM/4MuHFmbMw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-D8+SbzLSlCl7o18HMlS13hRC3CoNdLQGilaqeBKyxadQQStkvq6OQm+kokcrdTLJIXmRN5tyNovAHm2mh/gLjw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ia.xpi",
           "version": "102.0.1esr"
         },
         "id": {
           "hash": "sha512-s5np0ZMslMtvPwvRLhpIVu/ZS2xw2YBNdCct4EOvck14ti7qSuwT+WB9uKwlLhV4wiXKKXm+FDla1Mc3POAnAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-vVPHvTJdvgn8X/EwAbEj0L8GYcd3tyxv8DLdxJJcxjLDR6oSmqhwmF8vnegLS3/HbCf4ajT2Oh+uMOSR83XuzA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/id.xpi",
           "version": "102.0.1esr"
         },
         "is": {
           "hash": "sha512-SmQK3rrerXmnGVQbQ2wbeKZ7oEHM5MGSdBO0VMSA6mhpx92kgtAi/VTilWwZwT++myYwICbcf0q4E69hzbLQng==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-/KGuXXQcCT3tasKFFBd4YhSrEN4GyDHcyqof6ZS9wUA9RRqOT+Pv3l9LpkgImWKhx4S9VrX/ESPBReLGEYSZ0g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/is.xpi",
           "version": "102.0.1esr"
         },
         "it": {
           "hash": "sha512-EekXEc9sbcJ747ffnM7DgtOb0xmMk27fzgfjUei0c5h5/l9iQt1HEuEe6JiA/CXsQiXX7hgl3b2IxaQwnizi5A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-QcaYCk86GLTam1ylOUAsWQSKNXp/Gphwl2SK25fjuYQu5ml/BnsEAjHu28I6qPu1Ff6oSzCt2HzimO+ZxGpK7g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/it.xpi",
           "version": "102.0.1esr"
         },
         "ja": {
           "hash": "sha512-EdwBfZBJzY5ecwuNJxb4X9yjEIrFJWkxGlAxkU5DD9y27eTNyhXbtl5bl4c4PXE8/UEtQ/NJGdXMJkGTFs9LgA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-yllFrOch0KWAtW76eu/YYo8BhJFmjg7XjYIcDGb5vepLiPt9KImMorlFzPZIWRfOJMEmLtlzfMGNXAHnaJzwjg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ja.xpi",
           "version": "102.0.1esr"
         },
         "ka": {
           "hash": "sha512-aw6i53LWpzQlMNjDQtemXF6U8e3uymRse3E+gJGktG+CYdqqSKnRB+b/5kwScfe8LLphGY1zutLjQ2UC87jcfA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-NA2bd4BCnpokQKP8cbBYH2/7o5nZh8P8S7SGrnMkIIi5QR4I6H036wQXqoMUIeOc4QNmfETVTCZt6Ri5AhwtIQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ka.xpi",
           "version": "102.0.1esr"
         },
         "kab": {
           "hash": "sha512-ZgGDk0KS87gbIYbTCUu6VWPS9NnwnIcwmCbV6sjBw/ZhAF2Ie0Kw4nceNO1/uXkVqrIOUHOaHJXQOVk2nPdt/Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-fkXLv/W7Jq7FbvWEoTjDzd4z34mn3EYb+67PK063JBKEn0tOc1y3yQNOwV1XjaqdMg3a3s0/bbUG6lkBleETZA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/kab.xpi",
           "version": "102.0.1esr"
         },
         "kk": {
           "hash": "sha512-7z0vgI4GnhOo4tiEmTIVPTWvF3zQUqEATXiwB+IJfj6SP1NsBV73f834KQTeA6OW5Yj88XQiLeQd+dbhNrDWvQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-56icWOgpprBmGTuL3DRmghVqcn0obHiO3RlTRFoiHKVsuvviMrfM/A5RfUpgePNuFIE2IcHBb96VN7N1WX9hSA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/kk.xpi",
           "version": "102.0.1esr"
         },
         "km": {
           "hash": "sha512-2/cizMro1JGb8E/LzJVoiSvPCj4DbZjqIHl4NIb+X4oVcT1wWRH2Ky20Vu4RZRvvt++mcsG3le6Q7IcxCEir1Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-/YNBgO1zZEakvz2nKvpwFuGVJMRY6YsnJQ5ihniHLaeflt1jqiF/iBs66BStFGh6iI1yqf/tY+iHbWEo/Eg5vA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/km.xpi",
           "version": "102.0.1esr"
         },
         "kn": {
           "hash": "sha512-ecv5sb6PK3sRU3KWG3LksDXe31FQMrLBjeagOAHic+yTGChM2mbyYlMgp1kv5CZcmuQUZF6xTC8TeN0IluWo+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-jeEBBFgzXzLg4bz2AjvmyvgZPiPPEl319mdql0tAukoNgvnp+7aQl1o2TXVlMN/bkpuPLdo8sbdUaC9gC0v9jA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/kn.xpi",
           "version": "102.0.1esr"
         },
         "ko": {
           "hash": "sha512-ad6IhmsQ4G1VszvPMpaeONuDiY1VM0nJtP1SKeaft6+3zy1SzO5ks4nSSSUrpxS1S5vmNceBmpNykhicCo9J3Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-hDTZfOXfdhM6wQyQJelCgGVwge4sxeiusXTYmmxzie0iNerqF43Rc32BPLdAWK24LCF3Ag4ZFKyPn7x5+666vQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ko.xpi",
           "version": "102.0.1esr"
         },
         "lij": {
           "hash": "sha512-BO0tRNxp+NjSkTxfIPT4kLX2MxsNmdU1972CKgbnXt81zze6pn7daa28UbGs3SU5iUR4iNFcg89qPLK71/Hedg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-8e/+AMAy1sh4tsC1O7TM/LErgVe3y2C8zZBxUqoWos3zwIPNLdsZYYIDJg2enXc3KSpbD4KpCLmZxVA1Os6c3w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/lij.xpi",
           "version": "102.0.1esr"
         },
         "lt": {
           "hash": "sha512-OAez3eZtBLKMAk1nWp9QE0YrnH/4jQQdLRcFVEmm6YbheFWMplJqMyeX2VGKxT7U3qGoMiFKUPJzbZ0tcLJ0RQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-TbqR3acRfc66T4MAok8r3f/f/1esD0sS85JX4IkOu1PoiBPOsfF6cMUtgdmuvkd+7MUmNq7HBOeTV5YlDGE9/w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/lt.xpi",
           "version": "102.0.1esr"
         },
         "lv": {
           "hash": "sha512-TCDAs7nQAE6Cr9JQM4XCSlWJN1n27oyr/LXnx+vBLRmP7lWDw3zOPYaYJDnsOLRukSgjFwCSYEb9uBUj5LweAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-GEY6gOu8jRg7NzEs3TAbL7C76a+wKh7gtAFPgEjOTmIYmFqB5PWNR6xxgJWBW1UMtbDpqMepQ0UIj6hi2MhCiw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/lv.xpi",
           "version": "102.0.1esr"
         },
         "mk": {
           "hash": "sha512-+cXAJUxsP7Bte97eGsSzuBdqvyqEtbsi3wMwhuxT8AUF4qmn7I9QecaSUmhKgTqMqTixiEO8vWdcEXQOTuVwNg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-710xVIfk/L0zUEHVDCkEUIsDhzxFX9ONfUizCZzApMDtGWoFtAZmUqg1eBiAlvnw41fGVA6gS+NdpGpU7BHKig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/mk.xpi",
           "version": "102.0.1esr"
         },
         "mr": {
           "hash": "sha512-r4hp+4eXQNtxdSrpsCjx7HoHG4+usKlkhSZjOLK0dY8ENp7D5tji7dP3vIQ50MP/PHXIJ8PqB3X1C2l4iOCtOw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-S8GwipG3sciy6c4MHtG881M/waN75FdasP1zczYCDn2Keh55kQZYaAcdzSIWnlVuyQgrDNLIQA3EGHAUPcVzyg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/mr.xpi",
           "version": "102.0.1esr"
         },
         "ms": {
           "hash": "sha512-zQr2sMqjGZW02e9x+V8jvt8Ri54+PwF+tTJvgr4lH2+8JbKVvKe90lQtVov3aumxmnZm0aveur4ZEasWhq3/bg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-Ks8t/Y3Y582AjDRzN120EhSN2Eqb+JI3pAYGx9vdJWkdVf3pjkZ1Vkmyf7loQDjuPyUXhAlisbNfm2NccOQorw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ms.xpi",
           "version": "102.0.1esr"
         },
         "my": {
           "hash": "sha512-C0oCn/eGT+rcunRRc1i7T8K4y3F0+giCdl4EZqzdhWbvd7AS9d920P3Paqyma20Vk4X+Pfb6/ckD+zQISGUtAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-tNsfv3Cs1Wxol86O1eWqvtrAxWLXBphAH64VtnpoJugsSS2N2g+ajnWEh2dcf5ai/R3/I1AUHSJ+Z/+C6verdw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/my.xpi",
           "version": "102.0.1esr"
         },
         "nb-NO": {
           "hash": "sha512-sNholbQJyoNFQyAEdoZ9oXSaB9+ryEha32Opmtuj3CVM/v89k5cmzVXalpH+Xo5tFxUEH0+rNiZfX5I5RCyU/g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-y4vcTEooMhdgvIIjmEbxNOhSU2OblCGES0zdSqQvmwf2PdISMFFEEf0sJVQbSbobtewu99t7CaeHVg6FtjTcnw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/nb-NO.xpi",
           "version": "102.0.1esr"
         },
         "ne-NP": {
           "hash": "sha512-dv9scSkz7omPOfAnmfGmvZcVmATyqfNUnbirCu1rMBY6mWrUbJglUyPtrATEHzGIC1MZIYPeUSorcR5q2+CLvw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-Jh8oVlUDW5gQh1Qcdlk4i4E+/iQfwzjH2emoACSF7Vg+1uDHA+0+6DEZWHMDbLUzV9Fehd0xnssKZo0XeWYjtA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ne-NP.xpi",
           "version": "102.0.1esr"
         },
         "nl": {
           "hash": "sha512-VEb6isjUYvs3vMgeGtTz6l2+xwwk11QhV/KtXjf/Nv9m6r6/lcby06CLffblu6pP+gP0ed7NBwcM5CSLXTnoVg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-eWW2mvm2detkbQj3pyyLGCCw/7mnMKDwcPQwGvNXVr+AizrgoKcUIrUQ4EAotWBX//HCEup+TTpXByfCxwkn1A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/nl.xpi",
           "version": "102.0.1esr"
         },
         "nn-NO": {
           "hash": "sha512-ElfDz5FKatbuFbBJFgFhG8pdN0zEn9RnudYkjm3w4MD4oIilUfYBoS+NKDzo06KkQS5S4hZsPGMPF8H5hO90dQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-jEsPgCxJcxU5v0G6+JZYaBjA4DIuZUB5WBD34SdPm086JaY2UiBjJauKLhwkmFUSMUnoU24saE6YHxl25Gno6Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/nn-NO.xpi",
           "version": "102.0.1esr"
         },
         "oc": {
           "hash": "sha512-Em7ZWsVkvXVRJ+Hr4YpX5QwBDFkAnGuwAUBaf0o3Q61rxPJkZLJtAbTo3vA/TOT4/tsirAvkISf9vEh7oyq5Ow==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-Cva/gKCz8AXSRJaHhOnsTpdTBeDyj9y6LrlPvB8bQGWPVrxIZKySpF3MUp1XgkKptR0nWcmaiBpQ4gVXHSSPyQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/oc.xpi",
           "version": "102.0.1esr"
         },
         "pa-IN": {
           "hash": "sha512-67IIC93An2qX6ey1rzCh1xjX2yC17QfDTPmKu6sucm9UMSB3+CLFbwGA7gt3DlgIV63EgkI1qJEtBKl9RgjjYw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-JUI0+PMe97Q5YHfDpjetPTZkGMbcSgHQ4lhrbMwnSCz129Q2wgmOdTXABUYY5aD/OX5Aa+7oH8XXmyIVtVDiwQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/pa-IN.xpi",
           "version": "102.0.1esr"
         },
         "pl": {
           "hash": "sha512-cFhtXsnW3J+VyhBTY7qIb44BFBm7Sb2oJ+uOCY5YXByX7AmWxhQB5EU8IwK+crbvycWccEljr7Wg5VK6ZsydBw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-04Ax+N5F1DbbTs9lVVv+usP7gRTal6YyyNrLbY7c2WjnR3ADzolaxw8AAT1regF4sTg8KxxqCIHiIotGzEor5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/pl.xpi",
           "version": "102.0.1esr"
         },
         "pt-BR": {
           "hash": "sha512-XGhIucPCDDieN/yk+E9B5rjo49C9QECyqm/+C/EM8pKupZTrK1adPEU5wmtSBpMnNF0jTvHKqs3VJSX6kbXdGA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-Nfs+bsOL0zg0hzWBXcvyiGTccbOh81FGO7oLVmTmBiARq5MwoQkhLS+BOdLcjZDeyHX3rQAWswnlLmb43p929Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/pt-BR.xpi",
           "version": "102.0.1esr"
         },
         "pt-PT": {
           "hash": "sha512-bkqW0hB3PeVbwAAvmBn9P/wy7+mS4zjbnZfh0J6sQKwD2J7NCIiDTRd92VOwRaAbIBLVRHyTZHj+yJHtE21kcw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-cvd2JFRG2PBkIPdyj6NRkqEhE6xj/yLKO/G05e6ylORE7ZQDw454WV9RMg/PjIK/PaoTLiFDEGlnGewOq95Ftg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/pt-PT.xpi",
           "version": "102.0.1esr"
         },
         "rm": {
           "hash": "sha512-LyLIusbY3Wl1oFjCxq1av2GKzpq8ZzSXunPNw0OL4+d2YSfPHDLF/p192ONtTrd5ihZDhpTLEQWiQ6FyRQ+SUA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-l+mpAG9H3ED9uQbRVxbTaKsIDLfLPFPLLbowo7zKWgaQ8wjGPVDPZV+432giyos+RimSkGRLsG93EjTE/sF5zA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/rm.xpi",
           "version": "102.0.1esr"
         },
         "ro": {
           "hash": "sha512-g7x3sHsfY9TV5iT0Ob9BIKM+9ck9mJZVikVQYRXoNrdHeaQlpP+f/JHzu108DWzRft4+Zdik6/dLqsKwAqjqFQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-mzAlF+hCVBXWGLEpNMZJR2/L9JKTTQnfd2wMwOdK62HSlz72zOOh78KqjAXJ6K0HPvGJovvWOG2B9dNd6cR+9w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ro.xpi",
           "version": "102.0.1esr"
         },
         "ru": {
           "hash": "sha512-/NcWm/jGchI8wycvXERtiiAKfxs5eFenLZZvqE5xLHlA7r/o+4x05KzleMBnQU6w5kxYA+/ehTb+Y3Xe890S6Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-cKHJfOuG3jWU9CB1Nj/OtPLz9gw3NqX5QfsBERlrfASMCcL+BWtRAdnrRVEx9Dqb35EYwkmuveRvGf+fuGcvfQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ru.xpi",
           "version": "102.0.1esr"
         },
         "sco": {
           "hash": "sha512-7mHylcBbxN7cgZQdCmDK5/XaeoHU7WgueFyTRkRcRei+kxs/CqBX9TApN5iDThC+9GLtBefhtpOX5L4kIg3ttg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-U84i5THiKoSV2lqnFqLOjaSd3eTD/VlUff5FVzO7inRlB9iBCt7jSfdNXNrXg8jWnNp0LVI80ROrgFvsl6jAwg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/sco.xpi",
           "version": "102.0.1esr"
         },
         "si": {
           "hash": "sha512-Y/DmyWFWZmKkfXbRUivI/c19w4CtTxzhs6tfM7fUAAEqKRu/jYVlQ9hh9F6hovH5Hhimbxj4mtbv4v/BcDvA+w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-OswtIYrTG2ZTcPTpZp0VHUoaPgTvQe8+k6/ADYY+3cG9rFUE1un5L0Ccizgd1xWLzKEyZwWKj6M0tGO+NUOwmw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/si.xpi",
           "version": "102.0.1esr"
         },
         "sk": {
           "hash": "sha512-2D7invDL/itl1ZdHOc79waZWpkwGimT2jB0zFHQ9Gl/a+vy7MfA9qV0Jv+HfeSlnn8ERBm2ktllAKZml/7YSzA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-JorLMAeHDJzuYadJom/Hj/nli/X3A7tqTgeSU7dB8qYAdlQM8byyN9LNqDA6vl5J6wJnofdjLqtgjVsahK16Kw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/sk.xpi",
           "version": "102.0.1esr"
         },
         "sl": {
           "hash": "sha512-07ssMPoC3EZ5/vmNQEDXdIxbLPKRkE7oJ425j3/+EBbD6GiRT04oBRGX9KH8CqYXepT27UQY7VkzR06MrkbFXQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-tnC/rlG14zt7umcTkgVHfZVFRxzXk1pgekzsLyc41gnEfYBMFicSdVNCbhO0UkZkiEIol6CmGQsqhqNXaVxWkQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/sl.xpi",
           "version": "102.0.1esr"
         },
         "son": {
           "hash": "sha512-4vx56jCgCeWjjLZjGNBQkZsy24xySuLcG9bkzSUfmN4XSfjVj6H+gF8KkNf00r07YTpZBebZBh1iBnxlf6I0vg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-bPp6TEW4XjHu07d4JDfaASQa4/+ke3R5wnvzxLQfSmerExa+Qd3nbxQ9FW7IKppZwJ1Su4E8H8XORH99tYxvTw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/son.xpi",
           "version": "102.0.1esr"
         },
         "sq": {
           "hash": "sha512-mU7ycschXBqMt222QHEJbNTl08pOMYe3sestlBpW6komthRhw0tK+AzZ4xgE1NM1aKXZZdyP5gy2/8QDH6akTA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-zZ2ay7QEUxy3vz/aZ1m90k/usAUXXo4f7ogTgmkQDzY4XN8QW5AuEnO7XaA3LSCvCwRktU3NxGuiK2hj8yPm/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/sq.xpi",
           "version": "102.0.1esr"
         },
         "sr": {
           "hash": "sha512-6yAxLRnuGBkhtcFEOwNjQOVggIx9VgPdx/mMe6JD2rrX587/IoyEYT0jtO4N42nYaQQd3dy7/M8VFBU6Yunf+g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-/o+3fNAdtMzxShAeEW/giwiKgbZzjKp/tcHra+uTVqsqDndvetmlztEIMFmnacRb3Pk4gtX0T6BV7HRhVTEnnA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/sr.xpi",
           "version": "102.0.1esr"
         },
         "sv-SE": {
           "hash": "sha512-TUdVWwuACjk8g/4rK5roE7vji4jv9SxDEzZHXiUVF7fb9AEmjNsNdZS8FAO1maybppvOca87Nfkfm1+WNvgvgA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-gzNX1NBocvPPjdu8Fd2ne36w51iFouwG7Rodvl9uiWsdP+nJeKlOp0U1QVuhgs3bTRJ14x6503zDZ9jDhJqdBA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/sv-SE.xpi",
           "version": "102.0.1esr"
         },
         "szl": {
           "hash": "sha512-CYdcP36qEzPLuI3dnGurFLxbUmA0GvqZPi4fIhaKzNZ+Td928Cb64HPArZbBPXUIssPK1oiUst3lKrAHF7tt4g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-dM8OBdzcsT7t1SsFcYDEQhMWD3moNvwdsv6n/683qO3R7suagNSe/TJ7+bKS9VSNxERL58GtDigO8qDO02dQXA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/szl.xpi",
           "version": "102.0.1esr"
         },
         "ta": {
           "hash": "sha512-Bje4660grt4LI6ZphCO/au6LmRAyD6J22e6UA8P8ut6sZlfOjnrkOvAy4e0tMUvFxi4sK1Ng3HtKujCP/s/xCQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-kDD/+Ra1NsJKlumF2oaNyFZtQ08V4GfJv5Urj2Ir4fA+07xzPjF7IgM28vxqvbBOWzhl6jgx6u01X/LcvIgy9w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ta.xpi",
           "version": "102.0.1esr"
         },
         "te": {
           "hash": "sha512-sVfGpNQF01oXVGFK0IBJNFAT46mb1aazrBU5aQgq5Z9HQ97j+YpS17sKOL5y3bPQc5GbfkCf8St0pPhLLerMDQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-pn/MwWi92J7fqr6jeFWftfo9xXFQLtyBCaHv6qGBNShdf273+tC6KJ4j+LLOtrMN3E4+bLHopuIFbjAQIHq1tQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/te.xpi",
           "version": "102.0.1esr"
         },
         "th": {
           "hash": "sha512-biZTkGx0l+OvmYsuEqh1zNobv3qIzQwL1NI/Un29B031WO2HQAAEXksgK8+cgQHx82HHdjwdXEevehQ23w/48w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-omcoWOJTyI9PwOj+B3glu6TCk69bhTGnXN46OBPZuKTEUh8MdICjQ0EE424KZfWdbi1FqTBOKGW1DRmh0Z/k5g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/th.xpi",
           "version": "102.0.1esr"
         },
         "tl": {
           "hash": "sha512-K4pwYRa+whMNuSsaITEHMXQOa47qsqDyzTHxl06EpiJWxwy+MhOnu7yp7C18nPdnfY++8iPUBlK/z8rHMlqo2A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-cS8DHDtNonAETSLBMRKg7ElW+nVrfPjJN9HI2ySjBTO13dBtfQcSd0e9SXVNGCqZSuVUp0g6qovFaxKkBGeKsA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/tl.xpi",
           "version": "102.0.1esr"
         },
         "tr": {
           "hash": "sha512-24JCeYZLtoDvimhEfqjqyrdrKykTktXgDda9dVzEbjN+4gYY2soHtlDS2DEdDs3FyGj2VhyMBK6DhO18KHG3cw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-H8Tow8W2LV+R6blyKE2y8uPKe+fVWosKTJPfNhdvHasUnMMgiTsnozzZfLl8iCEX58g9HVxBLvOHySvizXhjow=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/tr.xpi",
           "version": "102.0.1esr"
         },
         "trs": {
           "hash": "sha512-8Se2FfK6tgd82uMb7waogZjf/xVK1K7lWGywdSEosr5nmqjF3ZAFpwX25RcVmQD2PkylACvNXArD7tKffp5rXg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-fL40uCnS8kIN982mOKMWmfdtvE3aUiExWJvSJj1T6cFJBqVWLlc93ZXHfKjcMh/6Qe+7d2Qf8/hNdVeT1LHtNg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/trs.xpi",
           "version": "102.0.1esr"
         },
         "uk": {
           "hash": "sha512-WfL9pxM12+Z4I4vWPsKpRn7aRXDhUEOeWezyLCGTe/6r/a4TUUej12F0rE6dLjtITwHAxF86trwwRkpQjGqdVw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-nsIZRFPEBV20fbus/k1c/hpVBMOz6t05icA8BxgtShf6+BdyrMm1vQTXhU0EskBMr8Fm7X70aROU4GABZ8YyGw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/uk.xpi",
           "version": "102.0.1esr"
         },
         "ur": {
           "hash": "sha512-CMHzrj0PQ7OSGGy7NCCysgWJf/tIHqYp2ydSTHfuW6wAZFoW+9kpeigHMO1mP7HrldxSOVIlX7FBz64ZSSzNKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-2lbZuK0FfAwRp6LPCCMKNjl7hnnIe30Y1wikm28HJKN0Qpp3Q4Z/+JQ26xXT4Q6xntEchmvQFQlQkRbjj1Nxdg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/ur.xpi",
           "version": "102.0.1esr"
         },
         "uz": {
           "hash": "sha512-JWS98LUNAz89JfK1/VjAAa7dDzB75hxH3R9/RImQqsoahmwVqA7QEDZSFSusL2DF0vCvo7Ames3gW4vMvt9VFw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-DbFKTnqxByDnHQZ6a9nUYm8CWdd8UtunQucKRB/jiOBsmZuN0xyVaFEUVXSQYCDU2TCD6Ay6zLE5FUnBqT+ncg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/uz.xpi",
           "version": "102.0.1esr"
         },
         "vi": {
           "hash": "sha512-qZdbuZCMvgSWkkquSrRz/nUS2jG5/9T2Os6LvTwfAsrbnC1OMgyaopD3O5JfQQkRVPyf384VhaNTKMVAkIILnA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-2uAt5nV8mN/BADE4kXX4F0DPOSHyPYzx//IzHM+P3Bx500dsggsjb+I6IZOqEdsjdr0beLsXF12nwro1GRECKA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/vi.xpi",
           "version": "102.0.1esr"
         },
         "xh": {
           "hash": "sha512-+Z6y6Lo4cFMtAUWbco8+oyhxPDMQIoLBtyHnwpBi+Orh5Hrpuc4jJXOd38r+/9mrmSLHbi+q3MG5mHum/v4zJQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-hVyOUpXszS+jJgN1STghD/ELFBU9JWvS03oulwriN7naSRpSCPh5rcl7SiVOP6q2tlBYa6JTTc32g+inKoehLQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/xh.xpi",
           "version": "102.0.1esr"
         },
         "zh-CN": {
           "hash": "sha512-LGSRzAgWqofP+9qffJTsOgnEcAJERM2CSrqFNDyV6lfn1le9QVdZ4+IwAbi2J7vK2Jd4H9IYo7OADk0AWZPjag==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-TnPJBU/pUGr/+s5ZgYDCS6IbPVK1lgfFj5ImMc4vnAPJbt4wgRBPrjrduP0Ds33pJIHtHzGwwyQzl7EFlIKm4g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/zh-CN.xpi",
           "version": "102.0.1esr"
         },
         "zh-TW": {
           "hash": "sha512-8qRGcQkGAHu3oVt9JDFVh4Pd0Jynhe4s+gdMyccDJSBspUIGCVPMXTdYulCUiYfy8NbtlDcjGwsBn4ZOu4yi+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-OHPZ1UchIlbt7QOVWxxSf3rob7VAp8yiHJJPuCdQwnHekb0piveOQx9qdHmjflWqcaHwWuuqev7/KnsP5trmMw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/102.0.1esr/linux-x86_64/xpi/zh-TW.xpi",
           "version": "102.0.1esr"
         }
@@ -2962,491 +4726,785 @@
       "linux-i686": {
         "ach": {
           "hash": "sha512-UV6EJNptFQVIDxVFHFY2O/ckcfpNDkez5DtMrCYbCIuCqFrS8yNO37hJm+q/OS4GNrIn0NfMcoXlRLHivc3zlQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-GTyumhHnbmPu/LGl96AoA6jjpqRwsja7WhIyYg7nj+ohlZt23U5XIm89Tcf1vN6KIN2KJac5L1l9aSDtqgQXzA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ach.xpi",
           "version": "91.11.0esr"
         },
         "af": {
           "hash": "sha512-BLzGi4YafJsuGPxP394CR/9Rh58E6NupwpmODNk8oVb4z1b7Y95jvPksVsktqbfgN57QhH0lH6reILnh35aNYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-93eBI7jdN468SVivdTRl+2VdwBfVccYMWO9jo2jBbEGq82NIwLEigHRTSs2mxkjX7PKpdLs8qjCiVMrQGcNfdg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/af.xpi",
           "version": "91.11.0esr"
         },
         "an": {
           "hash": "sha512-f49W0zNLvss74veApgME3wYxOm19vQ/Dry5tWwyT/nh8Nvek5iNkiT9ToDgV14RQBiY7EADbVtgX/ti+WQOz/Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-g54M4aF0HVgbFLEhUUhsTHmxA8mUYByrtVmZHveDEQB3cqSwqx2kJcWVQVU1m65/XRoymVlTBpMO7sK2Vio/qw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/an.xpi",
           "version": "91.11.0esr"
         },
         "ar": {
           "hash": "sha512-94JGx5McNi7n8Qj4/sudlOcgfT7i8On+W6/5ww3xJP4YvD3eDAuDPYT1lpINQ54CKWvLn6CK03mYZYUHgMsf/A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-SwVd3rq1OBWfwtm+tGIdn3mGEufcG0R8qET5i6hBRgBhVwCAc8EPFUMc7/uC8d9lcCozGejD98lVAZ/+dUINwA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ar.xpi",
           "version": "91.11.0esr"
         },
         "ast": {
           "hash": "sha512-ULtez3nBdtX8AN8wUMrUAwRTioG9zCI1rdbiZgormmufk9PdCsmaYI6fSz351RvEvBsCpQ4bwU+mYcGJabAauQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-2WtEnVhAuVh+wdiW0i2R29yk3srFauFc+NFs7xOZ7cbBOzzC0MG01bUGmzOUNdEVyn+nJSiVG0nUAutIW6RDnw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ast.xpi",
           "version": "91.11.0esr"
         },
         "az": {
           "hash": "sha512-wxfcqfoOJKo69EbD2pQR1Pk4QCQN6Up7wkXbmKoFTSK93CBB0MCzAZF/e3C9Ue6dmon51V/77gP5zBGJuntq1A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-puKUazkinjIO9W1nHUjrm4n8gKPhI18BZDY9kwzG1A4HzAysC6xc0GS5LV2d4yyQMFA9OyWUMxVbbCeNtVkTEw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/az.xpi",
           "version": "91.11.0esr"
         },
         "be": {
           "hash": "sha512-r8SI4EPzluBRHCVaPwmW+FJ8Ma0Zbq27S+Ht/7Lk0idEoBjAlnh3ABAsM64cGcHzVm79LvNez0ezP/Y1JK7S9w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-SDFza2Z02cdziK+78Y3Y3IAWcecmzHkq2CmJ1OhJlWISuIQ21p7dxzbW5Mg0j7DzNrXi2X2rqZThG8iuzaXGUw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/be.xpi",
           "version": "91.11.0esr"
         },
         "bg": {
           "hash": "sha512-Pt6NlaDrCFnAyBWZXg5Q6AAE8xtONJkit4EQ4wDH40mOjyqnL3evdoBUzF9k9Jo4hzF8PRknKT5Z0P3ey8w0XQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-p0cEqG0EKBkS2n102GXv3D220i9dznP1Ogg6KrhdsJAzuouipfuuHDPZNdTAm+hNV/DA95ezfs1o9tooIjJ91g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/bg.xpi",
           "version": "91.11.0esr"
         },
         "bn": {
           "hash": "sha512-UKe8O+iPPcxEdQcI9ZTcPESSi7oKvobjW25zCctBfbDtkS6ij4MhH5fNKvxbTj4i0yHdCt6yZhU8vfc767dLeA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-HGnJm9qGM+O2Ek9qYQR+QCnFT+wSzndFbHU85hVEzx7quxWAI9taVye6DnBEKJycm8deD6JdyjCvCq6/WdxA+A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/bn.xpi",
           "version": "91.11.0esr"
         },
         "br": {
           "hash": "sha512-QdOJPx91Msc+XYzQ+AoNNLW2t2fG7E54qw7m6oM266ppoTt1oUVScSrOTLQAOhJrIg7ZHq4paJeXFef/yv9+HA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-nwQ4JNluhW6GA9Bn3ouIlrkNlCHDUFPVmg4A0S7TfVHB0/qKPrl6rzLKNA3TL9oKuwbTVUMh1x5VJw1MJHzL/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/br.xpi",
           "version": "91.11.0esr"
         },
         "bs": {
           "hash": "sha512-2CvN3yDgQWtBSRvF56KSAueljmWPb6ZgR2oszvrSV5gWnObgbRRYrp3JBljbLF79VqL8rQ4VnfK8UWzFMX7X3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-stk3ZFoP5ykCHK6EkG7tydN8W7LL5ct/ZIo9oLBOOqGXYpM3EpoAJxXPUoZZTxf/U9z9iCZuh370x0Ay4uT8jg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/bs.xpi",
           "version": "91.11.0esr"
         },
         "ca": {
           "hash": "sha512-jr8i6v5GcWZbjGuHMrdc0wo1Dv2PDKhe6J8xPyUza3CdRhr9vyWXPwRQZgdXbsN4lHmV1n+9aRFyNEYApYlaqQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-WVQWLCQTPfGZj4X9qmimHBzuhKfZ+RlXFWD0nOGBfA1Bi6EnzkNHHNiflKvmoRX5bpIKxeVfAqeSeJTLI0oeNA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ca.xpi",
           "version": "91.11.0esr"
         },
         "ca-valencia": {
           "hash": "sha512-fhuSeL+aH4brhi04kyK7I47iqANqKkqPB+vWmIuGHV+zK8tgmFHv3dgaWyd1qExnaRPcN2HPoAbfUkbT7hKqIA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-tTKCYIQkJZyJ6Gm5AVqRfB4ypGm/GzfcklUvDkV2AjGHGtcXaT/a8nMwwYSFslBTjHgldj0DdzXY1ZUiNHUREw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ca-valencia.xpi",
           "version": "91.11.0esr"
         },
         "cak": {
           "hash": "sha512-Dgocidgf8KqwSpjOyO8x80tyxHFovF+f3SNPDCHIvRWFF4D6sMIGu+Bq5D0vzx7KiPcofXqwUtWP87IMqWIdeg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-/gppL/TjFRsRsfMp7NOALqiqb+wgY+dLD2hHYhlOP+09za85eIRDSY50gjB4dcivtcsZD9dUY/F+/sJyey5hzg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/cak.xpi",
           "version": "91.11.0esr"
         },
         "cs": {
           "hash": "sha512-I9D/+/I68WCXFc86niMfGHkxtOowFLW4CxMyQkJJoIw6MyzMABfAVlV+PlZBtewbCr1s0JPy+PGLFP6l+duRzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-wV39lL/+SFBxPBtdSIyW9sU4tgYSrfJ932TcTF2o+yHfsX6pLxRgxcb41PxwnLoLvcw/v42+o9ifsJR6rcLeug=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/cs.xpi",
           "version": "91.11.0esr"
         },
         "cy": {
           "hash": "sha512-zKpoeFcrOZJPibm+fqNRDh4l9d/Ok1g1S79tkZrpShzH1XhSDmTCczC6hLN+i9aYFVt7Z0xfT7WP0ADcFKI9Rw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-PeTHEgSCxV9DDZWEGFmAaghaXoKC/ztjHSiqSLorIYxXu4KfzKgPFZwJ469DAQ+OL3P5g3wuT/DVfw6T6vviGA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/cy.xpi",
           "version": "91.11.0esr"
         },
         "da": {
           "hash": "sha512-fLyB2fDeKrzHzQi+91wA0pFo5SKgsdhSoISCUE/PH7q+MRfk0dfj/Yq4J5XOKEpgYzamr2GfAN+58CUXa7o3Xg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-olk3jgpEB2xj9JuzjTAi5hVgegOAJTQRPFTOOPRA1ytqCloU6GZcvfTceUvz9F93A5kWpyoQ6WRKBurBgYIOvg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/da.xpi",
           "version": "91.11.0esr"
         },
         "de": {
           "hash": "sha512-/m1FB4/dTBUX5S7jtWPBIsxrHZbamWaGbIESj7cmS/7HcgwYTQU7LLHt2vIQI4Z6l3XGdqHILyT8k9DScWR8SQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-YPA9rUzhim1kKe0jWjyEHLRbYiZvdwp9nRcFoTmmhoDusly3loEkFv/5qb8EkcmC+hBTwas0QyLxTwybEuqTtw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/de.xpi",
           "version": "91.11.0esr"
         },
         "dsb": {
           "hash": "sha512-E/KZit146PjKX1s3eKlV9GZugjB3h3FpEinB29h1CljZvuqYzKVIxxQNFDY7nM355o8ImRTID8aXkV7IAqqmMg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-aoghRiiz/XD/e0pWEZgpdGvr4tNy3kf9RN3MsKq5lkFWDZGaVJh+wskJFjcf8xFPLLUZj+LXI3PqPlk3iWDGBA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/dsb.xpi",
           "version": "91.11.0esr"
         },
         "el": {
           "hash": "sha512-lO2J52kBcZGUYMEw/gU6MbVPErttpR/EdjWmwF8d5jENmdRKuIe4neQPoSyC+tkLPJZyPLQXspHsgurPwBVKLg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-ey4yICfzluzKe+AY168uTlz5EAWG5forMnZAagoC6fnk6z4HDKfN3pR2akkj4Xjt5SztDcH4POMJUDJU2ZhDTg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/el.xpi",
           "version": "91.11.0esr"
         },
         "en-CA": {
           "hash": "sha512-NcvBzq518rAfJSabvIQbTfk+IC+xnJgwv4A57RDrLeywhadZUn4cIaTj0j00PLNPAI7UlxzWGsi/RsUWqFaNCA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-beCQZiwBLv4FscwigkHqo4TfNsF3yzJJcBkc3cR5Q6yxT3cgIZzuiwFLeF20cmrNn9OaW+iIX5F+RBj/9ruWzA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/en-CA.xpi",
           "version": "91.11.0esr"
         },
         "en-GB": {
           "hash": "sha512-lnMgfyRh9rfqfcr6b0pBf1fWuFgOm8CyORnG3c8kkEHYKRILGJYPtbB8Dw34+G3a2WbU63jHkIRRj8IZJMuwDw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-ilexj3PIGJhFMsxBc3ZEFcuq7BBm9oyhTJl7XTw00YXVCTOgUvZUJWgM4orYXZPiJvrdI5134YQoPToy0sknsQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/en-GB.xpi",
           "version": "91.11.0esr"
         },
         "en-US": {
           "hash": "sha512-ORrlrbpmKMGUiRwxj0AP4fw3/LUD6smF+ohTIH4DSdy0d84PkKhoQ+8f0BybcBLR+GkA1okFLbZlQ+gJw+vE3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-tYvPxAC3FPHwoacEyswaS0sdJUtCKva7nEUENjNdr2FUZ5zJkye0ib72UO4xZLNTB/kUP59Aun9XrUIYG+stTg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/en-US.xpi",
           "version": "91.11.0esr"
         },
         "eo": {
           "hash": "sha512-hLcYuRiXOEIUs5CAuZp+aBXOFPDinr2Wy1AqAxbCbWOIWKG6kqBbAavaGIDH8aIi1qZg2ay+XEgdgpCYQJPN9Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-yLqrxviYlleLcw2PjB00Aah4VufI97sovWDF4qe7kB53t42mXVT242KQGvBcy6aY2+ROvqC+QwSbAsQfZAyO/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/eo.xpi",
           "version": "91.11.0esr"
         },
         "es-AR": {
           "hash": "sha512-+U45lF6ibVHUkgGnT3gA0d/B7l/Ag+a9QkN7zzqmaPKqQR/kzOco3K5cOivNaZna9LpZ+rfMS6ElxUx+LmsfBw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-FuB5SMCredWkLb5pIVySoBkAFQf9y3XBPaX9n80q7vAMtbTk5Gwx1rMkEDTlwGBuQoYFrUzjR6uJBWvxMMe/Cw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-AR.xpi",
           "version": "91.11.0esr"
         },
         "es-CL": {
           "hash": "sha512-GDl/22384NIUhPxxvCHoCMtCE4AAHWzoZ6ZsL3TqcfBBfPKgEa56ZNdBeKM5I4tckQtkJUF464JZj9zZPm1ccA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-BTvfLLoS6YZ+21mJwXt8kkwd2Xi9PeD6vg3uoQ4OuRXa1mLmwt+upw36ld5VoRMBpqgGbqrl5LM08jd1pvY4Rg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-CL.xpi",
           "version": "91.11.0esr"
         },
         "es-ES": {
           "hash": "sha512-xSlyakBEHiLCl2S0tmLoKDabJCe9BS5wcaAtOK2l0Ce3T07tjWRnh8XyIUH50G8PaJpK5P7xW17d0HG8Rk6WWw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-9AamXDucJQjja/z4EWcGEf2zYjmoO8bpMHygw4mGuSinMbce6iNmtalhbFBLJ2cvbcxt0+J+cbkPrlGnput/Sw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-ES.xpi",
           "version": "91.11.0esr"
         },
         "es-MX": {
           "hash": "sha512-zaoWYM32ekRtlNSOEWunKl5h2GuTodxNu7/zfq+UHoL56Fy5DiAE6JGVXzY4mVNHOitpxbT/QIO1KLHbAu3PyA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-FzHGXjXG9xYray437LH6ronlH7VdW8OxZ0jDWL6rAYgxLzfuLQAEPrcFhw8h0psqPsWUk+nOA1NHMJr9pTvdig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/es-MX.xpi",
           "version": "91.11.0esr"
         },
         "et": {
           "hash": "sha512-nhzyYLmQBIYtPrF6SNIPvuh7gnYPaboJqqIW8/inPIFmnxTmVyt6YJZdBQLSCXXP9cko9d36laaTvomikbDUKw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-qpiSQQdHjwkqbtJJUWEGF0c8LKoVQ8XLi5nSFw0NX7kQDiYnFlfqmG3gEM9dznSHLWxZsLhQCfVZQIIbklOmhA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/et.xpi",
           "version": "91.11.0esr"
         },
         "eu": {
           "hash": "sha512-usB8aJLfYiPFZBaT8k2MmCJmjbceZ6z0TCWaUhNejxfsqD2XhJ407CT/4GcspLa7KYT1vmo/31cS1+odjxTPzA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-bk3VVTmMvkGLn1JSsScabKQtsX3/LiTkm9L0e5mDkY1qGld8UBsDfl3/DZWoZYiulDd9/NZGu9w0G9lDj0HP7g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/eu.xpi",
           "version": "91.11.0esr"
         },
         "fa": {
           "hash": "sha512-fdawOVw1HrAsjYuOs8uld4Z/P291kPQxU0yv8msVb1xBYRTMarY4NG2QFImhDCcBbPXHMzKV3pY7Z3+cJCrjFQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-9IsSNUNy02e5mpxH6Yvh7e5pKdOBPA04M1cEdaTTNPeJSwP5Zs3kEsMgjgLYV5VDSekNx26o1jxQ+COVpM8KTQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fa.xpi",
           "version": "91.11.0esr"
         },
         "ff": {
           "hash": "sha512-XGJ59kaFLoZXFR7RthoUJD9VtqmCoUSRT5/nkU6g7iHMcuUwus2p5rtwiwRVyHCDqSCLDWvV5/TyzOSiTwTcMQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-gzhgIF2hiJ3lmAXyVUMuKH+zFZn13GrGw/DDDBQE4OZCUvSgGkLbu73QmscQjSUtMCE63zKVogdFgG3vHsL4Zw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ff.xpi",
           "version": "91.11.0esr"
         },
         "fi": {
           "hash": "sha512-2c1t1XPFiCvMP4K3t+a1Su8EpH2VjDVN/JwE3nrOOPBIWVk92IWj/s1LX4GhVYIyWbr0r5I/6zHHa3OkxkTW5Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-t3TBwYJpxPum3Et6vrzjygObcD0o9VpJOVZ4RbbTPcwiwTfci6/IbcEVxTjMoAwLes/1VsDiZGQp0rDrUN5XAA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fi.xpi",
           "version": "91.11.0esr"
         },
         "fr": {
           "hash": "sha512-FKFhdAPPX3oOFG7zBacAZcXSAkQUMNoqLbi7JiB8q4Sm57uHOHhH4Nm0A9myp5eoc5+fppXuwMnP9kjBdZ5i6Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-JXo5DNS++xZ/P91hXNHu9AnAXWOIP6/UgB09Y43FSsnoPaJ0z4SLxcSgilMv2hSFhzvviMXaeOWoYeNYKbKAQg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fr.xpi",
           "version": "91.11.0esr"
         },
         "fy-NL": {
           "hash": "sha512-rNyGzgwgaRod8erqF0vOdfKIa0UgZMZgH09+WT66C4jPnCOi5L0pM1sKD8Yr+4dPTMTEOSi+hSiXOdLzYa3ctQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-D5HXuazcWOAI9T05j7kMh6ONlQ1Ds6uUr2qyvpyv9EeNXPLZiP6Ak0U+f6BEhe0BS5U85Yb5/0ztEeOVCiavFg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/fy-NL.xpi",
           "version": "91.11.0esr"
         },
         "ga-IE": {
           "hash": "sha512-PrpkCjVQ0mlVA/djl10eOOg6H6SfhXZJj35yWceYxLA0MZ/sHlXnBaulqGSclHm1mQHjLUtPvI9zHhEcMlFMzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-t+fKv0HqPoq/Bx+QWLeYSW3Jql7Xo7PZlIhM63PTeqUStJxdESeJbr2Q1mFZXQgp4T5FsXBGsLei/w2zU7JYLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ga-IE.xpi",
           "version": "91.11.0esr"
         },
         "gd": {
           "hash": "sha512-YYwUXGpPGiQy74XlcmnZFQaj/18sJGRjKhjB4W/9w94bPCMjAC4j4Bl/twG3QI1JBa0ZBQQyOeG9iN4vXd0Fyw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-8eDs8CFpoFp8i42EbPW5KQSRfo8pjCgTQnmfe4SY66SfjVTMfoCDwD4myHw6bo1uWQExiQp71/zmyE9cftgMDQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gd.xpi",
           "version": "91.11.0esr"
         },
         "gl": {
           "hash": "sha512-DX5NcJsBqNkB+Wwl/VESKHSF9kj6FBiFQh4mVqgeQLcfhzcSQ5AhesGdkCwi5g8cqm8z6jzb5DUgjxm0P0+R5w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-aFtNjwap7EioFrCgGwSYv6cduOuS5fUwWAAjwd8jC7lADm7w57Vdbh81E/Os6Ga9KoZfctX/mNakeRTH2WNkeQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gl.xpi",
           "version": "91.11.0esr"
         },
         "gn": {
           "hash": "sha512-CrRKbWcy8FCFXFs9e59uX5IxaVEYcDDJUZLTXiF2LciRumhDCjMsHT/+IBYJYIrwhJv87QH0+es7euvDRZwrNw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-OkLyBI1aGxTZn6WFGKHWS+DgqBJs2dWovdyAtSkfCrOYGLjE3YyoySWjovkH4wlygXvh/oQDVcNuXC6whQ5VhA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gn.xpi",
           "version": "91.11.0esr"
         },
         "gu-IN": {
           "hash": "sha512-8+p9QmOx1Bj7i9wZ0LT8gAjU547ya5S7fU0k8ktkD5QQy3NFaQzzR57XlUt+AckK0BZ1mBIN+6hr6Xg+z5lHgw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-FQHmwymHVImh3SBid38b3cMxDH64ANpGE6hPslNaBjJNYbFXxJ+F+WQxQXnkzlq7jhhI9WK3tnIJb6RuuNSKrg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/gu-IN.xpi",
           "version": "91.11.0esr"
         },
         "he": {
           "hash": "sha512-VPVsppwYyDAT9gQTmx4/U8Mxv3a5r6UGiDdQWceqh4MnkireXm6vJSCFnE/Q+K27j7Y2En7nr/ehg2a7hmeW0w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-lGmJedujB9Fim05hI9DHCBg7xmh3UIpqW1417tn+6SrR5k8FNH87p2LiDEWLXrNES5GDFFxGpoLCGg8XPwb3iQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/he.xpi",
           "version": "91.11.0esr"
         },
         "hi-IN": {
           "hash": "sha512-2wzPeBMx7KaCe4j9jvs3qupZKUS3sr7pVg/Q1+RHyjK7kQoMmX7WHFVBV4U4t1SZxXtm4loZykSbXmwZVhSh9g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-vRj/nQTtVqrbs0g9iy+PnqRfzwcz70TyK9egltJ2tFjCPURWZNwLwB4SpG5oiyPl58yYJFxOlexSaHIBNtEiqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hi-IN.xpi",
           "version": "91.11.0esr"
         },
         "hr": {
           "hash": "sha512-8gc7m9/pEKbRSqVY5897jB9hEJk4uKlaMTgPCMRhjwzrssoUD2kyF5GWXcuXm9SuonFvCpLRF/B45hXOd9ouJA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-uPP2PkIzpxQauWMEXisQ8z6Ti5MWaDLgQC1Pzj8MmT656zjhLLkJTtQ1l+VyvGuUNV5wQR4wckTzXhMSyyX+hQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hr.xpi",
           "version": "91.11.0esr"
         },
         "hsb": {
           "hash": "sha512-JdzryecYb4D44HNwxr6/UFybZ4DBalPb3n0V3HNBA6xXw/GC9dFUL/2qqm1vPJaGDegRRsY07WiqIloHzcATAg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-r7Iq1Ogz5aVVE4Q+6kHPHiB9HTR+KGS0BYVZm5o3bHg22gGkboB7OlF5HZg9JY4Ubikl/vaF4T1pQO+ts4/3cA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hsb.xpi",
           "version": "91.11.0esr"
         },
         "hu": {
           "hash": "sha512-Qer9YcD1yjZjqtzG1X8bty5kPFNPMlZkP9CGvpV+lKzuWTL7wQyD2rZb/tmC5BCYrMscqAZ13aiHybsj5DyOuA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-8GRp8YX0GH9qPGRkbqlwjPkk+BB98Rrg4e4V+O7y7LqttSM7ZQXRO0gZVt6/qioNcwlNiYD67nLy5m476uYOuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hu.xpi",
           "version": "91.11.0esr"
         },
         "hy-AM": {
           "hash": "sha512-Aa035IVCc47fgtBwPvsVJ62NLj1CvxC8XLE5qrIqc8r0MmoMiK0b5IjhtMy16yZoZVh5SsmQwdExUj+edXFUJA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-JoyzntQT6UCWrxW+Dwf5i9d87gZW9Hjr0UUERwEUMyLYCt6ufmsc+g/M6ly9Nja/M3FDTVnyGk5JKHlz+q9H5w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/hy-AM.xpi",
           "version": "91.11.0esr"
         },
         "ia": {
           "hash": "sha512-OxogOR76N3b88N8uMtd4KfugN/EeYasVPSrsk/FyPJptWqSFIdNV9C008g/hkUiXal30IbHBaR0dlyzcMUtLUg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-IWo69a8nUoHWdqeQ+mcSZmvF3+tux/QSLtCHBpEEXoke/MOUb5G+LRl8rxErvGxI8BG8pjltb6o1No02BDQkXQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ia.xpi",
           "version": "91.11.0esr"
         },
         "id": {
           "hash": "sha512-n7UKOL6P2JS7MheZuMM7FCv5y7EePNBhGGDvl0yYes3Vez2kBwGspvPTacbU9TTa32nX5OvAHEyH1UuztreICw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-3JR7qXPJaxctNs1fwEDqz5iCkTcDDSL36OyFkfyy/FBnjvBM7KW7vCnyCCaREAvifkXxgpZUyvS0ccxDtoJlcw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/id.xpi",
           "version": "91.11.0esr"
         },
         "is": {
           "hash": "sha512-57NuiYfXsCgoRVK/NKvswDnoO0avP7fJVEcbIo2r+EPuEqWNgk+NFg/XQkWJnQfiRh44oJScj6IWNbk3UPss8g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-hon2DXKiu8I7tuoPhA97LOXDIyHBMha6qzYc0RD6/ugKnQ4nKKn/ez1lVkpeFfhyoRt3NZgbSVBRNIfmK6Oxhw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/is.xpi",
           "version": "91.11.0esr"
         },
         "it": {
           "hash": "sha512-Ytl7MCEHLYZC4NPqsdMv0Ec8IVemPoZ5YTLWzHIExpbL6qP61JuQnLagaARd6G3iU+QWBLjLA39a+1QbjJOTAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-1YVS6w3+lwV7aZzmCVVdMnm43UlBSJAKSj4RMpqjo4GVFt8u1JzQY699CBAKxQm8CdLcFaH2a5RhgYM7McNgrA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/it.xpi",
           "version": "91.11.0esr"
         },
         "ja": {
           "hash": "sha512-v1PK3QAWiRUMqMvsuHLPwiyf0CbtNGO7JZXyw7nWZ4p2gpBhCLxZcllNxD7glTWICUplKY2kGsO66AOpDskgrA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-jslzBq7vfPbpxsUvoPn9jRx1iMWjjT10VD0i023ml7h4sRwQlegD+q4UL5zVs5K104esh71Q+8PuqQ8MzBBjjg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ja.xpi",
           "version": "91.11.0esr"
         },
         "ka": {
           "hash": "sha512-C52pfkRqUvwdDDfqQCUXanxuobU/dlISd8+90cQZ8oQPH5i/vTM8AzhZKgIRix7MtEp6dxbzqNF1ggfWsV8k2A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-jxZyQl110pbQWT5oxBXwLqru4PSY0yusd89aiAIMWMj/aoXBlVNoVK5MiPOgbUDmasFPC9SMTiA43k6izKFBKQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ka.xpi",
           "version": "91.11.0esr"
         },
         "kab": {
           "hash": "sha512-v7DoY70F+wyrScPMewWA//ri9Bkt0s+xhSRw9eDeQld7l1UZGWdDUPKz+G5Tl2Oi00WLvrQKGFLYZuWya7qoiA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-ASwxGoao8YAz8mgI4uz4FHSECl5KND4fANGhiP6IHFqjnZERRnsw3/jpho3kzSMwqK1bkquGNm6vX2X/lRDVHw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/kab.xpi",
           "version": "91.11.0esr"
         },
         "kk": {
           "hash": "sha512-9Jd+FDpOTouR6423KrGsQ3hxztEoLkcAZX11Jn1FWc9oSvrDIPyx/MyLVBj55lI+CIeZWEk7tMlpk4qUrxwXag==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-YgD1JOlBpOKzPg2/TFHm9WzmaDGWJ6ctu+5N0WYll/lHunTW/KH5hjc7ZQKjl8TlSYqIg5lMH/maS0OXC2H9gg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/kk.xpi",
           "version": "91.11.0esr"
         },
         "km": {
           "hash": "sha512-UvKQ1ASbzjKs5kozwDKoBlILKekn/ov5LV+iJsXSHeDSmLAKJuBbulObr6LXAq8dvrcyhFxFZfdaF+Q74ZXjsA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-dunAO58VtxTYSoF775ToraOnu3B3aOTyTLyJlQMoqtzif2nteyMq6nIEzDqphDRONNRwLBjro6JfkHhsE+ncFQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/km.xpi",
           "version": "91.11.0esr"
         },
         "kn": {
           "hash": "sha512-ZAs6D9HJiF7ijjLN97ce6mk9XgHmfgkQs/Sf9QaxWTgn1M2YysFIGhfaMNs3RZkRTPmBvRC4jbjaNRjubR3HlA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-y8DORWKxHU5BOG55iNAAof73/hTLtqP86Ubt6/V8uNUQuXoidtfWDsj2hLieY2hOEDRroHHeY44HKPlu+XW7fw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/kn.xpi",
           "version": "91.11.0esr"
         },
         "ko": {
           "hash": "sha512-oxGM12zwwvl6kViugzUknQQt3jEJPfV6Hg5BdTbLkxFRDuV37CsSXhF8Uqaho9Betiud5H3Td4bpQq1ZDnG7mw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-mRbQgr6c/e4UXr9aY564xHh9mNKtFy+rGMARy/lli3NzAE+A0g2il7Vg6X0P+ucbxuJehBaPNwBt7qQp2HyIuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ko.xpi",
           "version": "91.11.0esr"
         },
         "lij": {
           "hash": "sha512-nGHU9ZZFgMIeSjYEkvq7C2ABuU1/Yo0cvIqOd5EuXP4MNZO/HPEh5VGW/u5i9aO35KzdR/17EqUcKyRT4jt9xQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-QzNvJyXNjzD8jjyIXoIAe2YFF9xB8bhUdl6EVwHEnnMk6ESp/YwAHEc3mr3EmSJAE9Kx6UPACkhOGPtwDjr+Tg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/lij.xpi",
           "version": "91.11.0esr"
         },
         "lt": {
           "hash": "sha512-cPTizsOTQJYqws3hMl7KeHkpjR5XM7ySKGweIJK1sXYBsjzY1knVgJ0PK/VjbLT6JNw7j+g/vjoWlIE3Q1xkIQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-C0maM4F/ywaHLr63Qij5OUczst/vpKJ3sgK9UIP1wgPJK3WRl/KxE0ClFemDqympHNsEwoIAD90e+j44N4hg2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/lt.xpi",
           "version": "91.11.0esr"
         },
         "lv": {
           "hash": "sha512-PjkQU1UrPSCLeYo5mbCSbjVorFtxiCrcOpZPEO8E5guOqMZkOE0wjsprBonM022i6ttEzlVotSqdz/LyXddoOA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-VRDVB51UboJqwz36BkLz25Am9c0b04LwHQJ/XKxkmSkUZxw3qtS5thsWPImPy5acU3GF/L2Fv3KwMvGbo7JCww=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/lv.xpi",
           "version": "91.11.0esr"
         },
         "mk": {
           "hash": "sha512-uEI6kPkmEsUIlaSSteqrbmzh1mZmdaxomq48vyhWQ6ATI3nblXkaWVKN7QKku168HS3kSrssPiQD77QfJLfKhw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-KFiyGOBSx8m1+Qk0ndpD4uFBzyELL7/gUNeaOwGeNO9Tkn0zt8a1KEe/cgGnK72TOVc9IfF9HRGs6JK/1Nir/Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/mk.xpi",
           "version": "91.11.0esr"
         },
         "mr": {
           "hash": "sha512-NuSfd7GeKwzqJDw7kgGhK7+1pj6C+1z5JoZ6cWusRASbj8/Kyuc4BNDMO77aIw50dgjKHJyRFc9gzmlx5n7JKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-FinPd3Z0REHheEoezCv3h6CZoUTduDJ8Nddy2hPfC5KgHK3b95nZX1ZjeRnj3mPqZVoaLiwhDmtYdZBHVyCWvw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/mr.xpi",
           "version": "91.11.0esr"
         },
         "ms": {
           "hash": "sha512-ZaQrukzvxklI7NT2rqhheKLTXXArvSnz6adTqtbuTEc4dEWvC9yOVYogWTV+J/bvMPMJGnBhZjmdk07h/xW+gg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-q4XzkOqo4hX7QTvHtR1LCFClIlM2YwSCPREC8G9tsWLAwdrSW3E8cG8W9fRiFTtkfHXoEJJNFXDGJUGR/f+tqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ms.xpi",
           "version": "91.11.0esr"
         },
         "my": {
           "hash": "sha512-J5sXSpMNnDx/lFlD8zI3HbDGSGl8iyt0PwkZklAJTeFcw+1NGDdF1R7T8Hh2p/36Kj2DtMV5F1fZRINvBwR+rw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-ImaRCe2lbOXwlpPnDiTuZCn4FcVhZf/3cKACtRaF7SPG0rvI6aqMtkjdYULLSQuVsC8Jz1Hex71okwA/+50lbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/my.xpi",
           "version": "91.11.0esr"
         },
         "nb-NO": {
           "hash": "sha512-9Ps9OR3CqeofXANUEU417kPEvYGQ164fDNx4V31lI0HPAaNgNDVfYV5V06gJqvKFHXePrZtr0mt6nEjbPgUhog==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-pZAPYZ0tDrsLN+cbPO5KNF07Lbk0/LY+wXms048+Y3lRnBsjAPOf6odIH/v32ftnVRuhboKxufm7Bk1euDE9TA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/nb-NO.xpi",
           "version": "91.11.0esr"
         },
         "ne-NP": {
           "hash": "sha512-jaQzMpw/svWQEASDu5h6hyDUH7BUNeyvcU9Flob00ZjlQbDDRKMT7o0mvlPVSMHKpITXrSKaS5D5zFHA6Lshrg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-N7pr2hbWs6JUNK8iSUQQIjC/PnPajIYSNMUBbd8on9FghT6MYJgflb59caWEKgeYEcqaikQFgmCEnXS7x3bMkw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ne-NP.xpi",
           "version": "91.11.0esr"
         },
         "nl": {
           "hash": "sha512-XWXxAHYuMlF2lF5PmidbcB75gBDT1hMtulOV8JVPpyPppM8YZGLzDZQo2Int24pxW68HDqcPf70+12phib/D+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-yV2Hut+BpnhqhZGUuqZxzeqNs6t34ewY+yvdWRk9QcX5kEGLwo4QIj3c3Z3K7v9H1FGawmbDMoyW0E16O8iMFg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/nl.xpi",
           "version": "91.11.0esr"
         },
         "nn-NO": {
           "hash": "sha512-4HBsfHf7mAGgI2Z6pbrL7BpzUWSWYaXXsqCyYMIH5cWTYxPU8ZJxnJXnmDKHNoQUuaONzhat65JJfzmRH9Qelg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-b5Ozt+IKL/kRxN5hUyDFu3X5OwaGwDviI4ca61JKONuXjP+TGI5AtKyTRrE457ZIni8BkyttSvt4aGiOHWSQoQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/nn-NO.xpi",
           "version": "91.11.0esr"
         },
         "oc": {
           "hash": "sha512-qIJpoqELzTVFRtULFjG5irzpcvN2c3gGtSYKT0yw9kpJz5uKInK2eqZlz5m46Iwr0is4RqMp+zpT47y1/SnP0w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-3aKxZ6khO1zD+h0BPRhET+H0/VlxaB0nD+NaJXxxIsh9FHxcIeF5Lo4DRbdIhj25EZ3acNvgmDiih/4gSCTD2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/oc.xpi",
           "version": "91.11.0esr"
         },
         "pa-IN": {
           "hash": "sha512-WBf3NDJYzV7vx2Muo2Om/wx82c67wMhQofnMgi1PWrK4OhnujYEbGvYSx1lN6z6NJ1i62qOoJfnA8/JL5UuG9A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-0oYiYOutMtOZy7rySfUcmVjl6rTGQUNn1XBi/O30BZAReis0jl90mq85o18kaBTqpO35sHmDhadLWJ5BvDsWyw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pa-IN.xpi",
           "version": "91.11.0esr"
         },
         "pl": {
           "hash": "sha512-0zuQ2Rq4lgjp9xEdcmptMv6Vgxrggwamd61/XeWeq5n9j0I6Vm/BdZCzsldrKdzTMoB1EzApiz06Li48JNsdoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-h8jHO2FaQyHg9Xjmyp7xUfJDqUXA9eWYrD4x+oaRX6eVAzmtzrp0SJaGValwoiGgNGIGyNnCLOw3s5DVAA99/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pl.xpi",
           "version": "91.11.0esr"
         },
         "pt-BR": {
           "hash": "sha512-ke7mRVO+XwK+ovpm5m2CeUQLAiJOLv48a4lekUT4mnkQpgZ9bdMgOGuSe7+Q/pmUK+xkfiO0WtzvUL6ZQu6SpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-1KGlHVsEGZ5InDCCyGBuJnwScTeHlXzMLisBjOFSNaxvomlr0BefNo/J5KAvsdPxemO2wD2U0Llv5qDsbqrcMw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pt-BR.xpi",
           "version": "91.11.0esr"
         },
         "pt-PT": {
           "hash": "sha512-qRUx5NNaCqMcQ6CTM6ArKTTxqT7GQTwR5W+MwPvvl0e6qzmpYuQjb22bUbSCqHBBOZUfw8WH56memD+6VAucqA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-MqXzeMN3YsS1ZL6rMRgrE7gXIxWgUW+WRn+rWyUHT2kAQBYYTEqwriceD2x6mwcEJeH+hKMt+O+3iXCPQEem2w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/pt-PT.xpi",
           "version": "91.11.0esr"
         },
         "rm": {
           "hash": "sha512-d+jMQC61PaaV45rC5t08Wj3G0heaHeyEV1sdNvIhPhcnJoOIYeXp34l8oyniErT/dJ25VzjqU20lvO6AGVBPCg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-w9eq05cLr7+SAv6uUjNzkAEVZyHGRTF+5ta6hObx1jC9uXi3/1oMQAT1WA5p2J9R0eyh541ZVSBM0ucc9/YfIA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/rm.xpi",
           "version": "91.11.0esr"
         },
         "ro": {
           "hash": "sha512-caMegR7q/ZhWzBjtljt0lSYQdNXlrHorthxFoGyqg7ao8g+fVmR0uiFBEWcYouCOpqbn6qicskAZHXSAEF300w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-jPx1lM67P1Xh++7DOIskgYg4DH/KkRlaQf+5LM8HfSeYfE2rFH5q4Gw0SY5OC3qRUbAampwrVNoYJMhVO8ROLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ro.xpi",
           "version": "91.11.0esr"
         },
         "ru": {
           "hash": "sha512-pHOVKn/D6XGaicl0O3xJkQch1mipVYI6V9mZTsvOr6ThFs614RzBES8zPnWs3Kh/l1zd2riCTjhIRlBBRFqFgg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-C1SmYrth9Xdv0BxBLW/pl4U+5sAXw66a15KA/udnWbq8VYSxcsccJbUoMpJFYptGGjWcepvq2rfbDz1cBhL0oQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ru.xpi",
           "version": "91.11.0esr"
         },
         "sco": {
           "hash": "sha512-jnXjz3aLhInVVxiVhf7mjgm5+rfW1AMCOt6bmsPKUfCGwjvf54TAGZ5HrtIiq/+Wrz5naV/xof3yUyB7XM5JkQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-e7p6/49qcgFCpqmElVDQo9Kg87KaPl71455yhOP4XtJwSQP/796tm6zwt9OcRH/O530QUC+LglyqL/YhxHpH+A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sco.xpi",
           "version": "91.11.0esr"
         },
         "si": {
           "hash": "sha512-1oTnKo9GGBfx2DrUIhejlgnbYYjFb+bcROz708eg1H71P6APDzjCqK7xNPzaHCxi0jvIFtRKXBtb1FoN3cWX2w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-taDhCpiTCIYwENGjsR6FNX9CVrFcyS8n7jtQvE7uIF3wERT/e/UkwAU7cuN27LjlwyA9rhjvTGhY/CbRe3TY6A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/si.xpi",
           "version": "91.11.0esr"
         },
         "sk": {
           "hash": "sha512-ZPCDMylV+HWMhGB0pD99ANkFONq+Hl2a/pIE0RxjduSx3jPN4F50i/IeYNQPedZjHq6POXY5uqcmIBpXk7Bgjw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-UaKsHJ6fA8yxLAI5Gus2N/zt3tIgKP30Bi31gKv5jLKvHCQS9MEaAsB1rkcnc7AsW8C0EBuxUB9mNYHHQ7jtJQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sk.xpi",
           "version": "91.11.0esr"
         },
         "sl": {
           "hash": "sha512-ij3hLLneA7b91oJFbCh+aTpeqKzFUpXYI+yuCBmS4eCpu9Ereqfmz4aACBmENnUA2FQmTND/P/JCKdyMGFK39g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-c1wt1TRlB3vRG5Ac5rFNr9NFiWVazeXoa+K+pdadYcZMbuDlZDPaZj631g6XaJzpMFFdZie49lDqCgn9CAF40Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sl.xpi",
           "version": "91.11.0esr"
         },
         "son": {
           "hash": "sha512-XJjPQ+9+Log6emtH5l3LqjhLqbZYSTIneGXy+IQ+KGJKd2wHTVFC457IyDjGl6V3ds1Xfma1+eI3S4idAOX7jg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-4+QcZnU3PE5t+2bTlwKNyZR6zwEnJkf3T4t/lpPnKYkgcekZ/nhr8E8fJvpOjWTp3nHq8enOdclA61DY5jr5pQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/son.xpi",
           "version": "91.11.0esr"
         },
         "sq": {
           "hash": "sha512-VWA5j9+UELrqTJr3u/B9tiQCOgiHurolG9or1ngNdpGCExfyGyocISsGpjE+oigAFeeGL1A7B54AhjWzxuoaGg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-B6UgopbuTjiJGiPrWbpDwdKuwfSj8VDNTxY4z4LUb4qg4I28uGrS7kdV9cdelEUNt1t61tD+0cA2Gu8zMtGsxQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sq.xpi",
           "version": "91.11.0esr"
         },
         "sr": {
           "hash": "sha512-9fxFJ288PLWRnq2wsjacWHG2MXTSJcJjQqnaDLwncid2bd2PUO9XBlvBFEXgGFVdMRgM47gMGJ1iqkaF4DWIpw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-DngY56+KrqPuKDdaftA4ZPaJmNc5yg64nV892yJbidyU8XGfuVQSAFoJMX6UZWhT9T7RFPjmcDwucbo4Rou0QQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sr.xpi",
           "version": "91.11.0esr"
         },
         "sv-SE": {
           "hash": "sha512-OJ8EK79SYfu0P1kBGrd2gDakVBwo4VxDkQ+dGoKPyASHglz9lLbPYti+KRX1w9fK7PAkhCATtKAeEfD8fS0OKg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-t945Sr73t9Lxj3hg0Xt27tWaEt/PigHcYXcKAtGgP7d/+PIIWyoHh7C/GoQhsGodTC8G+g/qlAAzN2posjZj9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/sv-SE.xpi",
           "version": "91.11.0esr"
         },
         "szl": {
           "hash": "sha512-rOPDKqy9WllR+YxGKyXdYiCPTe18POcafgq0uST7VtombQG9ik5WE3IPHKXm0EjkMtdgrFYGrNXrcyeHDuG68w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-j6HbyPQPYYWUlGpQyZZCn73dffU01ld6NqkUTmntCi/vH9OYZ5Z2wXAgidi8hgvxisOnr2wI/EWSLpSMKmHWIQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/szl.xpi",
           "version": "91.11.0esr"
         },
         "ta": {
           "hash": "sha512-kI5CW7B+PDMe9UltqPhVCPFu8228Rq91tExzNJFlJAOryjF1HuaigOAR7UNNlugw/RZxCOXCkCPjxyLObuTEjw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-tDdwsOS/R3akeK0yaraI3guqM9ZH8+Yda3STrXhqBiEKP73/4PcFoC12ZLBzbW2NGdqayfPntTRq5RoIQy1cqw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ta.xpi",
           "version": "91.11.0esr"
         },
         "te": {
           "hash": "sha512-kNDt5A5+Le1ntmg/NtITZCTabBOXE0d8uu3owtXEcPzDzJ7k0lQxlfZYIEYDfFSxMIFbl+BbVUS7ykfuL1vykA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-Dbnm2KDjTN7XRzNm7yxiNG8v9A+0s+UI651pukKmDTavnJN5CaYTaxpRTuJWiHm12TfqJFADkc1abr93C15AJQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/te.xpi",
           "version": "91.11.0esr"
         },
         "th": {
           "hash": "sha512-24gEYPrOH/0ntop6hZ1pz5VZeELNMaXS+bxpCTEUQayGH0K54cTv5vb8STjVmgsIABX8iYVzvVHKS0oRiK+wHg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-XNPp07ZOcC2Yz+MgZ9CXs+6NR+vhVCV7RS1i9G/7F/A//VkB8flst1ynLZBulEtl7xYMK8R4bOZbg15Yn5qDYw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/th.xpi",
           "version": "91.11.0esr"
         },
         "tl": {
           "hash": "sha512-onsjwThqW6YUhlBD+nKkRyhQeOGIow6uNxISJQybWzYVuZbN7u8lzkN1MGEOByXVRKQhSoUNWTTs80nVqcAA4g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-MUrfZ2KJ66+A+eeBBbdUAZi/jmQoZkFapwcnhY0v2P66jzH4eX4c5+IjFqHefaNLND4NOb0ceZFukz30TUwrGQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/tl.xpi",
           "version": "91.11.0esr"
         },
         "tr": {
           "hash": "sha512-lmlWRvgoeAwYjOP4qtChpz6eMkpDB7qnlya3E1ogkQpXF7iNG8cE79aElbBRPlwNUZzA+rs57/5hCJ1qlO6sDw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-0gagp/IIH0pZC4tLx9g7JicJM+EVNKzwryea72waXMeXDt5UL3VZerJ8k7DT7lyv0drTqYEZbIgYkXqQQ/922w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/tr.xpi",
           "version": "91.11.0esr"
         },
         "trs": {
           "hash": "sha512-EPYqiH32MK37bSbxJwAO++sNO3GDrYhsKMDpCabXi/hlDV6tOE0x2io7lmU/FUE99QDC/G/IQGsCe71tyKT4Lw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-0WITJZeVm7hR/5/edNbHi0zbecrXoNTtp/wgjsFejwvLOMQZyQB1DGF9yS97bdyKwONANRCwh6ZWKwYPIFp5sA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/trs.xpi",
           "version": "91.11.0esr"
         },
         "uk": {
           "hash": "sha512-3oO1rQDC7y77vuCwsMDVbVXJeUhNW5nqJz5Ggd09O8VF3K+GsU6bxv38hZY6x5xYtZbEmLlGle9Aii0vCWyWIQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-zdkTtowByx7PIRdViJ3POW9OZP4d9vHXxOBSd1FKnK9xeL2uYCgVL6785AyVCCyknsJ1grWQEbYq64mw63y9bQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/uk.xpi",
           "version": "91.11.0esr"
         },
         "ur": {
           "hash": "sha512-YJDxbzK0Sr1kBLebp157FP5DdCSFLZMqOfrCbiieYy5gBHS1PjmRjjc8WNiZSQ18X6ykI6JoqhJFeIXjI5S1sQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-QjyX9bqV8gpGIijlQ1tYbICJyHElAGQmsBFiBYr/h+9C1hNT3G8K1RsghqHMFmdIn40DvIMTopr2EXCs3NUbkg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/ur.xpi",
           "version": "91.11.0esr"
         },
         "uz": {
           "hash": "sha512-ISmfN85/73lmp3Tq6U2YICDIkAVpScxE7YI+rJ7Um3J1Q13gbmPeL6fNey+xziF9+Vwbpmkn+wRRja6HN/YcYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-m7VBmXfactVYmDUDeBa5HfbT+LLuDB3AqwO3kJTuE4KqZYG/BiD4mSokrV8VRnizgeYHzF9G/KOEku4v9CKm2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/uz.xpi",
           "version": "91.11.0esr"
         },
         "vi": {
           "hash": "sha512-HC/qjULmgiTJWkNoKwgLpe1kb3ZQlT2w7DuTMtWMmVmK8ArigxqsKhg3n/EbihAn2QhGcFy7h4FaWTDzA8h3TA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-0G5xQpGCx2AgMFb8UwGsVQ0F/yjuGLus/MFhiKy/M5YlWFPl6ThLsTaZZ4wd+GoonQQiSHgVAEPaYsgD5Q8k6Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/vi.xpi",
           "version": "91.11.0esr"
         },
         "xh": {
           "hash": "sha512-snkL2RSIKnFO+DVVWsONsnpoGDjSj1ObAE7QkYGjPo1yDv9Upz7sUSbjjIjndffjtf8NPeXrwo9rsZFerkarXA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-7EZn4upQO1nT480N+23VITeMGPiDiJuCLa82LJoWNXvxDNWe/mTMbzPQnimgiuncMVDCQMCjWbtuKvi1MkPe9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/xh.xpi",
           "version": "91.11.0esr"
         },
         "zh-CN": {
           "hash": "sha512-dYLq+uiNHlAkKXBq2IjBbWz46s9SYyrmNEImvmCYuIvvKxW8uKwNZMtW9eVHIzyrwrqn/480plwww3QNkmMX8Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-Sfoh418FbyEQkNojgH+kviBkftWhnTqDz9DCVAlD4GXzEQCJt0e8R9yi9OB7kF+Sw3YzFYZk67AuHjCPvCC0cw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/zh-CN.xpi",
           "version": "91.11.0esr"
         },
         "zh-TW": {
           "hash": "sha512-LChooIbS5pPNFX5ovZWUJ3OBIhyUzlbJyzGLyjguaWHaoq/AE4YydnazhOr50oJH6nlFuWjKpmvI1GwOwAzmDQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-md6EH/AfEDE8PnynpAhzSABwRHnp7S7XPw1PH8m+AE1BBCcq/LbgU5OVxUqDxK0iC6EzYRE4Qc/DhBK0gJbFGQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-i686/xpi/zh-TW.xpi",
           "version": "91.11.0esr"
         }
@@ -3454,491 +5512,785 @@
       "linux-x86_64": {
         "ach": {
           "hash": "sha512-UV6EJNptFQVIDxVFHFY2O/ckcfpNDkez5DtMrCYbCIuCqFrS8yNO37hJm+q/OS4GNrIn0NfMcoXlRLHivc3zlQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ach@firefox.mozilla.org.xpi": "sha512-GTyumhHnbmPu/LGl96AoA6jjpqRwsja7WhIyYg7nj+ohlZt23U5XIm89Tcf1vN6KIN2KJac5L1l9aSDtqgQXzA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ach.xpi",
           "version": "91.11.0esr"
         },
         "af": {
           "hash": "sha512-BLzGi4YafJsuGPxP394CR/9Rh58E6NupwpmODNk8oVb4z1b7Y95jvPksVsktqbfgN57QhH0lH6reILnh35aNYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-af@firefox.mozilla.org.xpi": "sha512-93eBI7jdN468SVivdTRl+2VdwBfVccYMWO9jo2jBbEGq82NIwLEigHRTSs2mxkjX7PKpdLs8qjCiVMrQGcNfdg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/af.xpi",
           "version": "91.11.0esr"
         },
         "an": {
           "hash": "sha512-f49W0zNLvss74veApgME3wYxOm19vQ/Dry5tWwyT/nh8Nvek5iNkiT9ToDgV14RQBiY7EADbVtgX/ti+WQOz/Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-an@firefox.mozilla.org.xpi": "sha512-g54M4aF0HVgbFLEhUUhsTHmxA8mUYByrtVmZHveDEQB3cqSwqx2kJcWVQVU1m65/XRoymVlTBpMO7sK2Vio/qw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/an.xpi",
           "version": "91.11.0esr"
         },
         "ar": {
           "hash": "sha512-94JGx5McNi7n8Qj4/sudlOcgfT7i8On+W6/5ww3xJP4YvD3eDAuDPYT1lpINQ54CKWvLn6CK03mYZYUHgMsf/A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ar@firefox.mozilla.org.xpi": "sha512-SwVd3rq1OBWfwtm+tGIdn3mGEufcG0R8qET5i6hBRgBhVwCAc8EPFUMc7/uC8d9lcCozGejD98lVAZ/+dUINwA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ar.xpi",
           "version": "91.11.0esr"
         },
         "ast": {
           "hash": "sha512-ULtez3nBdtX8AN8wUMrUAwRTioG9zCI1rdbiZgormmufk9PdCsmaYI6fSz351RvEvBsCpQ4bwU+mYcGJabAauQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ast@firefox.mozilla.org.xpi": "sha512-2WtEnVhAuVh+wdiW0i2R29yk3srFauFc+NFs7xOZ7cbBOzzC0MG01bUGmzOUNdEVyn+nJSiVG0nUAutIW6RDnw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ast.xpi",
           "version": "91.11.0esr"
         },
         "az": {
           "hash": "sha512-wxfcqfoOJKo69EbD2pQR1Pk4QCQN6Up7wkXbmKoFTSK93CBB0MCzAZF/e3C9Ue6dmon51V/77gP5zBGJuntq1A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-az@firefox.mozilla.org.xpi": "sha512-puKUazkinjIO9W1nHUjrm4n8gKPhI18BZDY9kwzG1A4HzAysC6xc0GS5LV2d4yyQMFA9OyWUMxVbbCeNtVkTEw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/az.xpi",
           "version": "91.11.0esr"
         },
         "be": {
           "hash": "sha512-r8SI4EPzluBRHCVaPwmW+FJ8Ma0Zbq27S+Ht/7Lk0idEoBjAlnh3ABAsM64cGcHzVm79LvNez0ezP/Y1JK7S9w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-be@firefox.mozilla.org.xpi": "sha512-SDFza2Z02cdziK+78Y3Y3IAWcecmzHkq2CmJ1OhJlWISuIQ21p7dxzbW5Mg0j7DzNrXi2X2rqZThG8iuzaXGUw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/be.xpi",
           "version": "91.11.0esr"
         },
         "bg": {
           "hash": "sha512-Pt6NlaDrCFnAyBWZXg5Q6AAE8xtONJkit4EQ4wDH40mOjyqnL3evdoBUzF9k9Jo4hzF8PRknKT5Z0P3ey8w0XQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bg@firefox.mozilla.org.xpi": "sha512-p0cEqG0EKBkS2n102GXv3D220i9dznP1Ogg6KrhdsJAzuouipfuuHDPZNdTAm+hNV/DA95ezfs1o9tooIjJ91g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/bg.xpi",
           "version": "91.11.0esr"
         },
         "bn": {
           "hash": "sha512-UKe8O+iPPcxEdQcI9ZTcPESSi7oKvobjW25zCctBfbDtkS6ij4MhH5fNKvxbTj4i0yHdCt6yZhU8vfc767dLeA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bn@firefox.mozilla.org.xpi": "sha512-HGnJm9qGM+O2Ek9qYQR+QCnFT+wSzndFbHU85hVEzx7quxWAI9taVye6DnBEKJycm8deD6JdyjCvCq6/WdxA+A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/bn.xpi",
           "version": "91.11.0esr"
         },
         "br": {
           "hash": "sha512-QdOJPx91Msc+XYzQ+AoNNLW2t2fG7E54qw7m6oM266ppoTt1oUVScSrOTLQAOhJrIg7ZHq4paJeXFef/yv9+HA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-br@firefox.mozilla.org.xpi": "sha512-nwQ4JNluhW6GA9Bn3ouIlrkNlCHDUFPVmg4A0S7TfVHB0/qKPrl6rzLKNA3TL9oKuwbTVUMh1x5VJw1MJHzL/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/br.xpi",
           "version": "91.11.0esr"
         },
         "bs": {
           "hash": "sha512-2CvN3yDgQWtBSRvF56KSAueljmWPb6ZgR2oszvrSV5gWnObgbRRYrp3JBljbLF79VqL8rQ4VnfK8UWzFMX7X3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-bs@firefox.mozilla.org.xpi": "sha512-stk3ZFoP5ykCHK6EkG7tydN8W7LL5ct/ZIo9oLBOOqGXYpM3EpoAJxXPUoZZTxf/U9z9iCZuh370x0Ay4uT8jg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/bs.xpi",
           "version": "91.11.0esr"
         },
         "ca": {
           "hash": "sha512-jr8i6v5GcWZbjGuHMrdc0wo1Dv2PDKhe6J8xPyUza3CdRhr9vyWXPwRQZgdXbsN4lHmV1n+9aRFyNEYApYlaqQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca@firefox.mozilla.org.xpi": "sha512-WVQWLCQTPfGZj4X9qmimHBzuhKfZ+RlXFWD0nOGBfA1Bi6EnzkNHHNiflKvmoRX5bpIKxeVfAqeSeJTLI0oeNA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ca.xpi",
           "version": "91.11.0esr"
         },
         "ca-valencia": {
           "hash": "sha512-fhuSeL+aH4brhi04kyK7I47iqANqKkqPB+vWmIuGHV+zK8tgmFHv3dgaWyd1qExnaRPcN2HPoAbfUkbT7hKqIA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ca-valencia@firefox.mozilla.org.xpi": "sha512-tTKCYIQkJZyJ6Gm5AVqRfB4ypGm/GzfcklUvDkV2AjGHGtcXaT/a8nMwwYSFslBTjHgldj0DdzXY1ZUiNHUREw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ca-valencia.xpi",
           "version": "91.11.0esr"
         },
         "cak": {
           "hash": "sha512-Dgocidgf8KqwSpjOyO8x80tyxHFovF+f3SNPDCHIvRWFF4D6sMIGu+Bq5D0vzx7KiPcofXqwUtWP87IMqWIdeg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cak@firefox.mozilla.org.xpi": "sha512-/gppL/TjFRsRsfMp7NOALqiqb+wgY+dLD2hHYhlOP+09za85eIRDSY50gjB4dcivtcsZD9dUY/F+/sJyey5hzg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/cak.xpi",
           "version": "91.11.0esr"
         },
         "cs": {
           "hash": "sha512-I9D/+/I68WCXFc86niMfGHkxtOowFLW4CxMyQkJJoIw6MyzMABfAVlV+PlZBtewbCr1s0JPy+PGLFP6l+duRzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cs@firefox.mozilla.org.xpi": "sha512-wV39lL/+SFBxPBtdSIyW9sU4tgYSrfJ932TcTF2o+yHfsX6pLxRgxcb41PxwnLoLvcw/v42+o9ifsJR6rcLeug=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/cs.xpi",
           "version": "91.11.0esr"
         },
         "cy": {
           "hash": "sha512-zKpoeFcrOZJPibm+fqNRDh4l9d/Ok1g1S79tkZrpShzH1XhSDmTCczC6hLN+i9aYFVt7Z0xfT7WP0ADcFKI9Rw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-cy@firefox.mozilla.org.xpi": "sha512-PeTHEgSCxV9DDZWEGFmAaghaXoKC/ztjHSiqSLorIYxXu4KfzKgPFZwJ469DAQ+OL3P5g3wuT/DVfw6T6vviGA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/cy.xpi",
           "version": "91.11.0esr"
         },
         "da": {
           "hash": "sha512-fLyB2fDeKrzHzQi+91wA0pFo5SKgsdhSoISCUE/PH7q+MRfk0dfj/Yq4J5XOKEpgYzamr2GfAN+58CUXa7o3Xg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-da@firefox.mozilla.org.xpi": "sha512-olk3jgpEB2xj9JuzjTAi5hVgegOAJTQRPFTOOPRA1ytqCloU6GZcvfTceUvz9F93A5kWpyoQ6WRKBurBgYIOvg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/da.xpi",
           "version": "91.11.0esr"
         },
         "de": {
           "hash": "sha512-/m1FB4/dTBUX5S7jtWPBIsxrHZbamWaGbIESj7cmS/7HcgwYTQU7LLHt2vIQI4Z6l3XGdqHILyT8k9DScWR8SQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-de@firefox.mozilla.org.xpi": "sha512-YPA9rUzhim1kKe0jWjyEHLRbYiZvdwp9nRcFoTmmhoDusly3loEkFv/5qb8EkcmC+hBTwas0QyLxTwybEuqTtw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/de.xpi",
           "version": "91.11.0esr"
         },
         "dsb": {
           "hash": "sha512-E/KZit146PjKX1s3eKlV9GZugjB3h3FpEinB29h1CljZvuqYzKVIxxQNFDY7nM355o8ImRTID8aXkV7IAqqmMg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-dsb@firefox.mozilla.org.xpi": "sha512-aoghRiiz/XD/e0pWEZgpdGvr4tNy3kf9RN3MsKq5lkFWDZGaVJh+wskJFjcf8xFPLLUZj+LXI3PqPlk3iWDGBA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/dsb.xpi",
           "version": "91.11.0esr"
         },
         "el": {
           "hash": "sha512-lO2J52kBcZGUYMEw/gU6MbVPErttpR/EdjWmwF8d5jENmdRKuIe4neQPoSyC+tkLPJZyPLQXspHsgurPwBVKLg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-el@firefox.mozilla.org.xpi": "sha512-ey4yICfzluzKe+AY168uTlz5EAWG5forMnZAagoC6fnk6z4HDKfN3pR2akkj4Xjt5SztDcH4POMJUDJU2ZhDTg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/el.xpi",
           "version": "91.11.0esr"
         },
         "en-CA": {
           "hash": "sha512-NcvBzq518rAfJSabvIQbTfk+IC+xnJgwv4A57RDrLeywhadZUn4cIaTj0j00PLNPAI7UlxzWGsi/RsUWqFaNCA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-CA@firefox.mozilla.org.xpi": "sha512-beCQZiwBLv4FscwigkHqo4TfNsF3yzJJcBkc3cR5Q6yxT3cgIZzuiwFLeF20cmrNn9OaW+iIX5F+RBj/9ruWzA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/en-CA.xpi",
           "version": "91.11.0esr"
         },
         "en-GB": {
           "hash": "sha512-lnMgfyRh9rfqfcr6b0pBf1fWuFgOm8CyORnG3c8kkEHYKRILGJYPtbB8Dw34+G3a2WbU63jHkIRRj8IZJMuwDw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-GB@firefox.mozilla.org.xpi": "sha512-ilexj3PIGJhFMsxBc3ZEFcuq7BBm9oyhTJl7XTw00YXVCTOgUvZUJWgM4orYXZPiJvrdI5134YQoPToy0sknsQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/en-GB.xpi",
           "version": "91.11.0esr"
         },
         "en-US": {
           "hash": "sha512-ORrlrbpmKMGUiRwxj0AP4fw3/LUD6smF+ohTIH4DSdy0d84PkKhoQ+8f0BybcBLR+GkA1okFLbZlQ+gJw+vE3w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-en-US@firefox.mozilla.org.xpi": "sha512-tYvPxAC3FPHwoacEyswaS0sdJUtCKva7nEUENjNdr2FUZ5zJkye0ib72UO4xZLNTB/kUP59Aun9XrUIYG+stTg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/en-US.xpi",
           "version": "91.11.0esr"
         },
         "eo": {
           "hash": "sha512-hLcYuRiXOEIUs5CAuZp+aBXOFPDinr2Wy1AqAxbCbWOIWKG6kqBbAavaGIDH8aIi1qZg2ay+XEgdgpCYQJPN9Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eo@firefox.mozilla.org.xpi": "sha512-yLqrxviYlleLcw2PjB00Aah4VufI97sovWDF4qe7kB53t42mXVT242KQGvBcy6aY2+ROvqC+QwSbAsQfZAyO/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/eo.xpi",
           "version": "91.11.0esr"
         },
         "es-AR": {
           "hash": "sha512-+U45lF6ibVHUkgGnT3gA0d/B7l/Ag+a9QkN7zzqmaPKqQR/kzOco3K5cOivNaZna9LpZ+rfMS6ElxUx+LmsfBw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-AR@firefox.mozilla.org.xpi": "sha512-FuB5SMCredWkLb5pIVySoBkAFQf9y3XBPaX9n80q7vAMtbTk5Gwx1rMkEDTlwGBuQoYFrUzjR6uJBWvxMMe/Cw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-AR.xpi",
           "version": "91.11.0esr"
         },
         "es-CL": {
           "hash": "sha512-GDl/22384NIUhPxxvCHoCMtCE4AAHWzoZ6ZsL3TqcfBBfPKgEa56ZNdBeKM5I4tckQtkJUF464JZj9zZPm1ccA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-CL@firefox.mozilla.org.xpi": "sha512-BTvfLLoS6YZ+21mJwXt8kkwd2Xi9PeD6vg3uoQ4OuRXa1mLmwt+upw36ld5VoRMBpqgGbqrl5LM08jd1pvY4Rg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-CL.xpi",
           "version": "91.11.0esr"
         },
         "es-ES": {
           "hash": "sha512-xSlyakBEHiLCl2S0tmLoKDabJCe9BS5wcaAtOK2l0Ce3T07tjWRnh8XyIUH50G8PaJpK5P7xW17d0HG8Rk6WWw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-ES@firefox.mozilla.org.xpi": "sha512-9AamXDucJQjja/z4EWcGEf2zYjmoO8bpMHygw4mGuSinMbce6iNmtalhbFBLJ2cvbcxt0+J+cbkPrlGnput/Sw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-ES.xpi",
           "version": "91.11.0esr"
         },
         "es-MX": {
           "hash": "sha512-zaoWYM32ekRtlNSOEWunKl5h2GuTodxNu7/zfq+UHoL56Fy5DiAE6JGVXzY4mVNHOitpxbT/QIO1KLHbAu3PyA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-es-MX@firefox.mozilla.org.xpi": "sha512-FzHGXjXG9xYray437LH6ronlH7VdW8OxZ0jDWL6rAYgxLzfuLQAEPrcFhw8h0psqPsWUk+nOA1NHMJr9pTvdig=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/es-MX.xpi",
           "version": "91.11.0esr"
         },
         "et": {
           "hash": "sha512-nhzyYLmQBIYtPrF6SNIPvuh7gnYPaboJqqIW8/inPIFmnxTmVyt6YJZdBQLSCXXP9cko9d36laaTvomikbDUKw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-et@firefox.mozilla.org.xpi": "sha512-qpiSQQdHjwkqbtJJUWEGF0c8LKoVQ8XLi5nSFw0NX7kQDiYnFlfqmG3gEM9dznSHLWxZsLhQCfVZQIIbklOmhA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/et.xpi",
           "version": "91.11.0esr"
         },
         "eu": {
           "hash": "sha512-usB8aJLfYiPFZBaT8k2MmCJmjbceZ6z0TCWaUhNejxfsqD2XhJ407CT/4GcspLa7KYT1vmo/31cS1+odjxTPzA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-eu@firefox.mozilla.org.xpi": "sha512-bk3VVTmMvkGLn1JSsScabKQtsX3/LiTkm9L0e5mDkY1qGld8UBsDfl3/DZWoZYiulDd9/NZGu9w0G9lDj0HP7g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/eu.xpi",
           "version": "91.11.0esr"
         },
         "fa": {
           "hash": "sha512-fdawOVw1HrAsjYuOs8uld4Z/P291kPQxU0yv8msVb1xBYRTMarY4NG2QFImhDCcBbPXHMzKV3pY7Z3+cJCrjFQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fa@firefox.mozilla.org.xpi": "sha512-9IsSNUNy02e5mpxH6Yvh7e5pKdOBPA04M1cEdaTTNPeJSwP5Zs3kEsMgjgLYV5VDSekNx26o1jxQ+COVpM8KTQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fa.xpi",
           "version": "91.11.0esr"
         },
         "ff": {
           "hash": "sha512-XGJ59kaFLoZXFR7RthoUJD9VtqmCoUSRT5/nkU6g7iHMcuUwus2p5rtwiwRVyHCDqSCLDWvV5/TyzOSiTwTcMQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ff@firefox.mozilla.org.xpi": "sha512-gzhgIF2hiJ3lmAXyVUMuKH+zFZn13GrGw/DDDBQE4OZCUvSgGkLbu73QmscQjSUtMCE63zKVogdFgG3vHsL4Zw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ff.xpi",
           "version": "91.11.0esr"
         },
         "fi": {
           "hash": "sha512-2c1t1XPFiCvMP4K3t+a1Su8EpH2VjDVN/JwE3nrOOPBIWVk92IWj/s1LX4GhVYIyWbr0r5I/6zHHa3OkxkTW5Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fi@firefox.mozilla.org.xpi": "sha512-t3TBwYJpxPum3Et6vrzjygObcD0o9VpJOVZ4RbbTPcwiwTfci6/IbcEVxTjMoAwLes/1VsDiZGQp0rDrUN5XAA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fi.xpi",
           "version": "91.11.0esr"
         },
         "fr": {
           "hash": "sha512-FKFhdAPPX3oOFG7zBacAZcXSAkQUMNoqLbi7JiB8q4Sm57uHOHhH4Nm0A9myp5eoc5+fppXuwMnP9kjBdZ5i6Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fr@firefox.mozilla.org.xpi": "sha512-JXo5DNS++xZ/P91hXNHu9AnAXWOIP6/UgB09Y43FSsnoPaJ0z4SLxcSgilMv2hSFhzvviMXaeOWoYeNYKbKAQg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fr.xpi",
           "version": "91.11.0esr"
         },
         "fy-NL": {
           "hash": "sha512-rNyGzgwgaRod8erqF0vOdfKIa0UgZMZgH09+WT66C4jPnCOi5L0pM1sKD8Yr+4dPTMTEOSi+hSiXOdLzYa3ctQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-fy-NL@firefox.mozilla.org.xpi": "sha512-D5HXuazcWOAI9T05j7kMh6ONlQ1Ds6uUr2qyvpyv9EeNXPLZiP6Ak0U+f6BEhe0BS5U85Yb5/0ztEeOVCiavFg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/fy-NL.xpi",
           "version": "91.11.0esr"
         },
         "ga-IE": {
           "hash": "sha512-PrpkCjVQ0mlVA/djl10eOOg6H6SfhXZJj35yWceYxLA0MZ/sHlXnBaulqGSclHm1mQHjLUtPvI9zHhEcMlFMzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ga-IE@firefox.mozilla.org.xpi": "sha512-t+fKv0HqPoq/Bx+QWLeYSW3Jql7Xo7PZlIhM63PTeqUStJxdESeJbr2Q1mFZXQgp4T5FsXBGsLei/w2zU7JYLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ga-IE.xpi",
           "version": "91.11.0esr"
         },
         "gd": {
           "hash": "sha512-YYwUXGpPGiQy74XlcmnZFQaj/18sJGRjKhjB4W/9w94bPCMjAC4j4Bl/twG3QI1JBa0ZBQQyOeG9iN4vXd0Fyw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gd@firefox.mozilla.org.xpi": "sha512-8eDs8CFpoFp8i42EbPW5KQSRfo8pjCgTQnmfe4SY66SfjVTMfoCDwD4myHw6bo1uWQExiQp71/zmyE9cftgMDQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gd.xpi",
           "version": "91.11.0esr"
         },
         "gl": {
           "hash": "sha512-DX5NcJsBqNkB+Wwl/VESKHSF9kj6FBiFQh4mVqgeQLcfhzcSQ5AhesGdkCwi5g8cqm8z6jzb5DUgjxm0P0+R5w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gl@firefox.mozilla.org.xpi": "sha512-aFtNjwap7EioFrCgGwSYv6cduOuS5fUwWAAjwd8jC7lADm7w57Vdbh81E/Os6Ga9KoZfctX/mNakeRTH2WNkeQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gl.xpi",
           "version": "91.11.0esr"
         },
         "gn": {
           "hash": "sha512-CrRKbWcy8FCFXFs9e59uX5IxaVEYcDDJUZLTXiF2LciRumhDCjMsHT/+IBYJYIrwhJv87QH0+es7euvDRZwrNw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gn@firefox.mozilla.org.xpi": "sha512-OkLyBI1aGxTZn6WFGKHWS+DgqBJs2dWovdyAtSkfCrOYGLjE3YyoySWjovkH4wlygXvh/oQDVcNuXC6whQ5VhA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gn.xpi",
           "version": "91.11.0esr"
         },
         "gu-IN": {
           "hash": "sha512-8+p9QmOx1Bj7i9wZ0LT8gAjU547ya5S7fU0k8ktkD5QQy3NFaQzzR57XlUt+AckK0BZ1mBIN+6hr6Xg+z5lHgw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-gu-IN@firefox.mozilla.org.xpi": "sha512-FQHmwymHVImh3SBid38b3cMxDH64ANpGE6hPslNaBjJNYbFXxJ+F+WQxQXnkzlq7jhhI9WK3tnIJb6RuuNSKrg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/gu-IN.xpi",
           "version": "91.11.0esr"
         },
         "he": {
           "hash": "sha512-VPVsppwYyDAT9gQTmx4/U8Mxv3a5r6UGiDdQWceqh4MnkireXm6vJSCFnE/Q+K27j7Y2En7nr/ehg2a7hmeW0w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-he@firefox.mozilla.org.xpi": "sha512-lGmJedujB9Fim05hI9DHCBg7xmh3UIpqW1417tn+6SrR5k8FNH87p2LiDEWLXrNES5GDFFxGpoLCGg8XPwb3iQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/he.xpi",
           "version": "91.11.0esr"
         },
         "hi-IN": {
           "hash": "sha512-2wzPeBMx7KaCe4j9jvs3qupZKUS3sr7pVg/Q1+RHyjK7kQoMmX7WHFVBV4U4t1SZxXtm4loZykSbXmwZVhSh9g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hi-IN@firefox.mozilla.org.xpi": "sha512-vRj/nQTtVqrbs0g9iy+PnqRfzwcz70TyK9egltJ2tFjCPURWZNwLwB4SpG5oiyPl58yYJFxOlexSaHIBNtEiqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hi-IN.xpi",
           "version": "91.11.0esr"
         },
         "hr": {
           "hash": "sha512-8gc7m9/pEKbRSqVY5897jB9hEJk4uKlaMTgPCMRhjwzrssoUD2kyF5GWXcuXm9SuonFvCpLRF/B45hXOd9ouJA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hr@firefox.mozilla.org.xpi": "sha512-uPP2PkIzpxQauWMEXisQ8z6Ti5MWaDLgQC1Pzj8MmT656zjhLLkJTtQ1l+VyvGuUNV5wQR4wckTzXhMSyyX+hQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hr.xpi",
           "version": "91.11.0esr"
         },
         "hsb": {
           "hash": "sha512-JdzryecYb4D44HNwxr6/UFybZ4DBalPb3n0V3HNBA6xXw/GC9dFUL/2qqm1vPJaGDegRRsY07WiqIloHzcATAg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hsb@firefox.mozilla.org.xpi": "sha512-r7Iq1Ogz5aVVE4Q+6kHPHiB9HTR+KGS0BYVZm5o3bHg22gGkboB7OlF5HZg9JY4Ubikl/vaF4T1pQO+ts4/3cA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hsb.xpi",
           "version": "91.11.0esr"
         },
         "hu": {
           "hash": "sha512-Qer9YcD1yjZjqtzG1X8bty5kPFNPMlZkP9CGvpV+lKzuWTL7wQyD2rZb/tmC5BCYrMscqAZ13aiHybsj5DyOuA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hu@firefox.mozilla.org.xpi": "sha512-8GRp8YX0GH9qPGRkbqlwjPkk+BB98Rrg4e4V+O7y7LqttSM7ZQXRO0gZVt6/qioNcwlNiYD67nLy5m476uYOuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hu.xpi",
           "version": "91.11.0esr"
         },
         "hy-AM": {
           "hash": "sha512-Aa035IVCc47fgtBwPvsVJ62NLj1CvxC8XLE5qrIqc8r0MmoMiK0b5IjhtMy16yZoZVh5SsmQwdExUj+edXFUJA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-hy-AM@firefox.mozilla.org.xpi": "sha512-JoyzntQT6UCWrxW+Dwf5i9d87gZW9Hjr0UUERwEUMyLYCt6ufmsc+g/M6ly9Nja/M3FDTVnyGk5JKHlz+q9H5w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/hy-AM.xpi",
           "version": "91.11.0esr"
         },
         "ia": {
           "hash": "sha512-OxogOR76N3b88N8uMtd4KfugN/EeYasVPSrsk/FyPJptWqSFIdNV9C008g/hkUiXal30IbHBaR0dlyzcMUtLUg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ia@firefox.mozilla.org.xpi": "sha512-IWo69a8nUoHWdqeQ+mcSZmvF3+tux/QSLtCHBpEEXoke/MOUb5G+LRl8rxErvGxI8BG8pjltb6o1No02BDQkXQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ia.xpi",
           "version": "91.11.0esr"
         },
         "id": {
           "hash": "sha512-n7UKOL6P2JS7MheZuMM7FCv5y7EePNBhGGDvl0yYes3Vez2kBwGspvPTacbU9TTa32nX5OvAHEyH1UuztreICw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-id@firefox.mozilla.org.xpi": "sha512-3JR7qXPJaxctNs1fwEDqz5iCkTcDDSL36OyFkfyy/FBnjvBM7KW7vCnyCCaREAvifkXxgpZUyvS0ccxDtoJlcw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/id.xpi",
           "version": "91.11.0esr"
         },
         "is": {
           "hash": "sha512-57NuiYfXsCgoRVK/NKvswDnoO0avP7fJVEcbIo2r+EPuEqWNgk+NFg/XQkWJnQfiRh44oJScj6IWNbk3UPss8g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-is@firefox.mozilla.org.xpi": "sha512-hon2DXKiu8I7tuoPhA97LOXDIyHBMha6qzYc0RD6/ugKnQ4nKKn/ez1lVkpeFfhyoRt3NZgbSVBRNIfmK6Oxhw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/is.xpi",
           "version": "91.11.0esr"
         },
         "it": {
           "hash": "sha512-Ytl7MCEHLYZC4NPqsdMv0Ec8IVemPoZ5YTLWzHIExpbL6qP61JuQnLagaARd6G3iU+QWBLjLA39a+1QbjJOTAQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-it@firefox.mozilla.org.xpi": "sha512-1YVS6w3+lwV7aZzmCVVdMnm43UlBSJAKSj4RMpqjo4GVFt8u1JzQY699CBAKxQm8CdLcFaH2a5RhgYM7McNgrA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/it.xpi",
           "version": "91.11.0esr"
         },
         "ja": {
           "hash": "sha512-v1PK3QAWiRUMqMvsuHLPwiyf0CbtNGO7JZXyw7nWZ4p2gpBhCLxZcllNxD7glTWICUplKY2kGsO66AOpDskgrA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ja@firefox.mozilla.org.xpi": "sha512-jslzBq7vfPbpxsUvoPn9jRx1iMWjjT10VD0i023ml7h4sRwQlegD+q4UL5zVs5K104esh71Q+8PuqQ8MzBBjjg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ja.xpi",
           "version": "91.11.0esr"
         },
         "ka": {
           "hash": "sha512-C52pfkRqUvwdDDfqQCUXanxuobU/dlISd8+90cQZ8oQPH5i/vTM8AzhZKgIRix7MtEp6dxbzqNF1ggfWsV8k2A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ka@firefox.mozilla.org.xpi": "sha512-jxZyQl110pbQWT5oxBXwLqru4PSY0yusd89aiAIMWMj/aoXBlVNoVK5MiPOgbUDmasFPC9SMTiA43k6izKFBKQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ka.xpi",
           "version": "91.11.0esr"
         },
         "kab": {
           "hash": "sha512-v7DoY70F+wyrScPMewWA//ri9Bkt0s+xhSRw9eDeQld7l1UZGWdDUPKz+G5Tl2Oi00WLvrQKGFLYZuWya7qoiA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kab@firefox.mozilla.org.xpi": "sha512-ASwxGoao8YAz8mgI4uz4FHSECl5KND4fANGhiP6IHFqjnZERRnsw3/jpho3kzSMwqK1bkquGNm6vX2X/lRDVHw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/kab.xpi",
           "version": "91.11.0esr"
         },
         "kk": {
           "hash": "sha512-9Jd+FDpOTouR6423KrGsQ3hxztEoLkcAZX11Jn1FWc9oSvrDIPyx/MyLVBj55lI+CIeZWEk7tMlpk4qUrxwXag==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kk@firefox.mozilla.org.xpi": "sha512-YgD1JOlBpOKzPg2/TFHm9WzmaDGWJ6ctu+5N0WYll/lHunTW/KH5hjc7ZQKjl8TlSYqIg5lMH/maS0OXC2H9gg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/kk.xpi",
           "version": "91.11.0esr"
         },
         "km": {
           "hash": "sha512-UvKQ1ASbzjKs5kozwDKoBlILKekn/ov5LV+iJsXSHeDSmLAKJuBbulObr6LXAq8dvrcyhFxFZfdaF+Q74ZXjsA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-km@firefox.mozilla.org.xpi": "sha512-dunAO58VtxTYSoF775ToraOnu3B3aOTyTLyJlQMoqtzif2nteyMq6nIEzDqphDRONNRwLBjro6JfkHhsE+ncFQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/km.xpi",
           "version": "91.11.0esr"
         },
         "kn": {
           "hash": "sha512-ZAs6D9HJiF7ijjLN97ce6mk9XgHmfgkQs/Sf9QaxWTgn1M2YysFIGhfaMNs3RZkRTPmBvRC4jbjaNRjubR3HlA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-kn@firefox.mozilla.org.xpi": "sha512-y8DORWKxHU5BOG55iNAAof73/hTLtqP86Ubt6/V8uNUQuXoidtfWDsj2hLieY2hOEDRroHHeY44HKPlu+XW7fw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/kn.xpi",
           "version": "91.11.0esr"
         },
         "ko": {
           "hash": "sha512-oxGM12zwwvl6kViugzUknQQt3jEJPfV6Hg5BdTbLkxFRDuV37CsSXhF8Uqaho9Betiud5H3Td4bpQq1ZDnG7mw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ko@firefox.mozilla.org.xpi": "sha512-mRbQgr6c/e4UXr9aY564xHh9mNKtFy+rGMARy/lli3NzAE+A0g2il7Vg6X0P+ucbxuJehBaPNwBt7qQp2HyIuw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ko.xpi",
           "version": "91.11.0esr"
         },
         "lij": {
           "hash": "sha512-nGHU9ZZFgMIeSjYEkvq7C2ABuU1/Yo0cvIqOd5EuXP4MNZO/HPEh5VGW/u5i9aO35KzdR/17EqUcKyRT4jt9xQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lij@firefox.mozilla.org.xpi": "sha512-QzNvJyXNjzD8jjyIXoIAe2YFF9xB8bhUdl6EVwHEnnMk6ESp/YwAHEc3mr3EmSJAE9Kx6UPACkhOGPtwDjr+Tg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/lij.xpi",
           "version": "91.11.0esr"
         },
         "lt": {
           "hash": "sha512-cPTizsOTQJYqws3hMl7KeHkpjR5XM7ySKGweIJK1sXYBsjzY1knVgJ0PK/VjbLT6JNw7j+g/vjoWlIE3Q1xkIQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lt@firefox.mozilla.org.xpi": "sha512-C0maM4F/ywaHLr63Qij5OUczst/vpKJ3sgK9UIP1wgPJK3WRl/KxE0ClFemDqympHNsEwoIAD90e+j44N4hg2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/lt.xpi",
           "version": "91.11.0esr"
         },
         "lv": {
           "hash": "sha512-PjkQU1UrPSCLeYo5mbCSbjVorFtxiCrcOpZPEO8E5guOqMZkOE0wjsprBonM022i6ttEzlVotSqdz/LyXddoOA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-lv@firefox.mozilla.org.xpi": "sha512-VRDVB51UboJqwz36BkLz25Am9c0b04LwHQJ/XKxkmSkUZxw3qtS5thsWPImPy5acU3GF/L2Fv3KwMvGbo7JCww=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/lv.xpi",
           "version": "91.11.0esr"
         },
         "mk": {
           "hash": "sha512-uEI6kPkmEsUIlaSSteqrbmzh1mZmdaxomq48vyhWQ6ATI3nblXkaWVKN7QKku168HS3kSrssPiQD77QfJLfKhw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mk@firefox.mozilla.org.xpi": "sha512-KFiyGOBSx8m1+Qk0ndpD4uFBzyELL7/gUNeaOwGeNO9Tkn0zt8a1KEe/cgGnK72TOVc9IfF9HRGs6JK/1Nir/Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/mk.xpi",
           "version": "91.11.0esr"
         },
         "mr": {
           "hash": "sha512-NuSfd7GeKwzqJDw7kgGhK7+1pj6C+1z5JoZ6cWusRASbj8/Kyuc4BNDMO77aIw50dgjKHJyRFc9gzmlx5n7JKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-mr@firefox.mozilla.org.xpi": "sha512-FinPd3Z0REHheEoezCv3h6CZoUTduDJ8Nddy2hPfC5KgHK3b95nZX1ZjeRnj3mPqZVoaLiwhDmtYdZBHVyCWvw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/mr.xpi",
           "version": "91.11.0esr"
         },
         "ms": {
           "hash": "sha512-ZaQrukzvxklI7NT2rqhheKLTXXArvSnz6adTqtbuTEc4dEWvC9yOVYogWTV+J/bvMPMJGnBhZjmdk07h/xW+gg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ms@firefox.mozilla.org.xpi": "sha512-q4XzkOqo4hX7QTvHtR1LCFClIlM2YwSCPREC8G9tsWLAwdrSW3E8cG8W9fRiFTtkfHXoEJJNFXDGJUGR/f+tqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ms.xpi",
           "version": "91.11.0esr"
         },
         "my": {
           "hash": "sha512-J5sXSpMNnDx/lFlD8zI3HbDGSGl8iyt0PwkZklAJTeFcw+1NGDdF1R7T8Hh2p/36Kj2DtMV5F1fZRINvBwR+rw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-my@firefox.mozilla.org.xpi": "sha512-ImaRCe2lbOXwlpPnDiTuZCn4FcVhZf/3cKACtRaF7SPG0rvI6aqMtkjdYULLSQuVsC8Jz1Hex71okwA/+50lbg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/my.xpi",
           "version": "91.11.0esr"
         },
         "nb-NO": {
           "hash": "sha512-9Ps9OR3CqeofXANUEU417kPEvYGQ164fDNx4V31lI0HPAaNgNDVfYV5V06gJqvKFHXePrZtr0mt6nEjbPgUhog==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nb-NO@firefox.mozilla.org.xpi": "sha512-pZAPYZ0tDrsLN+cbPO5KNF07Lbk0/LY+wXms048+Y3lRnBsjAPOf6odIH/v32ftnVRuhboKxufm7Bk1euDE9TA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/nb-NO.xpi",
           "version": "91.11.0esr"
         },
         "ne-NP": {
           "hash": "sha512-jaQzMpw/svWQEASDu5h6hyDUH7BUNeyvcU9Flob00ZjlQbDDRKMT7o0mvlPVSMHKpITXrSKaS5D5zFHA6Lshrg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ne-NP@firefox.mozilla.org.xpi": "sha512-N7pr2hbWs6JUNK8iSUQQIjC/PnPajIYSNMUBbd8on9FghT6MYJgflb59caWEKgeYEcqaikQFgmCEnXS7x3bMkw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ne-NP.xpi",
           "version": "91.11.0esr"
         },
         "nl": {
           "hash": "sha512-XWXxAHYuMlF2lF5PmidbcB75gBDT1hMtulOV8JVPpyPppM8YZGLzDZQo2Int24pxW68HDqcPf70+12phib/D+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nl@firefox.mozilla.org.xpi": "sha512-yV2Hut+BpnhqhZGUuqZxzeqNs6t34ewY+yvdWRk9QcX5kEGLwo4QIj3c3Z3K7v9H1FGawmbDMoyW0E16O8iMFg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/nl.xpi",
           "version": "91.11.0esr"
         },
         "nn-NO": {
           "hash": "sha512-4HBsfHf7mAGgI2Z6pbrL7BpzUWSWYaXXsqCyYMIH5cWTYxPU8ZJxnJXnmDKHNoQUuaONzhat65JJfzmRH9Qelg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-nn-NO@firefox.mozilla.org.xpi": "sha512-b5Ozt+IKL/kRxN5hUyDFu3X5OwaGwDviI4ca61JKONuXjP+TGI5AtKyTRrE457ZIni8BkyttSvt4aGiOHWSQoQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/nn-NO.xpi",
           "version": "91.11.0esr"
         },
         "oc": {
           "hash": "sha512-qIJpoqELzTVFRtULFjG5irzpcvN2c3gGtSYKT0yw9kpJz5uKInK2eqZlz5m46Iwr0is4RqMp+zpT47y1/SnP0w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-oc@firefox.mozilla.org.xpi": "sha512-3aKxZ6khO1zD+h0BPRhET+H0/VlxaB0nD+NaJXxxIsh9FHxcIeF5Lo4DRbdIhj25EZ3acNvgmDiih/4gSCTD2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/oc.xpi",
           "version": "91.11.0esr"
         },
         "pa-IN": {
           "hash": "sha512-WBf3NDJYzV7vx2Muo2Om/wx82c67wMhQofnMgi1PWrK4OhnujYEbGvYSx1lN6z6NJ1i62qOoJfnA8/JL5UuG9A==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pa-IN@firefox.mozilla.org.xpi": "sha512-0oYiYOutMtOZy7rySfUcmVjl6rTGQUNn1XBi/O30BZAReis0jl90mq85o18kaBTqpO35sHmDhadLWJ5BvDsWyw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pa-IN.xpi",
           "version": "91.11.0esr"
         },
         "pl": {
           "hash": "sha512-0zuQ2Rq4lgjp9xEdcmptMv6Vgxrggwamd61/XeWeq5n9j0I6Vm/BdZCzsldrKdzTMoB1EzApiz06Li48JNsdoQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pl@firefox.mozilla.org.xpi": "sha512-h8jHO2FaQyHg9Xjmyp7xUfJDqUXA9eWYrD4x+oaRX6eVAzmtzrp0SJaGValwoiGgNGIGyNnCLOw3s5DVAA99/A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pl.xpi",
           "version": "91.11.0esr"
         },
         "pt-BR": {
           "hash": "sha512-ke7mRVO+XwK+ovpm5m2CeUQLAiJOLv48a4lekUT4mnkQpgZ9bdMgOGuSe7+Q/pmUK+xkfiO0WtzvUL6ZQu6SpA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-BR@firefox.mozilla.org.xpi": "sha512-1KGlHVsEGZ5InDCCyGBuJnwScTeHlXzMLisBjOFSNaxvomlr0BefNo/J5KAvsdPxemO2wD2U0Llv5qDsbqrcMw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pt-BR.xpi",
           "version": "91.11.0esr"
         },
         "pt-PT": {
           "hash": "sha512-qRUx5NNaCqMcQ6CTM6ArKTTxqT7GQTwR5W+MwPvvl0e6qzmpYuQjb22bUbSCqHBBOZUfw8WH56memD+6VAucqA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-pt-PT@firefox.mozilla.org.xpi": "sha512-MqXzeMN3YsS1ZL6rMRgrE7gXIxWgUW+WRn+rWyUHT2kAQBYYTEqwriceD2x6mwcEJeH+hKMt+O+3iXCPQEem2w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/pt-PT.xpi",
           "version": "91.11.0esr"
         },
         "rm": {
           "hash": "sha512-d+jMQC61PaaV45rC5t08Wj3G0heaHeyEV1sdNvIhPhcnJoOIYeXp34l8oyniErT/dJ25VzjqU20lvO6AGVBPCg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-rm@firefox.mozilla.org.xpi": "sha512-w9eq05cLr7+SAv6uUjNzkAEVZyHGRTF+5ta6hObx1jC9uXi3/1oMQAT1WA5p2J9R0eyh541ZVSBM0ucc9/YfIA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/rm.xpi",
           "version": "91.11.0esr"
         },
         "ro": {
           "hash": "sha512-caMegR7q/ZhWzBjtljt0lSYQdNXlrHorthxFoGyqg7ao8g+fVmR0uiFBEWcYouCOpqbn6qicskAZHXSAEF300w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ro@firefox.mozilla.org.xpi": "sha512-jPx1lM67P1Xh++7DOIskgYg4DH/KkRlaQf+5LM8HfSeYfE2rFH5q4Gw0SY5OC3qRUbAampwrVNoYJMhVO8ROLw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ro.xpi",
           "version": "91.11.0esr"
         },
         "ru": {
           "hash": "sha512-pHOVKn/D6XGaicl0O3xJkQch1mipVYI6V9mZTsvOr6ThFs614RzBES8zPnWs3Kh/l1zd2riCTjhIRlBBRFqFgg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ru@firefox.mozilla.org.xpi": "sha512-C1SmYrth9Xdv0BxBLW/pl4U+5sAXw66a15KA/udnWbq8VYSxcsccJbUoMpJFYptGGjWcepvq2rfbDz1cBhL0oQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ru.xpi",
           "version": "91.11.0esr"
         },
         "sco": {
           "hash": "sha512-jnXjz3aLhInVVxiVhf7mjgm5+rfW1AMCOt6bmsPKUfCGwjvf54TAGZ5HrtIiq/+Wrz5naV/xof3yUyB7XM5JkQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sco@firefox.mozilla.org.xpi": "sha512-e7p6/49qcgFCpqmElVDQo9Kg87KaPl71455yhOP4XtJwSQP/796tm6zwt9OcRH/O530QUC+LglyqL/YhxHpH+A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sco.xpi",
           "version": "91.11.0esr"
         },
         "si": {
           "hash": "sha512-1oTnKo9GGBfx2DrUIhejlgnbYYjFb+bcROz708eg1H71P6APDzjCqK7xNPzaHCxi0jvIFtRKXBtb1FoN3cWX2w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-si@firefox.mozilla.org.xpi": "sha512-taDhCpiTCIYwENGjsR6FNX9CVrFcyS8n7jtQvE7uIF3wERT/e/UkwAU7cuN27LjlwyA9rhjvTGhY/CbRe3TY6A=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/si.xpi",
           "version": "91.11.0esr"
         },
         "sk": {
           "hash": "sha512-ZPCDMylV+HWMhGB0pD99ANkFONq+Hl2a/pIE0RxjduSx3jPN4F50i/IeYNQPedZjHq6POXY5uqcmIBpXk7Bgjw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sk@firefox.mozilla.org.xpi": "sha512-UaKsHJ6fA8yxLAI5Gus2N/zt3tIgKP30Bi31gKv5jLKvHCQS9MEaAsB1rkcnc7AsW8C0EBuxUB9mNYHHQ7jtJQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sk.xpi",
           "version": "91.11.0esr"
         },
         "sl": {
           "hash": "sha512-ij3hLLneA7b91oJFbCh+aTpeqKzFUpXYI+yuCBmS4eCpu9Ereqfmz4aACBmENnUA2FQmTND/P/JCKdyMGFK39g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sl@firefox.mozilla.org.xpi": "sha512-c1wt1TRlB3vRG5Ac5rFNr9NFiWVazeXoa+K+pdadYcZMbuDlZDPaZj631g6XaJzpMFFdZie49lDqCgn9CAF40Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sl.xpi",
           "version": "91.11.0esr"
         },
         "son": {
           "hash": "sha512-XJjPQ+9+Log6emtH5l3LqjhLqbZYSTIneGXy+IQ+KGJKd2wHTVFC457IyDjGl6V3ds1Xfma1+eI3S4idAOX7jg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-son@firefox.mozilla.org.xpi": "sha512-4+QcZnU3PE5t+2bTlwKNyZR6zwEnJkf3T4t/lpPnKYkgcekZ/nhr8E8fJvpOjWTp3nHq8enOdclA61DY5jr5pQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/son.xpi",
           "version": "91.11.0esr"
         },
         "sq": {
           "hash": "sha512-VWA5j9+UELrqTJr3u/B9tiQCOgiHurolG9or1ngNdpGCExfyGyocISsGpjE+oigAFeeGL1A7B54AhjWzxuoaGg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sq@firefox.mozilla.org.xpi": "sha512-B6UgopbuTjiJGiPrWbpDwdKuwfSj8VDNTxY4z4LUb4qg4I28uGrS7kdV9cdelEUNt1t61tD+0cA2Gu8zMtGsxQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sq.xpi",
           "version": "91.11.0esr"
         },
         "sr": {
           "hash": "sha512-9fxFJ288PLWRnq2wsjacWHG2MXTSJcJjQqnaDLwncid2bd2PUO9XBlvBFEXgGFVdMRgM47gMGJ1iqkaF4DWIpw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sr@firefox.mozilla.org.xpi": "sha512-DngY56+KrqPuKDdaftA4ZPaJmNc5yg64nV892yJbidyU8XGfuVQSAFoJMX6UZWhT9T7RFPjmcDwucbo4Rou0QQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sr.xpi",
           "version": "91.11.0esr"
         },
         "sv-SE": {
           "hash": "sha512-OJ8EK79SYfu0P1kBGrd2gDakVBwo4VxDkQ+dGoKPyASHglz9lLbPYti+KRX1w9fK7PAkhCATtKAeEfD8fS0OKg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-sv-SE@firefox.mozilla.org.xpi": "sha512-t945Sr73t9Lxj3hg0Xt27tWaEt/PigHcYXcKAtGgP7d/+PIIWyoHh7C/GoQhsGodTC8G+g/qlAAzN2posjZj9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/sv-SE.xpi",
           "version": "91.11.0esr"
         },
         "szl": {
           "hash": "sha512-rOPDKqy9WllR+YxGKyXdYiCPTe18POcafgq0uST7VtombQG9ik5WE3IPHKXm0EjkMtdgrFYGrNXrcyeHDuG68w==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-szl@firefox.mozilla.org.xpi": "sha512-j6HbyPQPYYWUlGpQyZZCn73dffU01ld6NqkUTmntCi/vH9OYZ5Z2wXAgidi8hgvxisOnr2wI/EWSLpSMKmHWIQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/szl.xpi",
           "version": "91.11.0esr"
         },
         "ta": {
           "hash": "sha512-kI5CW7B+PDMe9UltqPhVCPFu8228Rq91tExzNJFlJAOryjF1HuaigOAR7UNNlugw/RZxCOXCkCPjxyLObuTEjw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ta@firefox.mozilla.org.xpi": "sha512-tDdwsOS/R3akeK0yaraI3guqM9ZH8+Yda3STrXhqBiEKP73/4PcFoC12ZLBzbW2NGdqayfPntTRq5RoIQy1cqw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ta.xpi",
           "version": "91.11.0esr"
         },
         "te": {
           "hash": "sha512-kNDt5A5+Le1ntmg/NtITZCTabBOXE0d8uu3owtXEcPzDzJ7k0lQxlfZYIEYDfFSxMIFbl+BbVUS7ykfuL1vykA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-te@firefox.mozilla.org.xpi": "sha512-Dbnm2KDjTN7XRzNm7yxiNG8v9A+0s+UI651pukKmDTavnJN5CaYTaxpRTuJWiHm12TfqJFADkc1abr93C15AJQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/te.xpi",
           "version": "91.11.0esr"
         },
         "th": {
           "hash": "sha512-24gEYPrOH/0ntop6hZ1pz5VZeELNMaXS+bxpCTEUQayGH0K54cTv5vb8STjVmgsIABX8iYVzvVHKS0oRiK+wHg==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-th@firefox.mozilla.org.xpi": "sha512-XNPp07ZOcC2Yz+MgZ9CXs+6NR+vhVCV7RS1i9G/7F/A//VkB8flst1ynLZBulEtl7xYMK8R4bOZbg15Yn5qDYw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/th.xpi",
           "version": "91.11.0esr"
         },
         "tl": {
           "hash": "sha512-onsjwThqW6YUhlBD+nKkRyhQeOGIow6uNxISJQybWzYVuZbN7u8lzkN1MGEOByXVRKQhSoUNWTTs80nVqcAA4g==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tl@firefox.mozilla.org.xpi": "sha512-MUrfZ2KJ66+A+eeBBbdUAZi/jmQoZkFapwcnhY0v2P66jzH4eX4c5+IjFqHefaNLND4NOb0ceZFukz30TUwrGQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/tl.xpi",
           "version": "91.11.0esr"
         },
         "tr": {
           "hash": "sha512-lmlWRvgoeAwYjOP4qtChpz6eMkpDB7qnlya3E1ogkQpXF7iNG8cE79aElbBRPlwNUZzA+rs57/5hCJ1qlO6sDw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-tr@firefox.mozilla.org.xpi": "sha512-0gagp/IIH0pZC4tLx9g7JicJM+EVNKzwryea72waXMeXDt5UL3VZerJ8k7DT7lyv0drTqYEZbIgYkXqQQ/922w=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/tr.xpi",
           "version": "91.11.0esr"
         },
         "trs": {
           "hash": "sha512-EPYqiH32MK37bSbxJwAO++sNO3GDrYhsKMDpCabXi/hlDV6tOE0x2io7lmU/FUE99QDC/G/IQGsCe71tyKT4Lw==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-trs@firefox.mozilla.org.xpi": "sha512-0WITJZeVm7hR/5/edNbHi0zbecrXoNTtp/wgjsFejwvLOMQZyQB1DGF9yS97bdyKwONANRCwh6ZWKwYPIFp5sA=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/trs.xpi",
           "version": "91.11.0esr"
         },
         "uk": {
           "hash": "sha512-3oO1rQDC7y77vuCwsMDVbVXJeUhNW5nqJz5Ggd09O8VF3K+GsU6bxv38hZY6x5xYtZbEmLlGle9Aii0vCWyWIQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uk@firefox.mozilla.org.xpi": "sha512-zdkTtowByx7PIRdViJ3POW9OZP4d9vHXxOBSd1FKnK9xeL2uYCgVL6785AyVCCyknsJ1grWQEbYq64mw63y9bQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/uk.xpi",
           "version": "91.11.0esr"
         },
         "ur": {
           "hash": "sha512-YJDxbzK0Sr1kBLebp157FP5DdCSFLZMqOfrCbiieYy5gBHS1PjmRjjc8WNiZSQ18X6ykI6JoqhJFeIXjI5S1sQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-ur@firefox.mozilla.org.xpi": "sha512-QjyX9bqV8gpGIijlQ1tYbICJyHElAGQmsBFiBYr/h+9C1hNT3G8K1RsghqHMFmdIn40DvIMTopr2EXCs3NUbkg=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/ur.xpi",
           "version": "91.11.0esr"
         },
         "uz": {
           "hash": "sha512-ISmfN85/73lmp3Tq6U2YICDIkAVpScxE7YI+rJ7Um3J1Q13gbmPeL6fNey+xziF9+Vwbpmkn+wRRja6HN/YcYA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-uz@firefox.mozilla.org.xpi": "sha512-m7VBmXfactVYmDUDeBa5HfbT+LLuDB3AqwO3kJTuE4KqZYG/BiD4mSokrV8VRnizgeYHzF9G/KOEku4v9CKm2g=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/uz.xpi",
           "version": "91.11.0esr"
         },
         "vi": {
           "hash": "sha512-HC/qjULmgiTJWkNoKwgLpe1kb3ZQlT2w7DuTMtWMmVmK8ArigxqsKhg3n/EbihAn2QhGcFy7h4FaWTDzA8h3TA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-vi@firefox.mozilla.org.xpi": "sha512-0G5xQpGCx2AgMFb8UwGsVQ0F/yjuGLus/MFhiKy/M5YlWFPl6ThLsTaZZ4wd+GoonQQiSHgVAEPaYsgD5Q8k6Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/vi.xpi",
           "version": "91.11.0esr"
         },
         "xh": {
           "hash": "sha512-snkL2RSIKnFO+DVVWsONsnpoGDjSj1ObAE7QkYGjPo1yDv9Upz7sUSbjjIjndffjtf8NPeXrwo9rsZFerkarXA==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-xh@firefox.mozilla.org.xpi": "sha512-7EZn4upQO1nT480N+23VITeMGPiDiJuCLa82LJoWNXvxDNWe/mTMbzPQnimgiuncMVDCQMCjWbtuKvi1MkPe9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/xh.xpi",
           "version": "91.11.0esr"
         },
         "zh-CN": {
           "hash": "sha512-dYLq+uiNHlAkKXBq2IjBbWz46s9SYyrmNEImvmCYuIvvKxW8uKwNZMtW9eVHIzyrwrqn/480plwww3QNkmMX8Q==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-CN@firefox.mozilla.org.xpi": "sha512-Sfoh418FbyEQkNojgH+kviBkftWhnTqDz9DCVAlD4GXzEQCJt0e8R9yi9OB7kF+Sw3YzFYZk67AuHjCPvCC0cw=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/zh-CN.xpi",
           "version": "91.11.0esr"
         },
         "zh-TW": {
           "hash": "sha512-LChooIbS5pPNFX5ovZWUJ3OBIhyUzlbJyzGLyjguaWHaoq/AE4YydnazhOr50oJH6nlFuWjKpmvI1GwOwAzmDQ==",
+          "narHash": {
+            "share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/langpack-zh-TW@firefox.mozilla.org.xpi": "sha512-md6EH/AfEDE8PnynpAhzSABwRHnp7S7XPw1PH8m+AE1BBCcq/LbgU5OVxUqDxK0iC6EzYRE4Qc/DhBK0gJbFGQ=="
+          },
           "url": "https://archive.mozilla.org/pub/firefox/releases/91.11.0esr/linux-x86_64/xpi/zh-TW.xpi",
           "version": "91.11.0esr"
         }
@@ -3950,331 +6302,529 @@
       "linux-x86_64": {
         "af": {
           "hash": "sha512-3rivMIPfBg7XQJO3vASo2DjYQfSweE86Ve7QAVMSV+kzDVUrQcwxxa2tPQzCSNNHHi1GHDEJStG1yPTwnhnzyw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-af@thunderbird.mozilla.org.xpi": "sha512-U68wpaJBGlINGb5jNqnM6JL2+mvNG2i8oR8QOeCiSE7PjE6fxRG8Eri82beX7EXpO7w+0ofe8BnmHG1gVr1KMQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/af.xpi",
           "version": "102.0.2"
         },
         "ar": {
           "hash": "sha512-zm9SlU20onEwJpy/bBjhofIK0OBVuBw4uUqf6vQPXRpPw/NOy6Debjt3uj3t/Xqzh58qmIjEShvoIjhfHErOEg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ar@thunderbird.mozilla.org.xpi": "sha512-ShJKRhrufE1+g1UZlCFLtWxz0FErfCBOyUPD8H87mPSPVxRnuGJWWy5gguIscwj0Ba0VR9vDhzL8ecejyxmfeA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ar.xpi",
           "version": "102.0.2"
         },
         "ast": {
           "hash": "sha512-XP9Ik4FLSSH6nGQDmYK+qUMyooWdCPTakms81QUPEfEu9vgbRo36OS4Whd0DPq+DzPM18n5eOhI4Vpqt/1epWQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ast@thunderbird.mozilla.org.xpi": "sha512-o/rxe9xJq/EILfOVrXzNcsBLSXGGNaQQP716Cxu1mZQhqeY0uJ6JjYQDn2msuipZ2zWBfYz08WF+QaK9MSe/Qg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ast.xpi",
           "version": "102.0.2"
         },
         "be": {
           "hash": "sha512-9A14UrQ2qiW2Hao17v3HcUbZ/0OvZpm99zWDMB2sh05yOyAsSu0t3PTckrOS1h2jC88io5cW9iaHOAsxAaK1Dw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-be@thunderbird.mozilla.org.xpi": "sha512-oACWu9kh9AA5uY8gUSKXb7I78tW5KC+HA20u7kgKLq7NP9UViEdqb/oisMxQYmHx7vflFTRJJcViT2+uTrNiYA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/be.xpi",
           "version": "102.0.2"
         },
         "bg": {
           "hash": "sha512-EFvA+BYU9EkKao6leXA+FD8IUDqFfEol4zRTb0bEY0b7PBDtoNUik9FUEhXi+ny1l3EApMDcjDQhNMVuw6XuaQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-bg@thunderbird.mozilla.org.xpi": "sha512-Q3ZDVoG60nTfg48L3upSdupinfsqRJwjt6AFDAumjQj8dCXEqlYiFWMYXk2E8eQqm/YKDu6bG4lBsqwnh/ECzw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/bg.xpi",
           "version": "102.0.2"
         },
         "br": {
           "hash": "sha512-DYUKmyy7Jq1XBTrim7K8OL7Kw1MIDM7B4IX9mIzOdBCUXKQcxrqY8ufi3fFYol62KnGsrL7CQatN0I72TBIDRQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-br@thunderbird.mozilla.org.xpi": "sha512-+pKFceiZjW0b3WtkZzTRHtWFvyLk9IGJLA3hN6PZ9B/GWwjr08g4/EFTzC3Ogaqy16fae+3qFXsElDp1X0GooA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/br.xpi",
           "version": "102.0.2"
         },
         "ca": {
           "hash": "sha512-4Cmq2L2JYDAAdddax6dt9pNdH+5rRU0CVw+tTyrAWpK42CMuUIaiZXnmH17fSe8+wrDHFWkPjM+tD01cRy2brg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ca@thunderbird.mozilla.org.xpi": "sha512-XNtN9bco/7H96T0EPiJgpt1pBgCajv/zbmKbiFVLUOCt9/SuyC64GdK8RJ0uNz5Mt6MXquEN9zwF5T8y3gDgow=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ca.xpi",
           "version": "102.0.2"
         },
         "cak": {
           "hash": "sha512-fjVYBi2NnrmQemWhrDX3f+P0SXZ9jXVX6LY/BOeseqKQfvll2iFb0z5Lo1vH19o/rgG6BunQfL2PV7fh0X2Mxg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-cak@thunderbird.mozilla.org.xpi": "sha512-c1M0mHVYS+RhFPkU9DMgs3H2IakZaRCSNlNQO6/YsETNOr19RDAUupH1bvPSqmXqMFx71Y2f5+55E0DAmDN/bg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/cak.xpi",
           "version": "102.0.2"
         },
         "cs": {
           "hash": "sha512-MWjMHvxXxMjn1jok/sDv7O7clChg912pnoos1UIiYu830yrk28s+wIIcivczDAgefGTSK8LC99jBNNb4QAS+GQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-cs@thunderbird.mozilla.org.xpi": "sha512-I1jbefG4O3ZyG59nmE2ZG/iG/sYpDsr2Aux6L0foQP9Z62KVkNpfLvit1QR/k0Fh8htpuwZrdoHWHWn7xpL27A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/cs.xpi",
           "version": "102.0.2"
         },
         "cy": {
           "hash": "sha512-TCA2F6AfuZuS4U1j7UMyKVCgvh7k3iFbJNTtukQDHTHJ/h4BWfGD7mDczkyuESrU7a3AVLzXn6JMWu63ncWYpw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-cy@thunderbird.mozilla.org.xpi": "sha512-umMjRLr5DPX9xUpQqfUSS1P5sLNM57MmFA4Qz38ihex4NA9xfcYMaXMuvM/RqqliIJvuS3MYTraRdqs2G6acFA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/cy.xpi",
           "version": "102.0.2"
         },
         "da": {
           "hash": "sha512-fDvjhmDaMsoW+zEJhqy4GnAZ6caHLYgJB6n3l8Vlhd5wDUiqiYnUUmCpRJ0hfVGy7XLS4otG/gQjwxGMk0XUMg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-da@thunderbird.mozilla.org.xpi": "sha512-rNWKzjNVF6VAhw9O2L77BjjSWrFLBz7FyqkAr5eorCNuGLYRPDPmmUaM2+Xv4pyNsel3LbFlE0rHaHQ937u0/A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/da.xpi",
           "version": "102.0.2"
         },
         "de": {
           "hash": "sha512-KlhKjXHEJfbBm7e2rwZDdimgvs69FiGpkOZXXycipkh0vpEpBMVbnTUgjiyfx5SKijt5KvcsCAvBwzlx00eVsg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-de@thunderbird.mozilla.org.xpi": "sha512-U/LRuSL8G6bt1E8+SjAcGguSYXORQeiB/2+SsWlaGOX2jQBM+fEPCDibNAuFkGn3LzeYmRqpEPNaxGPcBaQ3qA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/de.xpi",
           "version": "102.0.2"
         },
         "dsb": {
           "hash": "sha512-uBv8dtZJei9rsanRezIZY6CgEocJELbDjoSrkuMrw+qI5rCt2HDDXhDKRXxcONbuH0V8rbJoyz5eUjobPuEqwA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-dsb@thunderbird.mozilla.org.xpi": "sha512-7YlvGPOXohL3ygy613x0tX1mNtXwM4d9YI1jKqz5qG8RC+hBrhG/TQmXnfI5VV9DQc+Gq8KxcBqMZ0PyzEFHmA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/dsb.xpi",
           "version": "102.0.2"
         },
         "el": {
           "hash": "sha512-BUg98PYpVM+ORtkDo655hfmEv06SJwhq749tg/ULgwnDLmTnOfv8ru8vzTg+jn7S66Dmde2E9Q2kJHGlS+RWrQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-el@thunderbird.mozilla.org.xpi": "sha512-DVVOjJjYzQlwIsSHu67DPtXIzRXQ4T1pnMu/rMY7xBnE6PbE0tw+ht+yVKxXGvQbDCi9I5mEUulPnp8grzFq/w=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/el.xpi",
           "version": "102.0.2"
         },
         "en-CA": {
           "hash": "sha512-omK2zO7Y4vBd6o+1DSrsTblYo/xz0nEso6BiyUgSR8aJa7bqP+z19LnTR5+kRwuf/AbeO59tY5bJbL7hw579Dw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-en-CA@thunderbird.mozilla.org.xpi": "sha512-Oyp0ktrgXSsX3iQlDGmv82KfU5QFXrGKxg9dryfDTCJoOJhVTqEKyS2KeXH52ktGHluEEMJaKmu0g1YAVbcQEQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/en-CA.xpi",
           "version": "102.0.2"
         },
         "en-GB": {
           "hash": "sha512-zvsxiqgok/XTEYWnEgFsko/BW7GHKJMY5311YbYmcQ4pfxzoyaI28Pw2UTXCy9MsCE3AaZ9f0YQo2BmJKipXvA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-en-GB@thunderbird.mozilla.org.xpi": "sha512-J66zS7noPdYcSjHVPgqSlHx5HHHGR/Rokh6vYKlgnrqIidhUNnUB5hPQoTRMTBfogyYu9vowa8hCfAKuTTzu8g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/en-GB.xpi",
           "version": "102.0.2"
         },
         "en-US": {
           "hash": "sha512-+bdiPslK2vgz8jvqKIliut9jnIzWENYaAEKES7lz42x7ifdVma8Xp7xDD6bweMZTvdx4LoKJ82biKnd6cBYQxw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-en-US@thunderbird.mozilla.org.xpi": "sha512-Wbc7C3W4awPIM6tjypXt+7IV2sFY895jPBO6an56ZrHL31pbnK7xhOTU1G5TZaGBHrub+9lmw7j8c/z2d3ywig=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/en-US.xpi",
           "version": "102.0.2"
         },
         "es-AR": {
           "hash": "sha512-8FyHBdSxcfw9deorkTYlqFplkSMJjAnZoPuiJ0sAYawgEOIx3uYMzRJBkPPH/vNPCX3fnHc2+V2kXGT4N8GvuQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-es-AR@thunderbird.mozilla.org.xpi": "sha512-VtzL7jJvMcPeWQKTxOlSDKC9G9CpcR2ee1CB/MZzE56XJqMCDdygzfSYJrgmRPNcS2GzWler1DlCxyQsvz+RQw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/es-AR.xpi",
           "version": "102.0.2"
         },
         "es-ES": {
           "hash": "sha512-h0BoR/P5GysR6r2vt4aWku3wOGWk+7EtOpjeCJw3kPoBpRBDMjbFjYl6RaYeCnhT9cfTIergomycy0Yg1RQwHQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-es-ES@thunderbird.mozilla.org.xpi": "sha512-YQFjDkBHffL3adPIpABkKZlS6LamvT0d0O0Fmg1DhHMcoJE5UwSq+RUUsiR/l1FXFTz5gdlIKTpn1Lz/nlHkqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/es-ES.xpi",
           "version": "102.0.2"
         },
         "es-MX": {
           "hash": "sha512-eS3mz7brOF8+GouXaauhI3W0Jk87JiJ3Rq8R0Q1bw1SB4dALRNt73zKiwPKb3//Tk0ovZ3M7/02zXUngb66syA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-es-MX@thunderbird.mozilla.org.xpi": "sha512-ROngloCVZxQDXoR9aU9n5PHHjUd7sixoOPFfGsKEeF8nSDQBz6dl58FnG9Vbf82XSgxbqb5/u9Lc1Y7KsSOjhg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/es-MX.xpi",
           "version": "102.0.2"
         },
         "et": {
           "hash": "sha512-ZQi30sHXBdLCI6yHcPA70tvWZCeV9mLytZ/0jIA84QYnAkOtcEbDczxb8qKwJ3xKetqVVjGdjpeXp4QQrW53dQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-et@thunderbird.mozilla.org.xpi": "sha512-eC8HAQZHUmq/KkaFgaMf7on8cxoKDL7ytzMsutuXD9xdMr2zPjDRN/cDQ3TUM9oeNdY6zadn2Y7aVcU69uLwWg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/et.xpi",
           "version": "102.0.2"
         },
         "eu": {
           "hash": "sha512-B/Qr7VPqfLC5YVSUMt9Dg3JYc+xQpmhG8QDN+MKuCSEAtz35jEd/ORMiD8V9mRr/9YeRyHS3UCpPOjc8VgWDRQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-eu@thunderbird.mozilla.org.xpi": "sha512-E45rP0Nm93aOxaYhB8DFxTtf/KUM3IZqVRlmz1V5KXhS5BIC11Mhl21AHumqJ19TrrVXGy1TYeKUXWDieTPLHw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/eu.xpi",
           "version": "102.0.2"
         },
         "fi": {
           "hash": "sha512-HIEkbW4wLEw5vT0HLw67z+71clZSOyPQlmSQGaF2b9jFqUynsPIbXZ4aQEf7juT9txFH2Is37C8zxZtZQ2ySFw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-fi@thunderbird.mozilla.org.xpi": "sha512-DCcBIh1LSfcUfSIXJf0iYEqntuYi6lSRBNBebOAAeKXB2vTo1ONpIivPz+ilAzL/nDcp/zFmmp4zS6oogQ1c6g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/fi.xpi",
           "version": "102.0.2"
         },
         "fr": {
           "hash": "sha512-02ponCQFFdm21v3fH4F021+zVJRQsNI6zjfVesx3zv9A1tDm+iASziZopjlfoppfDaKPw/etOlC29YEIvFVziA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-fr@thunderbird.mozilla.org.xpi": "sha512-m9/618RVWEaa2dGIaVwVv4ptuIMYx23PJ3s22un9vddT+yb5fUzcUPsElCg8CMnpF5aPBDJaf+s0BMUT74dlJw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/fr.xpi",
           "version": "102.0.2"
         },
         "fy-NL": {
           "hash": "sha512-mKeRL2G9U7jI3rrjXTX3u0ieiJHch7JeuuArBAvco2iBdXp7fgS2lxrl3UIx/+r2FLuQxATUTbPU21wXgcnIpw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-fy-NL@thunderbird.mozilla.org.xpi": "sha512-9Xly9z+HZ7HT4fW2AxyUfXl4NrzQNtk34WIJMva6PCeTHBhdyfQ4rIjaMlcaLcM2Gn/3k6VZpWDiudy66sV97A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/fy-NL.xpi",
           "version": "102.0.2"
         },
         "ga-IE": {
           "hash": "sha512-5np1F3D5Xkzml5CFtDhaGuNb90z9shAGV68re/MN5I1xfgN8nQlXN8qiMfYNpwCaHVh4sNB23cJOFQpt4lwiUA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ga-IE@thunderbird.mozilla.org.xpi": "sha512-+cux299OTE7qzHEvghXiNBSPZAkWdPPgfE/2M7rh0nqxO/oRRPKWO8m5XXRAe7NjqSCGcWhxOu/Zfzpbhfkm0w=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ga-IE.xpi",
           "version": "102.0.2"
         },
         "gd": {
           "hash": "sha512-YHZUwVukfHEDA7P75KWil/sxvk4ewL70iIh+W8yVMWtOc24E4lcR5AreHEd6+aPZllI2nrDJYAqx84xpMtPWYw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-gd@thunderbird.mozilla.org.xpi": "sha512-9a8z+uXxm5HxFppqEB1E2h3KQTtelmn6s45F8dTstm7dJE6RMk3UwWsFnUVLXNLfglixJKaaflKr+glJ9vrhfg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/gd.xpi",
           "version": "102.0.2"
         },
         "gl": {
           "hash": "sha512-g3hwR8NxhF6RwesTsqHjb4JKPymzgvZW8js9K/1Od21i4ulEHLIFXEtaQQaJq2aQl4GwJ1KaI8x45O+ri84VaA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-gl@thunderbird.mozilla.org.xpi": "sha512-JSTiW2FVSbGZDGKnq6i0gTdVSzUvj+BJ9lD8dOJ+3WsfxVGUJXGcBnOTsn7wApUioXZxWHbMeUAfFYDcmuSHng=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/gl.xpi",
           "version": "102.0.2"
         },
         "he": {
           "hash": "sha512-aGkfpKpxWIDL1mXIZJS6h0PJOOi4UpDQQG2vsW7ebJvOX7xVY8zpl+qfaEnWLjyh1bheQhDOff8W824bKUoBYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-he@thunderbird.mozilla.org.xpi": "sha512-8NtV6Q94CuU3Lt3v1DjIACWMeajYviI3bs8uTuxafvA9TzDraKKgCzq5XZrq3p13Sp0KYs8N4N33w03V9L+2gw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/he.xpi",
           "version": "102.0.2"
         },
         "hr": {
           "hash": "sha512-dwUvHczw5r10sG7eYYAJZ6/fu/gacpdj4ebTVeUIrReLnn3w3XxhOxazjzH5auDGFaTj9/GJ+xKQtp+3RfU49A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hr@thunderbird.mozilla.org.xpi": "sha512-ZG1FjyJwysfEoI3T7jIvMfITJjxBXOUJvropF0doDq1Kfta0luq88KOQPtIqr8RFO3mrR7GBhLdq+rDtnCBLsA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/hr.xpi",
           "version": "102.0.2"
         },
         "hsb": {
           "hash": "sha512-+lyJtE7Ty9NOlB/kfi3lGBFIAPcfP9PLTTCKgVnwxphzC7lq6ofyJ8L1aVIbRWAOhxPLVQEw6hcALpypIXMJ3g==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hsb@thunderbird.mozilla.org.xpi": "sha512-h8sHzson+2Q8HzRkzP2d1fms7wy39df16IM9o9JDDTJuONiddMSKtaFTIA/GNMZmHzpQTv4MPjcSbdNriRfuGA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/hsb.xpi",
           "version": "102.0.2"
         },
         "hu": {
           "hash": "sha512-PWWNn5rR5/DdwRK9mn0QXTQ5DQ4lbRLyDKzAlyD9L2gmiNljMH87fAakJGp67ZGPUJWR7qLGbF4iTuJYgZRQ0Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hu@thunderbird.mozilla.org.xpi": "sha512-OQvVMIcsxeHufiJEbfyKjoRn36Xe+inWpx/Pczhtuk/EMJsg4TeLtsgspGlGJAA/OfKrhjlfU5M0clLhQH9+1g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/hu.xpi",
           "version": "102.0.2"
         },
         "hy-AM": {
           "hash": "sha512-8A6CI2omXG7yNzdXbEF6Orow5BZUdy4hGQKwQiQx3LuBCS5dP+PDmqswjjr8QgYXRuPNTDtRJMaG0NJgG90abg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hy-AM@thunderbird.mozilla.org.xpi": "sha512-UvRkGgAHDXPbNzz7/wOY9EvsUzNq8jfw7YE1aRKkpUy+tJ+HRZzfO3NqPeE5QrGDN5VhBLmtzD4ZYBoGEV8g1A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/hy-AM.xpi",
           "version": "102.0.2"
         },
         "id": {
           "hash": "sha512-gxgGqWn6KLTXhdZYX7/A3S/jTwBv6AlWIigjb+XDCI6rNj+XdxOUniggWr/YxG5Vg1Zj9r92p6YqUHv2Fu7ung==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-id@thunderbird.mozilla.org.xpi": "sha512-I9wkrSVBMFoaloDZ8n26iEqNVbkI/17ouamLSuxM+qBEtuTk9rLySsgbfL0LDj1mSWc8ApHt/r6s2akv/3mxOA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/id.xpi",
           "version": "102.0.2"
         },
         "is": {
           "hash": "sha512-IBq+T+BCoGlKUnOyzj6L9scWKR7wMRzxmuyn0JB4H1i/durbh3qpxMvlywLRtBCh2ycIO7OFsowwej+KYJdGEg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-is@thunderbird.mozilla.org.xpi": "sha512-vJUgKMB4nYtCDS20udMMGLP2bmVDtZjGm1h5Z8GZU8s3jx8AJVMopn07r9bv9J0E17pl2bRljyUEs55Gr8xZBg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/is.xpi",
           "version": "102.0.2"
         },
         "it": {
           "hash": "sha512-1oJG+3SgB4bxEAawhIHKYj5MQM7Z4wI5jBZbItCu6W+xPIF/EzHcOHJ3x9naDpuJa/QrYClAmzFXODZI3K49iA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-it@thunderbird.mozilla.org.xpi": "sha512-WiAvdXwhpBbFk4HapzAMJLKD4adzzxNJuxfqO5nJFZ0Qyiajy0khOXGszgQyAcXYHompApJISL4vxCUHQTkYlw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/it.xpi",
           "version": "102.0.2"
         },
         "ja": {
           "hash": "sha512-2nQn0tAEICefR9d+1j9O8aFvmDEJGbZYXLq8NlFApjxzXQWwDg2VVlH0FwC9wgHc0jJeDyfisGERzZ5VmgHGjQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ja@thunderbird.mozilla.org.xpi": "sha512-IhhdT44QEuTun4Lhdk8FJU9ZQtNwi/9DYCTDDETGVM5s+crgptrpzLZ1zd3cd8H/YmB1IjXkrr43Xk1g07EpMA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ja.xpi",
           "version": "102.0.2"
         },
         "ka": {
           "hash": "sha512-HZJNlxDY5Ws4Nvls9LHJHRW+KKmx3UUqVlD86Qbv4sXt6whvTnUtg1vcLMdPcXKUuXfdqYGMPBhZBGJWza0x0A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ka@thunderbird.mozilla.org.xpi": "sha512-leZuJySS7GaSAPPuUdmr5s7dJ4eBHwqamgtwSsQin0/nzGCUFWDjliDqFmCroglsVXaDdK34AHjEaq2meLu/6g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ka.xpi",
           "version": "102.0.2"
         },
         "kab": {
           "hash": "sha512-vqHuKboVRDAQmq23/FsKOcXmjnDj/kkdOFJLPJenXupYQSk+8J3gb4tOsIHjmSRZKvkccVE1NKmOUmXEfL5hfA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-kab@thunderbird.mozilla.org.xpi": "sha512-CYKfJ0+hh+wwTlubu0JLs1LZBFELj3yENWxR7TLZlu1bezpRtTmNJ8DBQ4Hczrm+y59NNBwA0S+yBDRqfwXWog=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/kab.xpi",
           "version": "102.0.2"
         },
         "kk": {
           "hash": "sha512-zltaappHDSS5AFMNWxKejexX2+tZsV+d3yKc3nkbCEJi2STxsfyuzujalorrt6DU7cG2zwkm75Eim96lRcz2Rg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-kk@thunderbird.mozilla.org.xpi": "sha512-Js4v2ynmWTmQI+wFOAFO7wItSe94JEkKH3zcmWo+VlWMWjT0oaAKLVClk0532RbbzG7Gy1sx81wZgO3NJju1ZQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/kk.xpi",
           "version": "102.0.2"
         },
         "ko": {
           "hash": "sha512-ICXc/vk/XEUeliE6VD7t1QhOKJHgeSSjyschBQyos9HDf+q+bf5koGSIXAEBPXlPmHCeGFrTNKRtAYy/nojw0g==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ko@thunderbird.mozilla.org.xpi": "sha512-0o5aFRi4EleOUp575pqiGVxJD3EpHJH6yXorxqMusZsHVZXx+HE6TElt9WD6L8Ldx6/urcK+52qvu8NtvpqENg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ko.xpi",
           "version": "102.0.2"
         },
         "lt": {
           "hash": "sha512-I/63tz6lqPxbndotv6EctKXXIXZbNeXYXNSxwPk/INg/HlZCkW1WksnWtz/4l0RlBKihBGxJC3R7qxC8E/jUEQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-lt@thunderbird.mozilla.org.xpi": "sha512-sQbx158FfG4X0bVvYtsBcEe4spKALEtAi4QaHSSwZUVH5E22TZldptSu+ZHxbelidzcb7BAVTuNSZHNL5NPPfQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/lt.xpi",
           "version": "102.0.2"
         },
         "lv": {
           "hash": "sha512-lVly4gY6OirOayTJ2YiYCGpWrRsDs7vU3s+uqsvZyfcHVH6VAeIOFwpJxRU2uGMwJpdgDXyGUOd46TxKHgBuuw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-lv@thunderbird.mozilla.org.xpi": "sha512-kp2VmgKRbchWyE6jPocNiRgk+QRAPJVOg11hwA3f/AZlQN/ohPXQbOKrDFsKgo1dp4Lf9NeK0+Qky00vkZOpLw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/lv.xpi",
           "version": "102.0.2"
         },
         "ms": {
           "hash": "sha512-O7dGa0whOf22K/ieWLRZvZgneKBV8QJPiRwktUPsmdKOqIzsskLj5m0FkmrVs8tST5qLnHxDnB4/Tb3kz0Vo8A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ms@thunderbird.mozilla.org.xpi": "sha512-p0oHkzLSlWmCxuBaSemIBFg9HrQnnEFvD7RZD7rZVci0h4VL6OLJYLxMzPNjWIbFNMw7WiK6aEu5NFlDJPhqqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ms.xpi",
           "version": "102.0.2"
         },
         "nb-NO": {
           "hash": "sha512-Ss1yr4NKUBoplyR7n8vSdzuAX/6BJTqEA0B4bklT6ghio0mXrhj1GHbTB3jkDNgXdX1jo4LDekzoHMY/sHgcRQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-nb-NO@thunderbird.mozilla.org.xpi": "sha512-bgBRT0d4DD7AXCM1zY2tygTFm2u+dtBZoFqBHVBE1LHQHWTERjSyZZ/wd8iQ9iZHmzmd6tuk99gbBm9+YPbfFQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/nb-NO.xpi",
           "version": "102.0.2"
         },
         "nl": {
           "hash": "sha512-Mz6gIhx+INlYlnX8utW6cWa0vYYcCsyYWqS5eUYSROD57EMx3DBJo5I/iinr8H0JAdSh4LpBu4RJ5PWyyErsqg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-nl@thunderbird.mozilla.org.xpi": "sha512-wGoU5D14SwksxctA9gate2VBSXED6wF46tUNIUXJdb/0wXjP9jAZ2xgx/+lJHEqL2w525feB8KnMeV2fiT+ppQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/nl.xpi",
           "version": "102.0.2"
         },
         "nn-NO": {
           "hash": "sha512-Y9uYXLKwHqHhkrjcV41UyE+3W1pSA0rHY/m+Y8qn4aBFpgh6TWGr2o9TBg4NhER42RWAnj/i8fGBpIkdyGRsPw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-nn-NO@thunderbird.mozilla.org.xpi": "sha512-v53kqW7up1WhkyoPyO7c8YnxgvL/7P5s86EzLgnl81t3Ghm68ETJenh6bHsevBkT7o+UlXG0y7/+2Q2Zs9ZJVQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/nn-NO.xpi",
           "version": "102.0.2"
         },
         "pa-IN": {
           "hash": "sha512-jZZ4OcKXWqYuoXQBZFFrFzP44Tg93bwzZfgQ9fnYKC+DyF8zxo4rvy2WetsHLT1VuUYufpp0iRNHRBOMOo0KnQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pa-IN@thunderbird.mozilla.org.xpi": "sha512-Jin0xBJxww+s7m+sXlGu502PZF5NugHz8Uaa2w4YT9oraS5dUvscpJYMOQMpFimXaQc1KRLghy7VwFp1q4zE4A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/pa-IN.xpi",
           "version": "102.0.2"
         },
         "pl": {
           "hash": "sha512-rTv9giVN3fPVaon6jy41ChiQ34FpuGF9tA2s/RV4rBdtmxKcOhV9BHjObpNkY7RKYU9PzIRBIjIvKVJNglfMPg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pl@thunderbird.mozilla.org.xpi": "sha512-264/Cca6/XWYnJSCd5FfmbWQF727K+rHyIuwd/ge/2l5N4K2cTPY5z8h+1iYQqcNQFJlHhwle8Nop0z+c7pYjg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/pl.xpi",
           "version": "102.0.2"
         },
         "pt-BR": {
           "hash": "sha512-XtSBeO8RB1yCFNtWXBB8UjQiZAnVd9DZsISp1wJir+V/lEzs6/tY1y4sTRVDTmBr8nyV2J9y1eBUi8cQ3DAsoA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pt-BR@thunderbird.mozilla.org.xpi": "sha512-OVlYYaMEoVGTNqiuXd9D/rs5ZOysHnjoOFRsLzo2QVS+V1I/tRTyjFaXkguPougG5wVjNKJOrAlJ0+pvK+DtaA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/pt-BR.xpi",
           "version": "102.0.2"
         },
         "pt-PT": {
           "hash": "sha512-NdI8No1jW3QLokLsc4rA8RHSEy1riVwYGg0nT4NgPF2uNheLd/3cw7RfXvJerm6SAyuDeUiewlqyo8InP2ZBHg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pt-PT@thunderbird.mozilla.org.xpi": "sha512-frO8Y0d6aSYYh3vAGOwTJ+p4cRF9aUL0CwYMQSjQ/Sm1p8x+7DkytkyfakXcGX6as4g+bCM/0KlUdT1jIq+jJw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/pt-PT.xpi",
           "version": "102.0.2"
         },
         "rm": {
           "hash": "sha512-MKp2OL+SSJC3xZKjJNKqb+THuULqkhHojBf4gOe1qy0s2k+Gpekji75ckmNf5Y7MqYojeD2y4h/rPPs+9IN1zQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-rm@thunderbird.mozilla.org.xpi": "sha512-JQJPLcSrmzXJ0egwR2EufLIqdLN8/X/+dKwhYyqLOrjHhQ/N9qKJao8Zz8OFDbSTxBlJdRWSGhaROK4kHjNA+g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/rm.xpi",
           "version": "102.0.2"
         },
         "ro": {
           "hash": "sha512-2N381makyfM1HYN4vIvo9vs2JJo78sfIdC6GmLEpyz46TjO2nhWVrirTj7upsPSDRYC78OT1sxYLOeGw1Offcw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ro@thunderbird.mozilla.org.xpi": "sha512-enzcls7Wf/vJjc8JWBoMDhktCmw5+sdL0qsSQGFhIlkK01Y9zmsMmRLL0o9NBAx58eGq4QfIVcKMAhhC4AQtuA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ro.xpi",
           "version": "102.0.2"
         },
         "ru": {
           "hash": "sha512-HNg9Xcf9m3NjktsGnEcFCm74Y3ihnvyp2V9tLR/bDEw3aRFGZMYwoeZ4e2fF2Z22sKryU3HSE+hv3XZJYrqP7Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ru@thunderbird.mozilla.org.xpi": "sha512-J1gpFXVvSBbg+4h/m4fBpfaTvp5qV83ZAA8LR1BNiEDh2se1z41GDmhl+EvSq+i9py5zeIBt733xKZh2+ya8Bg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/ru.xpi",
           "version": "102.0.2"
         },
         "sk": {
           "hash": "sha512-fXGKF2x5E1f+DmTEmb9JmgQx9fURcP8Z/dFuMobZPKKTjPql6hpbbZqfYUugJmh7zO/RulfveLARiEs76fD5Hw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sk@thunderbird.mozilla.org.xpi": "sha512-a9uGY1i4HuDbcW+mD7cz1Imaytlom4Y7oVCOJBAIJvHcLCkzQidV1b4l3irlcYCl47g76P+UCy7h/xgxilGcsQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/sk.xpi",
           "version": "102.0.2"
         },
         "sl": {
           "hash": "sha512-GUrYzXNAaJrc9t9O+nkHl1VsK+AnVdrwAWlV4WcP0OkqjUXKRrzCF8e3odoq1OUOGl3Oe5WfgcbmULUY0ZSQrw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sl@thunderbird.mozilla.org.xpi": "sha512-zmkKyRNp5hr2w+Y+21nOtVKfprbQcs/sfaj5mTfJoP0bqX94FXBMl6Rht2dqUwvrJlFlfoQ0oijAp9QvMtdBuA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/sl.xpi",
           "version": "102.0.2"
         },
         "sq": {
           "hash": "sha512-56Lmcf6RERxLfELTtjpa0+D2VQcrtJemmwrmoltSmqT8sdPg7y2RC5DOsw4oqxcf2FopAKWJQ/ZljoGhA+3nsw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sq@thunderbird.mozilla.org.xpi": "sha512-3laz5nt9KcTesQQqs4Tg3/E/mfjdh+L8uq7my0aoxIhYbZQj7XCa4QkaTr5ySR3rnKnWNvegc3EeriwvMUjpcA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/sq.xpi",
           "version": "102.0.2"
         },
         "sr": {
           "hash": "sha512-qhcg+Q7hMrki2wLl5vQ7NoShBc+wOQsJ1pt36fozIituOlxNLICt4b3IgAepACCAt6oh5HuPr6RBfTKXqLiJwg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sr@thunderbird.mozilla.org.xpi": "sha512-qwI6MtePYIGTkPxQlWlB8xf/km7XsnwwS+YS6M1gblzKRacPXzKY73UYSEFcGqgRE+cluFpsbFtzL0IAkI9SoA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/sr.xpi",
           "version": "102.0.2"
         },
         "sv-SE": {
           "hash": "sha512-E9UH9i7nC+p7B82nwk0WxzM5ZKrkIE+UiVULIh9J7pL5dNN98oB35ANC4eRtGVA55ZvTJzHfh3CrpdDTGhAWlw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sv-SE@thunderbird.mozilla.org.xpi": "sha512-pCM+MvHFsjEgkb+4IcMWWT2Dn6PeB3JaHjXlF+RMVpBWu8linttRrCvL/UApLpumBzvRWwSnGFvlWoq0a8QV/Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/sv-SE.xpi",
           "version": "102.0.2"
         },
         "th": {
           "hash": "sha512-hZbEzoTnsDVKjdfOeOMBENPWmPLukr8cwQFvU4kJ9AOtwTVeaATgWBI1FrIX8h/qpn+KNSasgV3P1EzoT1m1Rg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-th@thunderbird.mozilla.org.xpi": "sha512-3GlRbpozVy0pINXczxjeeopn/4KGFSDVcWh4iXKVZvMHKg+OQ54SusO3vj160Jdw5H0j8yR+7oR/AmqQXIie4g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/th.xpi",
           "version": "102.0.2"
         },
         "tr": {
           "hash": "sha512-239s9kTqFjIrYTnLJOMknDbYiODobTFv1TEvQTuBhy7hKwukCZDcyc35V9SVwuLDdS2MxopRO1AM3IKyj/57VA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-tr@thunderbird.mozilla.org.xpi": "sha512-4Z5174AulYXbj24j8CjU9dRkly4AOhxZriXGswZ1D4RCoTXQwrZCdO2EZvG9oDL7S/d4euj57lVw0RwGVQdVJA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/tr.xpi",
           "version": "102.0.2"
         },
         "uk": {
           "hash": "sha512-u5C56XEOubpJSZna17SViv1uVt6mdqxbpQ5SW7ZCahNcacZb9foF1yXWejx7SOTQ5eHFKhG35Sk7o8jKw6RUJA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-uk@thunderbird.mozilla.org.xpi": "sha512-ABx7akWKfhc6uzHWUMO6OITy1h2FdOgm/wVM+UNRgkZbaaFpMM9sg+CGhwgu00feOMYshYNpOj98brminHIpyw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/uk.xpi",
           "version": "102.0.2"
         },
         "uz": {
           "hash": "sha512-tunGXdQOlcpm291wk/K6Nlp7T8WHu571U1cjVSNjEliHGaMtxtk8Xz3noW02JjYYa9goyepKurZCj+SiJE54hw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-uz@thunderbird.mozilla.org.xpi": "sha512-MCmdNL4BUCmb35jqFTH7nI5o/H8I8A9joU46V4hRpp5DKk9Un6O++cv4BiKJi6bTWO6ml47umxfYTkC79dr1xw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/uz.xpi",
           "version": "102.0.2"
         },
         "vi": {
           "hash": "sha512-teAAsZ+ArO9HYL6qS0sOCUUM/ki9Z2ME1WnbvkDlTJ9gKF9DQJqSN6T4boKHxHapA5iwkpdR8ipJQUJYQCUZiA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-vi@thunderbird.mozilla.org.xpi": "sha512-E+GpXzz2H+iH3ME6Eo280pQvRRay3U/sGWix0IXGJ8GChty2bN2Oeexfnb8Vb0PHJr5k/WsDCtXL9ucTN2yWrA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/vi.xpi",
           "version": "102.0.2"
         },
         "zh-CN": {
           "hash": "sha512-7o3KDbP+lgyFb1yhGlBmwFLHSBr85PUWB0H22Kz/2PWXJO3N6sFtqQog05TcE0EknyLJfe8bjdavlEtkpwVAig==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-zh-CN@thunderbird.mozilla.org.xpi": "sha512-+h/Z0rZB+2HyWzN1bc8HQusu4gHCZKnvbb/+x8poXAJm6WD/vgkjE2tHupMXqUEbbDu89jxh6kG6ffY0vJyDiw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/zh-CN.xpi",
           "version": "102.0.2"
         },
         "zh-TW": {
           "hash": "sha512-l3bna8P2rDnfYitL3TEm8iVndkxN6UmxMIgrOQq/ksTTRfLKIKQgNwq2aPmRLmeWUDxqfTZdQsFPSSRNkHH+sg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-zh-TW@thunderbird.mozilla.org.xpi": "sha512-/9Hx9/Jk+0B6rSWZCqOj4nvVvmtfkceW7WLTn5jeJECwNVWOZd+VFRv73dccM8FLfVpqoAh0J3oTcI2u3stpwQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/102.0.2/linux-x86_64/xpi/zh-TW.xpi",
           "version": "102.0.2"
         }
@@ -4284,326 +6834,521 @@
       "linux-x86_64": {
         "af": {
           "hash": "sha512-rzOifvErUOF56SngW9J3SEZj4w2vFWpzQU7IEUibaAUvZxv9V7effZATcGZIQIoiOyuweRl5yqdnc9su0rDGcA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-af@thunderbird.mozilla.org.xpi": "sha512-8IwTCMXKbzmzp+SqZPqUOrJR8gZM93Vj3UIX4ljgQy6blaYky04HxoCnm9i0PqtQPamSAGZlP7LOMduihIkNmg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/af.xpi",
           "version": "91.11.0"
         },
         "ar": {
           "hash": "sha512-H28foTzNbzjdM6MRpTQL+bAvikQ6uAnjFOSAHVQCtjwX8CSLstvWU+owKG+SrnHDfeXZ/d9cGlY6ygwbRCuWwg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ar@thunderbird.mozilla.org.xpi": "sha512-rzhj/z/h3dQZgd4/3gsbP3ypmbXfZvo0POADDeKAMNr0WCjoUGsTxipUoT0NAp/fYRCAhfDP8c0kNRrIImckzw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ar.xpi",
           "version": "91.11.0"
         },
         "ast": {
           "hash": "sha512-qDgz3JIRBO9lJPTT3VpQ7aNHlaRlPKWKEHPuJPq5Z0F6QqqXb3QLLs5CR6zmNq1vGLvnBHEghb1skl/29x9FuA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ast@thunderbird.mozilla.org.xpi": "sha512-jWLqJzbf50lIJAaruJUlaqv1y36Fa1nCetjSn6GoCTsKRcwTv9Xbg/ZRspIep8U5Te3yGNGLimrHtx+BsrkIqQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ast.xpi",
           "version": "91.11.0"
         },
         "be": {
           "hash": "sha512-qCPn0zL72CYUhGVvB1KeZPmxLTa8zGGcDwp4F3DFy1sb7ppdIadMuJuLD7NjnfnHEOrTcE1csiw5CckbViq3oA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-be@thunderbird.mozilla.org.xpi": "sha512-mfzW+IF2SSBfjbjZFcH+6r1q+UYuELH0G7YyqVTF6M1Sewsu4FOoZqgA+Yf+9FrcNKZydxr889fZX9zPyR8Xeg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/be.xpi",
           "version": "91.11.0"
         },
         "bg": {
           "hash": "sha512-4vsVeExzAe3ETMpHF9lrJ+bwBb72eYnE1QW1HpR3h9E2yAdZBga9xefm42WrSsFwRlhMvitJ47WGgXeHHWu+3A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-bg@thunderbird.mozilla.org.xpi": "sha512-Jo7iX2c9RF9BNS7h/BG7bANtoemNrP5Zeb3rtxZ2r0qyz7hUfVep8fWfwu0sHP5d1u4gAjPak+rL3Y23Ul3JoQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/bg.xpi",
           "version": "91.11.0"
         },
         "br": {
           "hash": "sha512-DFglH9EfxeDxfY7IreSvJnRN+EiOh2jcmOABsfiCsOCiCjD2htWyDyHCVbQYmNpHdTOkp/1Q3jrZCt+ogooCcw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-br@thunderbird.mozilla.org.xpi": "sha512-3/WLeDBFDabjTg8xuuk6/IR37AfPNoUI/QMh3N9ZEWNNR9x3Lx9xciqXaBd2jM4G9AMdFwyQbtGoSeP/hD33Ug=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/br.xpi",
           "version": "91.11.0"
         },
         "ca": {
           "hash": "sha512-e0FL2sbgsu1GMeKY9aFhg9cxB6zKabhm5RCTmgtc+gQHgOSpitkVx+2cXKWU4XQaYLqNrWXA1Q5V994DVtxffQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ca@thunderbird.mozilla.org.xpi": "sha512-C7nXY2y4Z8r8TLS7wwexTco2h617PPY2cb/EsTNwNo/d3z5ML/yTKlHzlb48SBLopeJ+VweqpTzx/X1SE8HY3w=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ca.xpi",
           "version": "91.11.0"
         },
         "cak": {
           "hash": "sha512-UcsFakmJ+LnWS4zj4SotLZ7iAwLueMQ7YQWEDI/g41TsptnTfiHVJtcubrsH0SOv2myGDbaJEROUPl9Tp1hNJA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-cak@thunderbird.mozilla.org.xpi": "sha512-7Eykoex8eLP6cRzM3/xQEug81ruEEWDBqWb5dyt0KpecjlU5l+khRfoGewgjEJkpxz/a3aHGHQ5r1HuhSpPSGA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/cak.xpi",
           "version": "91.11.0"
         },
         "cs": {
           "hash": "sha512-HUMT5XG2UqZYiJxtL/PmLCim/ii87V4XRyL6AUyr0QpQWEIoGLjTveyRzuTtkrLtxfp72GUMytk2EM7zxNQF+A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-cs@thunderbird.mozilla.org.xpi": "sha512-TAqd5J++OU1vNxvan96kJ+JskNjJHyf9WbbFL/p1U5xKnVV6ShREE/6uwlDT4nMkn83NyZzX0JeWHzndvj1veQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/cs.xpi",
           "version": "91.11.0"
         },
         "cy": {
           "hash": "sha512-hQYZH8wIm3ajTN0rmiTW/X6G4ZUtESomdros+uFkWucAaeo1hmIRYzUfFx6EULemM3msivo3tYb8HW92/8dKYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-cy@thunderbird.mozilla.org.xpi": "sha512-35xPO9puvErFAqXjxFdTf/XhquwMT+QYxOCGh1Wa/LkQdYiJqJc/OBurrZHKrxd6waVTTmt3Asuajaz68hhpRQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/cy.xpi",
           "version": "91.11.0"
         },
         "da": {
           "hash": "sha512-nPaoiG64mvYwFlGITlrHcshEopovBbRfIW1jEaO6J4pG2+aSRj6pOfza42a+WJggrfuQVWNw/TLBdVsfTnScTg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-da@thunderbird.mozilla.org.xpi": "sha512-PhvmaeYO64gkq4aOHu5W+i8cDPdFfgZMnpDd1KVICrk/DCohkN2vmor/4xPVbtcZCL0+fL/2G9rEnRAYy4hqVQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/da.xpi",
           "version": "91.11.0"
         },
         "de": {
           "hash": "sha512-VUw5hxVxROnde4rbHJXVg1jPki9O7UO++UVf5y9QrgsK0kh37vhcWCTMoou3k3el8Hu6qfRIUvBwOck4db84hw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-de@thunderbird.mozilla.org.xpi": "sha512-vWMY14X8YHtAIJas00aTrFzDhNr5iCsfeL56RD7fAVM/xAiGOAJcSjoYv5Or8pA7ewp2YSVvdz2Mr9R3P5e2RQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/de.xpi",
           "version": "91.11.0"
         },
         "dsb": {
           "hash": "sha512-OcPJpP/7Hi3wN7Svm8imuQ31E9FbshOJTbVtytW8MPFkE+aNjfOrbL0IK947Otu3xNyHIOLmdRDOekjCLsqknA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-dsb@thunderbird.mozilla.org.xpi": "sha512-FyhKYasMjX13gv3oETjZ1wcUFGHhc+IG9qEbI1iJqv0ZX5sK3Biz81SKDlcwgRj2E1J742Xdhbs4sQesIxZlrg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/dsb.xpi",
           "version": "91.11.0"
         },
         "el": {
           "hash": "sha512-tzz5t56UtnSr/UguCoEszbglMm0QKIo76wtg5nkrACtysd2XL5kKkrUFO7Jit+GjRj+QU3Dwa2mCBKo+iPIkwA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-el@thunderbird.mozilla.org.xpi": "sha512-83eDKRjVlvbFNq6VdzwtqAltVX92RYEYUBqjSwHtnIuaXqObKCAru+F4zeqtg0Y0otBy1xUTOTYUEGBqkBo/lg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/el.xpi",
           "version": "91.11.0"
         },
         "en-CA": {
           "hash": "sha512-yCAeRcyDF4bsq881oiqZ2TA423CiffztYBb/PUo5APvzWO9BVSj8X8z/pmrzdn1j6xMz/tptULyd03cZJUFncw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-en-CA@thunderbird.mozilla.org.xpi": "sha512-nwd6zXVE+TBc9J8YLLuKtCfjxOnseuUo7PUMICzEHqzraIn0FlSSwTO4lVdp1Z9ycBUJDnkqlqoPefFXdBn55Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/en-CA.xpi",
           "version": "91.11.0"
         },
         "en-GB": {
           "hash": "sha512-LSjP82NcoCX+TxsM0PUGN5mXWP8sAUULVIE53CRE6neObYijf9leV02N1BUjVe/cSLpWwd9CFtasz9HNQf+zGg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-en-GB@thunderbird.mozilla.org.xpi": "sha512-VauDAwOH4A1buuR4lWeKO9ymoYKTq7mzhrgl8iA3sTSHCQW3MH+PWAdzfwcdATtK/Q1JoygIOY9LkcsJOO75uw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/en-GB.xpi",
           "version": "91.11.0"
         },
         "en-US": {
           "hash": "sha512-KkRRsE+EyoYHN5G4OJe2sVl95vBMGCwLd84cWdSeRpCES8pitVQPZvOB22uxR3XUoKyIQX34wJveF5kOnQcuRg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-en-US@thunderbird.mozilla.org.xpi": "sha512-UzNUrpFz+7f75LEeP4q3S7fhl/CVu4OiM9CaUm04ABDE1HywP5e3A0x8Pk3tEKlTZbp0scuzEURpo9bp12LLrA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/en-US.xpi",
           "version": "91.11.0"
         },
         "es-AR": {
           "hash": "sha512-PpmMEmYAKgYhPA4fYqfxvMHh6FQGauTl7JUD9U2eN7uoSEVXzmvOCiRMAyW2t02t5XRsHRnot4wTK5QdGTVEXg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-es-AR@thunderbird.mozilla.org.xpi": "sha512-PQwlcHaAXa9OClnKMDz9v5nLhSko9yozd7hqOK3d8dp0Z+qJaUQRDNtotxzxTgkfHeuoUpzb4xYzZmrnu58zHw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/es-AR.xpi",
           "version": "91.11.0"
         },
         "es-ES": {
           "hash": "sha512-Qy1KLwnfaFvjHQN26E0itOHNgY0+NbvDVwqq8DAAyblk7/+fRJexV5u9XO4UfLDIF03GBDctiE7sQSBpiyGXSA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-es-ES@thunderbird.mozilla.org.xpi": "sha512-t+c7Clhxt/3uVi2bOexcuZww+ozIPi+Fm8pCTpTMDxyqWXe+1J0GsZ9pH+50hN4DaApPkXwO6lTdiv0ZArvd6g=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/es-ES.xpi",
           "version": "91.11.0"
         },
         "et": {
           "hash": "sha512-5lR1/vZl6ZdetL+EIldyhqzXFzsHZJpLg0gQnlOBhCY6kZiNQx800acD9EweiYhmJTmSakIZyZg0pfT18FLiJQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-et@thunderbird.mozilla.org.xpi": "sha512-AgOrcnMcFFKucmZLx1Xs6ydmSUuz2eay5tKXrMAxVuU6yiLuk0nuOWhYfvFXuBDlOY2PP/W2M9VoD807tq46wQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/et.xpi",
           "version": "91.11.0"
         },
         "eu": {
           "hash": "sha512-5G2tRCR4jRYpKBybFuJniZgJBPE9CptP8G5YAe87pLbCkPm5rGh/haCCofgb6PgTPh5KprUzboIaOqMK01JSig==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-eu@thunderbird.mozilla.org.xpi": "sha512-BH3zNG+nImVKBIzaGnePXRBBcbnQEdkZO5+IMt0FeHCKe5p/F+NFwOEk0ZnFyyKtX/Tp4zzhOAet1ts01S33bw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/eu.xpi",
           "version": "91.11.0"
         },
         "fi": {
           "hash": "sha512-iRNSmkF6bPbUTB0vhkw8LFApS6b6c7nJQlMIOZUboxFyN+GTrlWePutdGZJdvPD/H2DfhOypSHydXJmmujPvmg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-fi@thunderbird.mozilla.org.xpi": "sha512-8L1NoAcpu4jI1OrJri3nrGWjYcTvYL3C5Ifhz+VMGslihlziUmXBN/bdIW38UDTvX10x+dTEGY9Qo5Lng2ZI1Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/fi.xpi",
           "version": "91.11.0"
         },
         "fr": {
           "hash": "sha512-ldOJGevrz0LJFJsm37BcBHBVsiMt7V49BVukBIBBEnyTGur2qQ0NQMjWAmR3o3W6+8hN4oPfXrHSomjboDx2Dw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-fr@thunderbird.mozilla.org.xpi": "sha512-izw0xVCrdJ4YY2bxiG/gzy3FNkS4iCLrSvuu85JYiVIjXtXkx6TJACgboiuYNQ2dkN4Aj/mEJKBasTq6qmdMkg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/fr.xpi",
           "version": "91.11.0"
         },
         "fy-NL": {
           "hash": "sha512-Q3wllGVHGl3ad4urNBbQYg75gxSpTemU1n2UTFihlZhS6Is9sBzFXp6S+htMTmb5EvRhkd8mbw5mpZ6EuJmL7A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-fy-NL@thunderbird.mozilla.org.xpi": "sha512-x6D8lDJk6GtHBBJXJKZkyq4ci+HB3BXDKJTWkX+xzJmG6rpj3PWRzSgluQgOkGnNv2sSEyWJykJ33E04/Z5YFg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/fy-NL.xpi",
           "version": "91.11.0"
         },
         "ga-IE": {
           "hash": "sha512-M0Tq6pfABKXKuVvIiWWA3nrgapkjnhIRxaG9TXEqllUyMIjYEpkNT26wjSb60iV718pX7FJv74qWT/TvkUhpnA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ga-IE@thunderbird.mozilla.org.xpi": "sha512-Z6FcOU7MxHbQlNct3aO58qgjKEmTOGPiVbhUPvGwyM3ArJQZQca6jK5qt+5Y3+lopcf7eS1LOYGsw9qPnOkKXQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ga-IE.xpi",
           "version": "91.11.0"
         },
         "gd": {
           "hash": "sha512-vYnfBl1SbCsVJGwZWCvK2Y/xlPIZVR28D0v31gFJZPomSyMJfGmIX37K76dl3b66+ljs6SDpxNQuQ1ROcYVtDg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-gd@thunderbird.mozilla.org.xpi": "sha512-rqI6h2tcl6tmmZJu5fO3zZCQQO9K69IAYziNBZYZbMBuyUxhzmabp3BQqDgvnjYVjfrRQXurEMfjEcLV47he5A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/gd.xpi",
           "version": "91.11.0"
         },
         "gl": {
           "hash": "sha512-VEmx/oIXYVxm1eTxicyqPvMWOkb1H/q0ZOOPb5mOKu0rgriqQl30Vaywx2hoiu98wMQSVK7yddtFqYwggFj6ug==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-gl@thunderbird.mozilla.org.xpi": "sha512-pWAEMbnc96GKOwdSc8uqLNlVUeARdYmjd6dX63/1kPHlzrM26MZaoNQQ57NSUpltO07FbbmSkR0lmGGqPN6jJg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/gl.xpi",
           "version": "91.11.0"
         },
         "he": {
           "hash": "sha512-FYuV2DErEdqVTm8s00vVoaod5oR3tbOELvqLIly04KSXNT5UPJZ7PVP7Lo2M1f8ILbyutCNljn+r8xazzuQSOw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-he@thunderbird.mozilla.org.xpi": "sha512-Sspj3X8bPEtYBw7sOjP+DZOU7xhZBggN1FuIQ3HnevWs90dWoyT+ApcaInM1QN1zifcmo721i5QOlHyA6LaoDw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/he.xpi",
           "version": "91.11.0"
         },
         "hr": {
           "hash": "sha512-wOkWQ3JunZJWakRZ36p4FYvomNE3j7dViSqr9NuHY1phxmhr8pF5JDiKAOW2dgXo+rOmPIleb/a6v3KTdHAfKQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hr@thunderbird.mozilla.org.xpi": "sha512-0HKsdVH/yuL2vgE/unDvSMBT3MWuTNUSz24Go7XkLd7G0pwrXWGgns5ZyXPgdyu9aVqHG1Mo8CHnzRRiVzoJxA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hr.xpi",
           "version": "91.11.0"
         },
         "hsb": {
           "hash": "sha512-0H4smMvZ4cnkITyHeFK8luRtqWbi+sucblaAsiZGaoNaqzknmg+qRBsRZpRb3P+KGdedQDELlOpYezc3exLj4g==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hsb@thunderbird.mozilla.org.xpi": "sha512-KIB6w/qiNhvtbu498dCfBjWy/KHJ573FFJp31bq6RBliay0SbiYtWRfTd+9CFHq0j25RDIfUxTsUpePp255N5A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hsb.xpi",
           "version": "91.11.0"
         },
         "hu": {
           "hash": "sha512-/08BN4coXAtqpIgMTeV2zdlOknH+/Ya8ugo+VA/z2/LKMHJxKd9xHDGvu/zAW/x/dl1QmJ/HIldyYUoprBHQMg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hu@thunderbird.mozilla.org.xpi": "sha512-rBv1+Tsq+sciTsrBCkYtygyXnbThjANedaWdJvuFTvP1fbFj4AuwyDr3J2bGBRPJmMv4T+CXnBfx+MMJaISz1A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hu.xpi",
           "version": "91.11.0"
         },
         "hy-AM": {
           "hash": "sha512-me8Zn6QJ14PXBQV3EScurcx6vt+BsGMkJUuAVxFabsccSKhhpxsEcwPNtrLSPIkvOxagyGs3xTaoXQXuSxFxsw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-hy-AM@thunderbird.mozilla.org.xpi": "sha512-8Nv0dea+6cWY831C2M/zH2Luar2hpfIRyPbLyV3Ma6ZvTvd1sLtDWXVJkzHrJhbZwizFYlSdTOYgegXvCIiCKg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/hy-AM.xpi",
           "version": "91.11.0"
         },
         "id": {
           "hash": "sha512-FToHdF8DSjYxamNTqwlYfoJoODQDMNVTveyDOGWqkAT5GB9hfr+5RsEOt1iLbhVn82PJ+rJ3iyIDsIS3uR6olw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-id@thunderbird.mozilla.org.xpi": "sha512-Njph1O5N88EAB+xe8RAFX/UUrF3qE/7TqBV6j9axeqX1hjMTVHp6KQU55zgPpg+zhtVWsobU954SXJ1ANCLz9Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/id.xpi",
           "version": "91.11.0"
         },
         "is": {
           "hash": "sha512-K4BY9K85UcXxQusWRAmFL8nZQtKqNbX6vAlsyH31aAx/3B1qGOAX02RIpX5fcJ75v91dYQeZ54b3ewjIXJJm2g==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-is@thunderbird.mozilla.org.xpi": "sha512-hRgQQrAkuURmXXtDY7/PwYQngBnQxMO2yJlcQZHQu78n8DwMUbZk5hh6w179WCqOor2iicKEk6+C5hDLkP0lLw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/is.xpi",
           "version": "91.11.0"
         },
         "it": {
           "hash": "sha512-9VdtBTi23R7eN9P2IOKrVfYHUienDj/Q9KWDWBRrDFCgRbp9HEunS64hvOxXCsVl4Gwt3mdCZD0xlOpHH0N64Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-it@thunderbird.mozilla.org.xpi": "sha512-A0lBASo5N1dLF8Gc9SOewbkY7xnoBPtSpnYMgzpxsRvhuv8z7nezFwNWYAhi6+7aGeStEQfDununGfEsSZyCDw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/it.xpi",
           "version": "91.11.0"
         },
         "ja": {
           "hash": "sha512-Jj9rvaT9o0b5Za5zgcBroQOsRAvZySrvgRthzv2jJpgiVJW3UZgU2KGKjQ7/X+zUoDrQXvKckmnrij/HaBepPg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ja@thunderbird.mozilla.org.xpi": "sha512-yjbV26xNJ/U0Y3VNfx9fLA9DMx1FL7zZAvoLKaYdevMXpXFakC0eJD9jQH4HRJQFkovXEMxlYAXdD5xEKiQf0Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ja.xpi",
           "version": "91.11.0"
         },
         "ka": {
           "hash": "sha512-bYlMRTKr7S7ipDJGTpjz/BN6KnnyGDJir2OnpTDy3S+RJ9ZskLRYtuYu+BpYbIJtdIoCqXoCKwGzic87Bmrh+w==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ka@thunderbird.mozilla.org.xpi": "sha512-xSxyC9PfUHdkxFEh7RQAafRtG+bzBvlxsDUu6Giu96k7rTif4qd98ZL6eJ5W3AW8aGWFvuu6AYcQpAIwE058Tg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ka.xpi",
           "version": "91.11.0"
         },
         "kab": {
           "hash": "sha512-IHl2hL5MgM6+DGCHoGDs6PiI90vEhYlDMxaynGBvQWfBqQr3LqSeixOXeF2E1xjfq735OIvtSncxjBwI28G7Sw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-kab@thunderbird.mozilla.org.xpi": "sha512-C91bdWWwl+lrdN4ahpfe2bpWdyEGsfLDYBQfQn9XuSyfkdrQ66kt0pmiWb38MN8Pn/ws2Rde9gMt5BF1ujbrxw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/kab.xpi",
           "version": "91.11.0"
         },
         "kk": {
           "hash": "sha512-9BXDRPcjNqV1GK2pdsb80qoA+d03SKnVc4TetP5HHDj+3hQpm52elr40RLeXxSsZZjbNHYY5zrdT2sYggaCn9A==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-kk@thunderbird.mozilla.org.xpi": "sha512-hUdniSXZavYFy418PQo/3hl0SpUAI/UjL3YAmxM9A/5rtp81HNZ9Ja7BJSgarIC3F8zSGcKTWdoGwGHVHsqthg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/kk.xpi",
           "version": "91.11.0"
         },
         "ko": {
           "hash": "sha512-YrCS0O7mi1zHTqo9loTNwY8/EzgRK9BffysqPADAB2b1WMIe2WK4SlJsQRiG72M0iZQMLm7AjvV7+G2OTsjp+w==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ko@thunderbird.mozilla.org.xpi": "sha512-P+VspwGcvTSRZCD1S9vWYZrViKRwi3O1x2QSdmpOteIxvooGibZHXGRtsT2h9AvRjJkkLaIB/lZ+UnMVhDpJjw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ko.xpi",
           "version": "91.11.0"
         },
         "lt": {
           "hash": "sha512-3ySQeJcqhrdkOtaYBM4OmLGjz7nsctlysAlTd/hq0Ad5wEyAD9bQgTLmpW8m1qxHC7l9X/Vy1gtlz2PlhIKlLQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-lt@thunderbird.mozilla.org.xpi": "sha512-PQE9IUC3BHB5GlPwCIhZ8fQ+jCD1xb1hi9za3pWZNwBn2Du2soIIqgg7AMvW45G/KXlM+ZW1JVUodAv0Afsbwg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/lt.xpi",
           "version": "91.11.0"
         },
         "lv": {
           "hash": "sha512-8qr5LqpbkrBa0olGhg5GAgakd2A90O9W9pLXwvgpa2CN1/4CFvublteU0vNfa4CZI5Rjq2W5kF59tGyKgfjGxg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-lv@thunderbird.mozilla.org.xpi": "sha512-LegtmyZjwVSwesAM6ISFtUUqZJPcd4WnxyxRUgCBbBmRDYOabfnn3UwitbwAAeaK/L0WuXUPDLxUBlSO5PQ2rA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/lv.xpi",
           "version": "91.11.0"
         },
         "ms": {
           "hash": "sha512-5Nw8WQbWb3Odq1hREACnoyhN0uFZUdBc4ibDe0q7I9waF/QVMWUafJWtPryJ6EuPeGjQbYRqJUy9CkmZeDrjlg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ms@thunderbird.mozilla.org.xpi": "sha512-PHmx1CQP2qvhDmt1SeT5PpqDxKkBXPAkrW7aDrpM8K2ptKDCNbPhuv0pvLGm5+sQM0AAhf4qEcm7bObHZjz+Gg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ms.xpi",
           "version": "91.11.0"
         },
         "nb-NO": {
           "hash": "sha512-WyAc9zByVXezSU+4NwiWSJNgUDu4Erf45olEkVZstYbwmAyi0sSyvfKtC2azCGhFsxi2xpA4+398dtcZpq8gRA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-nb-NO@thunderbird.mozilla.org.xpi": "sha512-lj905/H7t3llwZ9iRv4IxTLL6p+GKKv7YKjtUUinK7cGoZJBwsbMtqMUR+rDZ4BkxCd9Wxqjs8k8XzH9GjhzuQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/nb-NO.xpi",
           "version": "91.11.0"
         },
         "nl": {
           "hash": "sha512-ayEZXm3YJqL/F5Juz28h0jikTZ/0IOPwtAR/v/y6KvdX/dP+fTsdhaNma48vlmR2ZEGNYtdFE6Q1eCt2VQg9+Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-nl@thunderbird.mozilla.org.xpi": "sha512-zC+Ey6LdDTCVVlTJ01Qw6SK+N37S1MNJHGJOY2ayKEhHJsWksxHjj8jTTU+VHVzEol6SJItG7YZ2S1okN88jfg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/nl.xpi",
           "version": "91.11.0"
         },
         "nn-NO": {
           "hash": "sha512-d3C+PLDiw27hYJZz2EQ0ZFDM6hnmlmI5VB2ULDrsURPP0iZjtKHfQHLKG+Oru0sCWPa7Lk7dcAUl4FGSbGYHpQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-nn-NO@thunderbird.mozilla.org.xpi": "sha512-T7BRFqEg7whxQYsPdOItHsliYX7qxq43Q6BVOpt7hdP3mTJl7Vr8fExg3LGdUfz4VCAQwmQRoX8uFIzdni6qiQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/nn-NO.xpi",
           "version": "91.11.0"
         },
         "pa-IN": {
           "hash": "sha512-UFRCNWLoRhf0ctJjzQ6hcolvw6boL0jXjtdjpLrxfWXVzSqwFVnkvRNpx2TX2LoaLZuHpjPg8Gp4PpYnoAdDYQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pa-IN@thunderbird.mozilla.org.xpi": "sha512-a1Kj8QSW8KTzNIyatjD8AAs+5/xWzY00my6yzE0cyEZPMHTb1bs9aazNIKKI2diC33OawvXx9nyZdeuEZ8cCkQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pa-IN.xpi",
           "version": "91.11.0"
         },
         "pl": {
           "hash": "sha512-HX55GTtCD8ZEChfnEsptLcdcH0s59GL47yAOjJJ2cTSxTldnFrVctR2765plikfemTFRsduGlMAafB7+HU2keA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pl@thunderbird.mozilla.org.xpi": "sha512-IGa94neHCwv+Smo2aYg3X9NY80mx9rzhQgypBEz4nWZ4eCeDYxiZB3KtfPiTT5uoBURfAVLk/soo3vlm6bXEVA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pl.xpi",
           "version": "91.11.0"
         },
         "pt-BR": {
           "hash": "sha512-CcYyhc97HWX7Dus0nBPDN9IH00snyuT1sBFXNQ+NuV6TnNBUUq9rabmwyiYbQJeH5K0BB1tmTw0tBGzAerBV9w==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pt-BR@thunderbird.mozilla.org.xpi": "sha512-rgTQcaO5QU3aqzfQiPlL1wPvF0fYG+PTbgl3hfsHsqxVdy8xAyxBqQUfwSSEYXf3REa49fdKxyyVI2mr7DYw+Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pt-BR.xpi",
           "version": "91.11.0"
         },
         "pt-PT": {
           "hash": "sha512-8c8gSuN2rmGgtjy7Utee2yqC8j24Jp/3+WSSkmxl9INhEic2jwBxx0kR+DR4+ReRLI4wXjmSy/PeGWnKQwmXSw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-pt-PT@thunderbird.mozilla.org.xpi": "sha512-amxkxQ+wFU3b6Y0jL+I/oivMn+j+C9EDf+3RnkvJUCNTt6Q09ZqH2MYJDclZc1ZlKTePBUe1/hITjYk8D+XrTw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/pt-PT.xpi",
           "version": "91.11.0"
         },
         "rm": {
           "hash": "sha512-mrC111igwHq1dAecbhSqCEFJ1EXGUKkJdGZ5PDK/ieFhKy+iwcr5DDFSx2nD2SxqaNeE4BBNrzbO/Bi9GYi3Jg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-rm@thunderbird.mozilla.org.xpi": "sha512-WXvig8Y4G7nYz9+mcxUOohgJb3BzV6nta9aYQxnZ46WIUTsk+AYrnRl3aAjVGGBh/MbIloTNPqrW82kMUSHYjQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/rm.xpi",
           "version": "91.11.0"
         },
         "ro": {
           "hash": "sha512-AywPZu1XuQU18Ak5P1cegKd/JPDR7Md2fvUqcyb693PGvGH0j5FBRYlyjO4vZls1CpXCC4rC8U0uPSeWjEhF3Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ro@thunderbird.mozilla.org.xpi": "sha512-1I8aDHJg7KuHHCCpc8JtFu5P9xeUECNFfvfwTn3PbnEMgooH0+yULhtP+Aj0IH9WjABHtwZOWIn7W3UySSyHRg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ro.xpi",
           "version": "91.11.0"
         },
         "ru": {
           "hash": "sha512-yjz5WdPN0kVRaIMoVmp3AtrRbP9Jo59gx9XOyTkThbk1r037+XnBGtPu5JK+BcOteBsAkPR7cAxt98GxaXpBNw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-ru@thunderbird.mozilla.org.xpi": "sha512-riH32BNFoTorJBDMTC42t5vNX0DPgwOrCXmU4NIKZRGEDLjIjpD+rF6soCRZKcyKwOzWeN+AD/7gU81mVi1zoQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/ru.xpi",
           "version": "91.11.0"
         },
         "sk": {
           "hash": "sha512-SiCknuCjqda0uKhZh5zvUXZoIz5DCR0VBOfHGaVp7li/F7RNN3paQrEXbbcc5ugV+mJnXlDk43HptAfgYLr7Pw==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sk@thunderbird.mozilla.org.xpi": "sha512-Ese7nv65gIRy4S0D7o2pnqbpUxMwGfnfBFco2qMvctVb3PMcnVMJDhpL96XUF0G5Uf3GnWNJV+d4iKLc9/4XKg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sk.xpi",
           "version": "91.11.0"
         },
         "sl": {
           "hash": "sha512-s4MTGkD0Bi3hcw3IFwXwcKS9xGgojDMd7g+7mXK35mIF6LTL9zJmNEzK8BHMchFQRfhHSR11UqcUCnnpOluRyg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sl@thunderbird.mozilla.org.xpi": "sha512-7/oz5mltdHPQMNduaLZQm9nb4IA99qCIGDM4aHgw2TtOhG7Nkit3HBGvg8653DUrQ5Ytf8KBlBcozBwphb1W3Q=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sl.xpi",
           "version": "91.11.0"
         },
         "sq": {
           "hash": "sha512-LVDCONjKMO2HAGuC1loPg3JX76/ahksW2Y2w7j6AcUT401DwjkDsFnpMEIL0l+z5TspTK9/69+ew9LcL3jRa1Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sq@thunderbird.mozilla.org.xpi": "sha512-vFjuPGBVGD65yDfzrNziNtntzUh8gh+j3bPsD5kEdoiWW83/ljdEHYK0lP5rZT65MjwfoRwtlMvcvJj3V1CvYw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sq.xpi",
           "version": "91.11.0"
         },
         "sr": {
           "hash": "sha512-3GhCZqZ2oJvh718ogLm900TZNiA9x5/iQOYWWBIHbY9QFng8kIIEsNsFfOzFzE70oa8mPr6IFNtSQTi/7LfgzQ==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sr@thunderbird.mozilla.org.xpi": "sha512-OI6J9KvZJqFf+kIXVjotfBtKl51+81tJV90KEny9VcKh2Lz0wauEnWTkA39loUSj5flSXQdfG6yMb5zQ/bmOHA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sr.xpi",
           "version": "91.11.0"
         },
         "sv-SE": {
           "hash": "sha512-qZcouoeKskTNTYUB3/M8J2d0Izwu/766ULAVJ1TrOqHQATn+HhdhCofrZnKrdnaHoj45EaRbcZtDD0+hjz8h/Q==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-sv-SE@thunderbird.mozilla.org.xpi": "sha512-ocj1xGXl89YWUWPfhYVjtmhRG6GGIpl8UL0fYodrm8yuVJe8At+LmgMJ+ZiAeChDb5eJ2BN+yyLNI1HigFBuHA=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/sv-SE.xpi",
           "version": "91.11.0"
         },
         "th": {
           "hash": "sha512-lWHvNqbcEpzJefkUdPIArN1Aj95ypko7uSdtkHZ3BVQVQQWs8btf9cn59/y12Vj0UZd/7uiKtbCbn8U12frrJA==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-th@thunderbird.mozilla.org.xpi": "sha512-jdX6Bz3/Mb/WZREn/9lJrnqZKj0673vt7f7mV/a63jYSBNRg5LkNlxKmwkDTMZor00fsdfKDKQ1x9CiTqj5Ibw=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/th.xpi",
           "version": "91.11.0"
         },
         "tr": {
           "hash": "sha512-hKFCTfRrpPtQ1egxo7/G/CjJmyiMHRB+uOxkc29wkwPoGmbqbeLaUdB09PTGPw1sZUvJFmpuJhPiKflQ77R31w==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-tr@thunderbird.mozilla.org.xpi": "sha512-Xm8mnncAoAwyX29+QeB9qP+VIk3gRfBoGCCDLfkq9pMKwyU5lXFMoWARL9q5yExYetvV03iQXdka+BkJo+rpOQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/tr.xpi",
           "version": "91.11.0"
         },
         "uk": {
           "hash": "sha512-GZ5BuBhGJVFTX6kBIp81lowbSUjmuGiDZ9ujclJLMmpp0eIhLUe9EThGQZI/zvy8XZ9An18+csYjssb6cEJUng==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-uk@thunderbird.mozilla.org.xpi": "sha512-qyVZvyySQ0E/9eOuG8UXt4kBB2JGYMgIKthv0weX/DBm8dKKCnn1tEhs2FULdkMjuDfCo2yX5BIKOM+U5ou07A=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/uk.xpi",
           "version": "91.11.0"
         },
         "uz": {
           "hash": "sha512-homWcMuguZKPtWt9wHEBeHpt58dS4d718M8KjkdLNpD8ZIFQCIIkVX7YFBsJ2Y62QaQWJJEGHBFzpEK6A+tjIg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-uz@thunderbird.mozilla.org.xpi": "sha512-YEJ9hhQJhwJJNhIWYtyqpg1OreYUist5+CQbeyGqz7n6ySj0T8yInDP9IJMn4JsNzbddSC6lKPCkdhlhKrLdQg=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/uz.xpi",
           "version": "91.11.0"
         },
         "vi": {
           "hash": "sha512-+RqXd1PRQbNQ8lyCIm0J6GaCsoozjOQFwsaNbk9Imp1WpdjAFb+63YfHkh93mxUuvKmP7XFUtgRjXvsl2cD4zg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-vi@thunderbird.mozilla.org.xpi": "sha512-gTpO9D3W534Nta/vYDmrUKDIL1qLXMVK6ZPoBeEbiKu4YFQnbNzy7N4QDSP6Gv4cZHysPvTcD3LcUv6zPkNOuQ=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/vi.xpi",
           "version": "91.11.0"
         },
         "zh-CN": {
           "hash": "sha512-Qd6AvHNnv54Hser2a64SZ7AIXV4ZlPEW+FNt/oJrlwj01biwrVTVu8AKrHLyJGESkiPoKBqeb3wCD4WC/NnSfg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-zh-CN@thunderbird.mozilla.org.xpi": "sha512-y3RzZZevRJAzaaDAs+JiUGsT/6ZtZYrK6KaFvBd/IWfT0/gFFq1c5kW/FGdOKdILeZWWFHKdO6ClmlFGwybM7w=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/zh-CN.xpi",
           "version": "91.11.0"
         },
         "zh-TW": {
           "hash": "sha512-ZFDjQdckcoRv0jqmXrCpMceX+cKPtVJLj+TBw/SrEpIaV8dQ/kh3yY6JPC7XKdLtMmkf+rXepGJKz2+rkfPQHg==",
+          "narHash": {
+            "share/mozilla/extensions/{3550f703-e582-4d05-9a08-453d09bdfdc6}/langpack-zh-TW@thunderbird.mozilla.org.xpi": "sha512-VF6m1A5Mk+OwvuTJ+5qHfEoS/fP4oUtkjpF1mDWe7jgtnroxKlA1oUvqm7cgTdD9Xlx0wTXvStP3TssyP2/E3w=="
+          },
           "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.11.0/linux-x86_64/xpi/zh-TW.xpi",
           "version": "91.11.0"
         }


### PR DESCRIPTION
Language packs for Firefox and Thunderbird were normal packages (although built with `pkgs.stdenvNoCC`), therefore the output paths of those packages depended not only on the source file content, but also on `pkgs.stdenvNoCC`, therefore they were different for every supported branch of Nixpkgs and sometimes were changed after Nixpkgs updates, even though the actual content of those packages was exactly the same.

Turning the language packs into fixed output derivations allows those packages to be exactly the same for all supported Nixpkgs branches, and saves some space in the binary cache (new archives need to be uploaded only when the language packs actually were changed due to a new release, and any Nixpkgs updates don't require adding a new copy of NAR archives containing the same data).

However, this optimization requires precalculating the NAR hashes for output packages (and it is not possible to calculate the required hash from the hash of the language pack file — the only way is to download the file, install it into the subdirectory with the desired name, then run `nix hash dir` to obtain the NAR hash). Therefore the `update.sh` script was changed to do exactly that for all language packs, and `source.json` now contains those hash values in addition to the usual hashes for source files.