### PR TITLE
ci: Switch to the latest snapshot of `cpcloud/flake-update-action`

### DIFF
--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -61,7 +61,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Update ${{ matrix.input }}
-        uses: sigprof/flake-update-action@71d25b66c5c46f0443f424995831902748fe836e
+        uses: cpcloud/flake-update-action@b301c3d29fa56f72b786626a50478b61528cfd13
         with:
           dependency: ${{ matrix.input }}
           pull-request-token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
The upstream version of `cpcloud/flake-update-action` now includes the required updates to avoid deprecation warnings.  Unfortunately, the `v1.0.4` release of that action does not contain all required updates (in particular, it still refers to `peter-evans/create-pull-request@v3` and `peter-evans/enable-pull-request-automerge@v1`, which use the obsolete `node12` version instead of `node16`), therefore the latest commit from the `main` branch is used instead of the release tag.