### PR TITLE
virt-manager: Fix the availability-related meta attributes

### DIFF
--- a/pkgs/virt-manager/default.nix
+++ b/pkgs/virt-manager/default.nix
@@ -37,4 +37,13 @@ in
     postFixup = ''
       ln -s ${virt-manager-2}/bin/virt-manager $out/bin/virt-manager-2
     '';
+
+    meta = lib.mergeAttrs oldAttrs.meta {
+      # This package is available only when both the current and the old
+      # versions of virt-manager are available; combine the corresponding meta
+      # attributes in the appropriate way.
+      broken = (oldAttrs.meta.broken or false) || (virt-manager-2.meta.broken or false);
+      platforms = lib.intersectLists oldAttrs.meta.platforms virt-manager-2.meta.platforms;
+      badPlatforms = lib.unique ((oldAttrs.meta.badPlatforms or []) ++ (virt-manager-2.meta.badPlatforms or []));
+    };
   })


### PR DESCRIPTION
Recently the `virt-manager` package was updated to make it build on Darwin (https://www.github.com/NixOS/nixpkgs/pull/185415); this broke the customized version of `virt-manager`, because it inherited the updated meta attributes, but the old 2.x version of `virt-manager` still does not build on Darwin.  Fix the problem by merging the values of `meta.broken`, `meta.platforms` and `meta.badPlatforms` in the appropriate way, so that the combined package gets built only if both the original package and the old version could be built.