### PR TITLE
Update `cachix-action` to fix `save-state` deprecation warnings

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -74,7 +74,7 @@ runs:
         extra_nix_config: ${{ inputs.nix-extra-config }}
 
     - name: Setup Cachix
-      uses: cachix/cachix-action@v11
+      uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
       if: inputs.cachix-name
       with:
         name: ${{ inputs.cachix-name }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -33,7 +33,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v11
+        uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
         with:
           name: ${{ env.CACHIX_NAME }}
           extraPullNames: "pre-commit-hooks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v11
+        uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
         with:
           name: ${{ env.CACHIX_NAME }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -123,7 +123,7 @@ jobs:
         uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v11
+        uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
         with:
           name: ${{ env.CACHIX_NAME }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'


### PR DESCRIPTION
Replace `cachix/cachix-action@v11` with a forked version which contains a fix for deprecation warnings for the `save-state` command.

GitHub [deprecated the `save-state` and `set-output` commands on 2022-10-11](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/); it turned out that [cachix/cachix-action](https://github.com/cachix/cachix-action) was using the `save-state` command directly.  Temporarily replace `cachix/cachix-action@v11` with a forked version which has a fix for that problem.