### PR TITLE
CI: Fix caching for `hosts` builds

### DIFF
--- a/lib/ci-data.nix
+++ b/lib/ci-data.nix
@@ -8,6 +8,13 @@
       packages.groups = [
         [".*"]
       ];
+      hosts.exclude = [
+        # `nixosConfigurations.${name}.config.system.build.toplevel`
+        # derivations have `allowSubstitutes = false`, which breaks
+        # `nix-build-uncached`; don't build them directly (cacheable
+        # `checks."host/${name}"` wrappers would be built instead).
+        ".*"
+      ];
       hosts.groups = [
         [".*"]
       ];

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,6 +2,7 @@
   packages =
     {
       cosevka = callPackage ./cosevka {};
+      lib = (callPackage ./lib/lib.nix {}).lib;
       terminus-font-custom = callPackage ./terminus-font-custom {};
       virt-manager = callPackage ./virt-manager {};
     }

--- a/pkgs/lib/force-cached/default.nix
+++ b/pkgs/lib/force-cached/default.nix
@@ -1,0 +1,53 @@
+# Originally from https://github.com/Mic92/nix-build-uncached/blob/8cc18174e8d351954d6fe1a2115988f7c1acd10c/scripts/force_cached.nix
+#
+# Copyright 2020 Jörg Thalheim
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+{
+  lib,
+  coreutils,
+}: let
+  # Return true if `nix-build` would traverse that attribute set to look for
+  # more derivations to build.
+  hasRecurseIntoAttrs = x: builtins.isAttrs x && (x.recurseForDerivations or false);
+
+  # Wrap a single derivation that disallows substitutes so that it can be
+  # cached.
+  toCachedDrv = drv:
+    if !(drv.allowSubstitutes or true)
+    then
+      derivation {
+        name = "${drv.name}-to-cached";
+        system = drv.system;
+        builder = "/bin/sh";
+        args = ["-c" "${coreutils}/bin/ln -s ${drv} $out; exit 0"];
+      }
+    else drv;
+
+  # Traverses a tree of derivation and wrap all of those that disallow
+  # substitutes.
+  forceCached = val:
+    if lib.isDerivation val
+    then toCachedDrv val
+    else if hasRecurseIntoAttrs val
+    then lib.mapAttrs (_: forceCached) val
+    else val;
+in
+  forceCached

--- a/pkgs/lib/lib.nix
+++ b/pkgs/lib/lib.nix
@@ -1,0 +1,5 @@
+{callPackage, ...}: {
+  lib = {
+    forceCached = callPackage ./force-cached {};
+  };
+}


### PR DESCRIPTION
The `nixosConfigurations.${name}.config.system.build.toplevel` derivations have `allowSubstitutes = false`; this is [documented to break the proper functionality of `nix-build-uncached`](https://github.com/Mic92/nix-build-uncached/#packages-with-allowsubstitutes--false) — those derivations get rebuilt every time the CI runs, resulting in useless work and wasted time. Implement and use the workaround described in the `nix-build-uncached` documentation, so that host configurations get rebuilt only when something had actually changed.

To avoid any problems caused by modifying the values inside `nixosConfigurations.${name}`, separate `checks."host/${name}` outputs are introduced — these outputs contain the cacheable wrappers for the corresponding `nixosConfigurations.${name}.config.system.build.toplevel` derivations. The support for building the `hosts` entries is still left in, but all those entries are excluded from the CI build.