### PR TITLE
ci: Switch to `cachix/cachix-action@v12`

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -74,7 +74,7 @@ runs:
         extra_nix_config: ${{ inputs.nix-extra-config }}
 
     - name: Setup Cachix
-      uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
+      uses: cachix/cachix-action@v12
       if: inputs.cachix-name
       with:
         name: ${{ inputs.cachix-name }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -37,7 +37,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix
-        uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
+        uses: cachix/cachix-action@v12
         with:
           name: ${{ env.CACHIX_NAME }}
           extraPullNames: "pre-commit-hooks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         uses: cachix/install-nix-action@5c11eae19dba042788936d4f1c9685fdd814ac49
 
       - name: Setup Cachix
-        uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
+        uses: cachix/cachix-action@v12
         with:
           name: ${{ env.CACHIX_NAME }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -127,7 +127,7 @@ jobs:
         uses: cachix/install-nix-action@5c11eae19dba042788936d4f1c9685fdd814ac49
 
       - name: Setup Cachix
-        uses: sigprof/cachix-action@3fea4e0b704f4ec6a652bb4c28391efb5a0b7a8c
+        uses: cachix/cachix-action@v12
         with:
           name: ${{ env.CACHIX_NAME }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'


### PR DESCRIPTION
Using the `sigprof/cachix-action` fork is no longer needed (the change to fix `save-state` deprecation warnings was accepted and included in the `v12` upstream release).