### PR TITLE
ci: Configure Nix to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-per-system.yml
+++ b/.github/workflows/ci-per-system.yml
@@ -50,6 +50,9 @@ on:
 
 permissions: {}
 
+env:
+  NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   early-checks:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ env:
   nur_channels: nixpkgs-unstable nixos-unstable nixos-22.05 nixos-21.11
   nur_main_channel: nixos-22.05
 
+  NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   setup_flake:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoid some rate limit errors by using authentication for GitHub API accesses from Nix.