### PR TITLE
ci: Avoid recursive usage of `cachix/cachix-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,7 @@ jobs:
           item: ${{ steps.collect_setup_checks.outputs.setup_checks }}
           system: ${{ env.this_system }}
           nix-install-url: ${{ env.CI_NIX_INSTALL_URL }}
-          cachix-name: ${{ env.CACHIX_NAME }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No `cachix-name` here to avoid recursive usage of `cachix-action`.
 
   setup_nur:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `setup-flake` job of the CI workflow used `cachix/cachix-action` itself, but it also called the `nix-build` action, which tried to use `cachix/cachix-action` again.  Such recursive usage broke after the update to `cachix/cachix-action@v14`, where the Cachix daemon is enabled by default (the problem is the cleanup step was also running twice, therefore the Cachix daemon was getting stopped by the first cleanup step, and the second cleanup step failed when trying to communicate with the daemon).

Removing the recursive usage of `cachix/cachix-action` by removing the `cachix-name` parameter from the `nix-build` invocation should fix the problem (now only the outer Cachix usage remains, which should be enough to get the build results pushed to the cache).