### PR TITLE
ci: Bump `cpcloud/flake-update-action` to `v2.0.1`

### DIFF
--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -65,7 +65,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Update ${{ matrix.input }}
-        uses: cpcloud/flake-update-action@eecde7936cf2f8b489398550ed8a4ef16c12bc1a
+        uses: cpcloud/flake-update-action@v2.0.1
         with:
           dependency: ${{ matrix.input }}
           pull-request-token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Using the raw commit hash is no longer needed, because the most recent tagged release is now usable.

The v2.0.1 version reverts the incompatible change made in v2.0.0 which required Nix >= 2.19.0; however, that code is compatible only with Nix up to 2.18.x (Nix >= 2.19.2 should also work with some deprecation warnings; the intermediate 2.19.0 and 2.19.1 releases won't work). Currently the CI jobs have the Nix version locked to 2.18.1 (which is also the version used by NixOS 23.11), therefore the incompatibility with Nix 2.19.{0,1} is not a problem.