### PR TITLE
flake: Add check for `telegram-desktop` breakage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1682526928,
-        "narHash": "sha256-2cKh4O6t1rQ8Ok+v16URynmb0rV7oZPEbXkU0owNLQs=",
+        "lastModified": 1682453498,
+        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6b863fd9b7bb962e6f9fdf292419a775e772891",
+        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The wrapper for `telegram-desktop` had become corrupted after https://www.github.com/NixOS/nixpkgs/pull/225881 changed it to be a binary file instead of a shell script.  This should be fixed in https://www.github.com/NixOS/nixpkgs/pull/228410, but the fix will need some time to propagate; add a test so that automatic flake updates would wait until the `nixos-unstable` channel gets the fix.