### PR TITLE
hosts(test1): Add `unstable.kicad-small`

### DIFF
--- a/hosts/test1/default.nix
+++ b/hosts/test1/default.nix
@@ -36,6 +36,7 @@ in
           self.packages.${system}.firefox-langpack-ru
           self.packages.${system}.thunderbird-langpack-ru
 
+          unstable.kicad-small
           unstable.tdesktop
           unstable.vial
         ];


### PR DESCRIPTION
Use the KiCad package from `nixos-unstable` to get a more recent version (KiCad updates do not get backported to the stable branch).  Having this in CI would catch cases when the KiCad build gets broken (which happened sometimes before).