### PR TITLE
ci: Build both `x86_64-darwin` and `aarch64-darwin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ env:
   CACHIX_NAME: sigprof
   NUR_REPO: sigprof
 
-  nur_systems: x86_64-linux x86_64-darwin
+  nur_systems: x86_64-linux x86_64-darwin aarch64-darwin
   nur_channels: nixpkgs-unstable nixos-unstable nixos-23.11 nixos-23.05 nixos-22.11
   nur_main_channel: nixos-23.11
 
@@ -295,9 +295,28 @@ jobs:
     uses: ./.github/workflows/ci-per-system.yml
     with:
       system: x86_64-darwin
-      runs-on: macos-latest
+      runs-on: macos-13
       flake-jobs: ${{ toJSON(fromJSON(needs.setup_flake.outputs.flake_jobs).x86_64-darwin.flake) }}
       nur-jobs: ${{ toJSON(fromJSON(needs.setup_nur.outputs.nur_jobs || '{}').x86_64-darwin.nur) }}
+      nix-install-url: ${{ needs.setup_flake.outputs.nix_install_url }}
+      cachix-name: ${{ needs.setup_flake.outputs.cachix_name }}
+    secrets:
+      cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  aarch64-darwin:
+    needs:
+      - setup_flake
+      - setup_nur
+    if: >-
+      (always() && !cancelled())
+      && (needs.setup_flake.result == 'success')
+      && (needs.setup_nur.result == 'success' || needs.setup_nur.result == 'skipped')
+    uses: ./.github/workflows/ci-per-system.yml
+    with:
+      system: aarch64-darwin
+      runs-on: macos-latest
+      flake-jobs: ${{ toJSON(fromJSON(needs.setup_flake.outputs.flake_jobs).aarch64-darwin.flake) }}
+      nur-jobs: ${{ toJSON(fromJSON(needs.setup_nur.outputs.nur_jobs || '{}').aarch64-darwin.nur) }}
       nix-install-url: ${{ needs.setup_flake.outputs.nix_install_url }}
       cachix-name: ${{ needs.setup_flake.outputs.cachix_name }}
     secrets:
@@ -309,6 +328,7 @@ jobs:
       - setup_nur
       - x86_64-linux
       - x86_64-darwin
+      - aarch64-darwin
     runs-on: ubuntu-latest
     if: >-
       (always() && !cancelled())
@@ -319,6 +339,7 @@ jobs:
           && (needs.setup_nur.result == 'success' || needs.setup_nur.result == 'skipped')
           && (needs.x86_64-linux.result == 'success')
           && (needs.x86_64-darwin.result == 'success' || needs.x86_64-darwin.result == 'skipped')
+          && (needs.aarch64-darwin.result == 'success' || needs.aarch64-darwin.result == 'skipped')
         }}
     steps:
       - name: Trigger NUR update


### PR DESCRIPTION
Currently it is possible to use free GitHub runners to build packages for `x86_64-darwin` (on `macos-12` or `macos-13` runners) and for `aarch64-darwin` (on `macos-14` runners); also the `macos-latest` alias was recently changed to point to `macos-14`, which resulted in doing the `aarch64-darwin` build instead of the expected `x86_64-darwin`.  Update the CI job to use proper runners and build packages for `x86_64-darwin` and `aarch64-darwin.`