### PR TITLE
Update channels for the NixOS 23.11 release

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   CACHIX_NAME: sigprof
 
-  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11 nixos-22.05
+  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11
 
   CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   CACHIX_NAME: sigprof
 
-  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11
+  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.11 nixos-23.05 nixos-22.11
 
   CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ env:
   NUR_REPO: sigprof
 
   nur_systems: x86_64-linux x86_64-darwin
-  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11
+  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.11 nixos-23.05 nixos-22.11
   nur_main_channel: nixos-23.05
 
   CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ env:
   NUR_REPO: sigprof
 
   nur_systems: x86_64-linux x86_64-darwin
-  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11 nixos-22.05
+  nur_channels: nixpkgs-unstable nixos-unstable nixos-23.05 nixos-22.11
   nur_main_channel: nixos-23.05
 
   CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.14.1/install


### PR DESCRIPTION
Update channels used by the CI:

- Add `nixos-23.11` (the current release).
- Drop `nixos-22.05` (went EOL a long time ago).
