### PR TITLE
hosts(test1): Add `firefox-langpack-ru`, `thunderbird-langpack-ru`

### DIFF
--- a/hosts/test1/default.nix
+++ b/hosts/test1/default.nix
@@ -32,6 +32,10 @@ in
           pkgs.tor-browser-bundle-bin
           self.packages.${system}.virt-manager
 
+          # Temporary until the Home Manager config is ported
+          self.packages.${system}.firefox-langpack-ru
+          self.packages.${system}.thunderbird-langpack-ru
+
           unstable.tdesktop
           unstable.vial
         ];


### PR DESCRIPTION
Because the list of packages is generated dynamically, the main CI does not detect when those packages disappear due to the version mismatch. Add these packages to the host configuration, so that CI would fail in that case.

Note that adding these packages to `environment.systemPackages` is not the proper way to use them, but the required parts of the Home Manager config are still not published in this repo.