### PR TITLE
Switch to NixOS 23.05

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           extraPullNames: "pre-commit-hooks"
 
       - name: Check flake evaluation
-        run: nix flake check --no-build
+        run: nix flake check --no-build --show-trace
 
       - name: Collect flake jobs
         id: collect_flake_jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ env:
 
   nur_systems: x86_64-linux x86_64-darwin
   nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11 nixos-22.05
-  nur_main_channel: nixos-22.11
+  nur_main_channel: nixos-23.05
 
   CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -98,16 +98,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686476475,
-        "narHash": "sha256-W9yUePvCSDghn+YUXewuodyPxt+kJl/a7zdY4Q6r4MU=",
+        "lastModified": 1686431482,
+        "narHash": "sha256-oPVQ/0YP7yC2ztNsxvWLrV+f0NQ2QAwxbrZ+bgGydEM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eef86b8a942913a828b9ef13722835f359deef29",
+        "rev": "d3bb401dcfc5a46ce51cdfb5762e70cc75d082d2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Personal NUR repository of @sigprof";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixos-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     systems.url = "github:nix-systems/default";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@ in
       hardware/gpu/driver/nvidia/legacy_340.nix
       hardware/printers/driver/hplip.nix
       hardware/sane/backend/epkowa.nix
+      hardware/video
       i18n/ru_RU.nix
       nixpkgs/permitted-unfree-packages.nix
     ];

--- a/modules/hardware/gpu/driver/nvidia/legacy_340.nix
+++ b/modules/hardware/gpu/driver/nvidia/legacy_340.nix
@@ -14,8 +14,10 @@
 
     hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_340;
 
-    # The legacy 340 driver does not compile against kernels newer than 5.4.x.
-    boot.kernelPackages = pkgs.linuxPackages_5_4;
+    # In NixOS 23.05 the legacy_340 driver was patched to fix build with 6.1.x
+    # kernels (https://github.com/NixOS/nixpkgs/pull/211524); on older NixOS
+    # releases the kernel needs to be downgraded to 5.4.x.
+    boot.kernelPackages = lib.mkIf (lib.versionOlder config.system.nixos.release "23.05") pkgs.linuxPackages_5_4;
 
     # Workaround for https://github.com/NixOS/nixpkgs/issues/120602
     hardware.opengl.setLdLibraryPath = true;

--- a/modules/hardware/video/default.nix
+++ b/modules/hardware/video/default.nix
@@ -1,0 +1,11 @@
+{lib, ...}: let
+  inherit (lib) mdDoc mkOption types;
+in {
+  options = {
+    sigprof.hardware.video.uiScale = mkOption {
+      type = types.either types.float types.ints.positive;
+      description = mdDoc "UI scaling factor for the default display.";
+      default = 1;
+    };
+  };
+}

--- a/modules/i18n/ru_RU.nix
+++ b/modules/i18n/ru_RU.nix
@@ -29,19 +29,19 @@ in {
     console.keyMap = "ruwin_cplk-UTF-8";
     console.font = lib.mkMerge [
       (lib.mkOverride 600 "${terminus_font}/share/consolefonts/ter-c16n.psf.gz")
-      (lib.mkIf config.hardware.video.hidpi.enable
+      (lib.mkIf (config.sigprof.hardware.video.uiScale > 1.5)
         (lib.mkOverride 500 "${terminus_font}/share/consolefonts/ter-c32n.psf.gz"))
     ];
 
     # Set the font for GRUB.
     boot.loader.grub.font = lib.mkMerge [
       (lib.mkOverride 600 "${terminus_font}/share/fonts/terminus/ter-x16n.pcf.gz")
-      (lib.mkIf config.hardware.video.hidpi.enable
+      (lib.mkIf (config.sigprof.hardware.video.uiScale > 1.5)
         (lib.mkOverride 500 "${terminus_font}/share/fonts/terminus/ter-x32n.pcf.gz"))
     ];
     boot.loader.grub.fontSize = lib.mkMerge [
       (lib.mkOverride 600 16)
-      (lib.mkIf config.hardware.video.hidpi.enable
+      (lib.mkIf (config.sigprof.hardware.video.uiScale > 1.5)
         (lib.mkOverride 500 32))
     ];
 


### PR DESCRIPTION
It's time to update to the latest NixOS release — 23.05.