### PR TITLE
virt-manager-2.2.1: rename `gnome3` to `gnome`

### DIFF
--- a/pkgs/virt-manager/virt-manager-2.2.1.nix
+++ b/pkgs/virt-manager/virt-manager-2.2.1.nix
@@ -16,7 +16,7 @@
   gsettings-desktop-schemas,
   glib,
   libosinfo,
-  gnome3,
+  gnome,
   gtksourceview4,
   spiceSupport ? true,
   spice-gtk ? null,
@@ -48,7 +48,7 @@ with lib;
         vte
         dconf
         gtk-vnc
-        gnome3.adwaita-icon-theme
+        gnome.adwaita-icon-theme
         avahi
         gsettings-desktop-schemas
         libosinfo


### PR DESCRIPTION
The rename was done long ago in NixOS/nixpkgs#122107 (back in 21.05), and since NixOS/nixpkgs#192681 the old `gnome3` name no longer works. Update the old virt-manager package accordingly.