### PR TITLE
ci: Limit GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci-per-system.yml
+++ b/.github/workflows/ci-per-system.yml
@@ -48,6 +48,8 @@ on:
           Signing key secret for Cachix; needed for pushing objects to the
           cache when signing is not managed by the Cachix service.
 
+permissions: {}
+
 jobs:
   early-checks:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
     # https://www.random.org/clock-times/?num=1&earliest=01%3A00&latest=08%3A00&interval=5&format=html&rnd=new
     - cron:  '30 1 * * *'
 
+permissions: {}
+
 defaults:
   run:
     # Use `bash` by default.  Note that, according to the documentation, the


### PR DESCRIPTION
The `ci` workflow should need only minimal permissions for `GITHUB_TOKEN`.