### PR TITLE
ci: Make all CI jobs respect cancellations

### DIFF
--- a/.github/workflows/ci-per-system.yml
+++ b/.github/workflows/ci-per-system.yml
@@ -51,7 +51,9 @@ on:
 jobs:
   early-checks:
     runs-on: ${{ inputs.runs-on }}
-    if: fromJSON(inputs.flake-jobs).earlyChecks.item[0]
+    if: >-
+      (always() && !cancelled())
+      && fromJSON(inputs.flake-jobs).earlyChecks.item[0]
     strategy:
       matrix: ${{ fromJSON(inputs.flake-jobs).earlyChecks }}
     steps:
@@ -69,7 +71,9 @@ jobs:
 
   pkgs:
     runs-on: ${{ inputs.runs-on }}
-    if: fromJSON(inputs.flake-jobs).packages.item[0]
+    if: >-
+      (always() && !cancelled())
+      && fromJSON(inputs.flake-jobs).packages.item[0]
     strategy:
       matrix: ${{ fromJSON(inputs.flake-jobs).packages }}
     steps:
@@ -87,7 +91,9 @@ jobs:
 
   nur:
     runs-on: ${{ inputs.runs-on }}
-    if: fromJSON(inputs.nur-jobs).other.include[0]
+    if: >-
+      (always() && !cancelled())
+      && fromJSON(inputs.nur-jobs).other.include[0]
     strategy:
       matrix: ${{ fromJSON(inputs.nur-jobs).other }}
     steps:
@@ -106,7 +112,9 @@ jobs:
 
   nur1:
     runs-on: ${{ inputs.runs-on }}
-    if: fromJSON(inputs.nur-jobs).stage1.include[0]
+    if: >-
+      (always() && !cancelled())
+      && fromJSON(inputs.nur-jobs).stage1.include[0]
     strategy:
       matrix: ${{ fromJSON(inputs.nur-jobs).stage1 }}
     steps:
@@ -127,10 +135,10 @@ jobs:
     needs:
       - pkgs
     runs-on: ${{ inputs.runs-on }}
-    if: >
-      always() &&
-      (needs.pkgs.result == 'success' || needs.pkgs.result == 'skipped') &&
-      fromJSON(inputs.nur-jobs).stage2.include[0]
+    if: >-
+      (always() && !cancelled())
+      && (needs.pkgs.result == 'success' || needs.pkgs.result == 'skipped')
+      && fromJSON(inputs.nur-jobs).stage2.include[0]
     strategy:
       matrix: ${{ fromJSON(inputs.nur-jobs).stage2 }}
     steps:
@@ -151,10 +159,10 @@ jobs:
     needs:
       - nur1
     runs-on: ${{ inputs.runs-on }}
-    if: >
-      always() &&
-      (needs.nur1.result == 'success' || needs.nur1.result == 'skipped') &&
-      fromJSON(inputs.nur-jobs).stage3.include[0]
+    if: >-
+      (always() && !cancelled())
+      && (needs.nur1.result == 'success' || needs.nur1.result == 'skipped')
+      && fromJSON(inputs.nur-jobs).stage3.include[0]
     strategy:
       matrix: ${{ fromJSON(inputs.nur-jobs).stage3 }}
     steps:
@@ -175,10 +183,10 @@ jobs:
     needs:
       - pkgs
     runs-on: ${{ inputs.runs-on }}
-    if: >
-      always() &&
-      (needs.pkgs.result == 'success' || needs.pkgs.result == 'skipped') &&
-      fromJSON(inputs.flake-jobs).hosts.item[0]
+    if: >-
+      (always() && !cancelled())
+      && (needs.pkgs.result == 'success' || needs.pkgs.result == 'skipped')
+      && fromJSON(inputs.flake-jobs).hosts.item[0]
     strategy:
       matrix: ${{ fromJSON(inputs.flake-jobs).hosts }}
     steps:
@@ -198,10 +206,10 @@ jobs:
     needs:
       - pkgs
     runs-on: ${{ inputs.runs-on }}
-    if: >
-      always() &&
-      (needs.pkgs.result == 'success' || needs.pkgs.result == 'skipped') &&
-      fromJSON(inputs.flake-jobs).checks.item[0]
+    if: >-
+      (always() && !cancelled())
+      && (needs.pkgs.result == 'success' || needs.pkgs.result == 'skipped')
+      && fromJSON(inputs.flake-jobs).checks.item[0]
     strategy:
       matrix: ${{ fromJSON(inputs.flake-jobs).checks }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
     outputs:
       nur_jobs: ${{ steps.collect_nur_jobs.outputs.nur_jobs }}
     if: >-
-      (!inputs.flake_only)
+      (always() && !cancelled())
+      && (!inputs.flake_only)
       && !(
         (github.event_name == 'pull_request')
         && (github.event.pull_request.head.repo.full_name == 'sigprof/nur-packages')
@@ -257,7 +258,7 @@ jobs:
       - setup_flake
       - setup_nur
     if: >-
-      always()
+      (always() && !cancelled())
       && (needs.setup_flake.result == 'success')
       && (needs.setup_nur.result == 'success' || needs.setup_nur.result == 'skipped')
     uses: ./.github/workflows/ci-per-system.yml
@@ -275,7 +276,7 @@ jobs:
       - setup_flake
       - setup_nur
     if: >-
-      always()
+      (always() && !cancelled())
       && (needs.setup_flake.result == 'success')
       && (needs.setup_nur.result == 'success' || needs.setup_nur.result == 'skipped')
     uses: ./.github/workflows/ci-per-system.yml
@@ -295,7 +296,8 @@ jobs:
       - x86_64-linux
       - x86_64-darwin
     runs-on: ubuntu-latest
-    if: always()
+    if: >-
+      (always() && !cancelled())
     env:
       ci_success: >-
         ${{


### PR DESCRIPTION
Using `if: always() && ...` without checking for `!cancelled()` results in the job continuing to run even after the workflow was cancelled.  Add checks like `(always() && !cancelled())` to all such jobs, so that any cancel requests would be handled properly, according to the docs at https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run.

While at it, use `if: >-` to strip any extra newlines.