### PR TITLE
flake: Make the `pre-commit-hooks.nixpkgs-stable` input follow `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,22 +107,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1668984258,
-        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -133,7 +117,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1671014608,

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
 
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+    pre-commit-hooks.inputs.nixpkgs-stable.follows = "nixpkgs";
     pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
 
     devshell.url = "github:numtide/devshell";


### PR DESCRIPTION
The `pre-commit-hooks` flake now has two Nixpkgs inputs (`nixpkgs`, which originally points to a snapshot of the `nixos-unstable` branch, and `nixpkgs-stable`, which currently points to a snapshot of the `nixos-22.05` branch).  Make the `nixpkgs-stable` input follow our `nixpkgs` input instead of using an obsolete snapshot, so that the number of different Nixpkgs versions in use does not grow.

(It could be possible to make the `pre-commit-hooks.nixpkgs` input to follow `nixos-unstable` instead, but currently that is not needed, because `pre-commit-hooks` was fixed to not fail on `nixos-22.05` unless the packages which are missing in that release are actually used by some checks, and the `pre-commit-hooks.nixpkgs` input is also used to provide `pre-commit-hooks.gitignore.nixpkgs`.)