### PR TITLE
ci: Pin Nix to 2.14.1 for compatibility with `nix-build-uncached`

### DIFF
--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -13,6 +13,7 @@ defaults:
     shell: bash
 
 env:
+  CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -26,6 +27,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a
+        with:
+          install_url: ${{ env.CI_NIX_INSTALL_URL }}
 
       - name: Generate matrix from flake inputs
         id: generate_matrix
@@ -51,6 +54,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a
         with:
+          install_url: ${{ env.CI_NIX_INSTALL_URL }}
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Generate a GitHub token

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -16,6 +16,7 @@ env:
 
   nur_channels: nixpkgs-unstable nixos-unstable nixos-22.11 nixos-22.05 nixos-21.11
 
+  CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -34,6 +35,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a
         with:
+          install_url: ${{ env.CI_NIX_INSTALL_URL }}
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix

--- a/.github/workflows/ci-per-system.yml
+++ b/.github/workflows/ci-per-system.yml
@@ -25,6 +25,11 @@ on:
         description: >
           The description of NUR-related build jobs in the JSON format, or an
           empty string if no NUR builds need to be performed.
+      nix-install-url:
+        type: string
+        default: ''
+        description: >
+          Installation URL that will contain a script to install Nix.
       cachix-name:
         type: string
         default: ''
@@ -69,6 +74,7 @@ jobs:
         with:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -89,6 +95,7 @@ jobs:
         with:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -110,6 +117,7 @@ jobs:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
           channel: ${{ matrix.channel }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -131,6 +139,7 @@ jobs:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
           channel: ${{ matrix.channel }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -155,6 +164,7 @@ jobs:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
           channel: ${{ matrix.channel }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -179,6 +189,7 @@ jobs:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
           channel: ${{ matrix.channel }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -202,6 +213,7 @@ jobs:
         with:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}
@@ -225,6 +237,7 @@ jobs:
         with:
           item: ${{ toJSON(matrix.item) }}
           system: ${{ inputs.system }}
+          nix-install-url: ${{ inputs.nix-install-url }}
           cachix-name: ${{ inputs.cachix-name }}
           cachix-extra-pull-names: ${{ inputs.cachix-extra-pull-names }}
           cachix-auth-token: ${{ secrets.cachix-auth-token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ env:
   nur_channels: nixpkgs-unstable nixos-unstable nixos-22.11 nixos-22.05 nixos-21.11
   nur_main_channel: nixos-22.11
 
+  CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -52,6 +53,7 @@ jobs:
     env:
       this_system: x86_64-linux
     outputs:
+      nix_install_url: ${{ env.CI_NIX_INSTALL_URL }}
       cachix_name: ${{ env.CACHIX_NAME }}
       flake_jobs: ${{ steps.collect_flake_jobs.outputs.flake_jobs }}
     steps:
@@ -60,6 +62,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a
+        with:
+          install_url: ${{ env.CI_NIX_INSTALL_URL }}
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
@@ -104,6 +108,7 @@ jobs:
         with:
           item: ${{ steps.collect_setup_checks.outputs.setup_checks }}
           system: ${{ env.this_system }}
+          nix-install-url: ${{ env.CI_NIX_INSTALL_URL }}
           cachix-name: ${{ env.CACHIX_NAME }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -125,6 +130,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a
+        with:
+          install_url: ${{ env.CI_NIX_INSTALL_URL }}
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
@@ -271,6 +278,7 @@ jobs:
       runs-on: ubuntu-latest
       flake-jobs: ${{ toJSON(fromJSON(needs.setup_flake.outputs.flake_jobs).x86_64-linux.flake) }}
       nur-jobs: ${{ toJSON(fromJSON(needs.setup_nur.outputs.nur_jobs || '{}').x86_64-linux.nur) }}
+      nix-install-url: ${{ needs.setup_flake.outputs.nix_install_url }}
       cachix-name: ${{ needs.setup_flake.outputs.cachix_name }}
     secrets:
       cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -289,6 +297,7 @@ jobs:
       runs-on: macos-latest
       flake-jobs: ${{ toJSON(fromJSON(needs.setup_flake.outputs.flake_jobs).x86_64-darwin.flake) }}
       nur-jobs: ${{ toJSON(fromJSON(needs.setup_nur.outputs.nur_jobs || '{}').x86_64-darwin.nur) }}
+      nix-install-url: ${{ needs.setup_flake.outputs.nix_install_url }}
       cachix-name: ${{ needs.setup_flake.outputs.cachix_name }}
     secrets:
       cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Nix 2.15 changes broke compatibility with `nix-build-uncached`:

  https://www.github.com/Mic92/nix-build-uncached/issues/52

Until the issue is resolved in some way (apparently `nix-build-uncached` is deprecated and not really maintained, but there is no drop-in replacement yet), pin Nix to 2.14.1 (the last compatible version).