### PR TITLE
ci: Turn off the Cachix daemon

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -86,6 +86,7 @@ runs:
         pushFilter: ${{ inputs.cachix-push-filter }}
         #cachixArgs: ${{ inputs.cachix-args }}
         installCommand: ${{ inputs.cachix-install-command }}
+        useDaemon: false
 
     - name: Build
       shell: bash

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           name: ${{ env.CACHIX_NAME }}
           extraPullNames: "pre-commit-hooks"
+          useDaemon: false
 
       - name: Run the update script
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           name: ${{ env.CACHIX_NAME }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           extraPullNames: "pre-commit-hooks"
+          useDaemon: false
 
       - name: Check flake evaluation
         run: nix flake check --all-systems --no-build --show-trace
@@ -138,6 +139,7 @@ jobs:
           name: ${{ env.CACHIX_NAME }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           extraPullNames: "pre-commit-hooks"
+          useDaemon: false
 
       - name: Check NUR evaluation
         run: |


### PR DESCRIPTION
There are some problems with hanging jobs on macOS; try turning the Cachix daemon off as a workaround.

See also https://www.github.com/cachix/cachix-action/issues/170 (apparently upgrading Cachix might fix things too, but just turning off the daemon is easier).