### PR TITLE
ci(actions/nix-build): Add default to `cachix-skip-push`

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -45,6 +45,7 @@ inputs:
   cachix-skip-push:
     required: false
     description: 'Set to true to disable pushing build results to the cache'
+    default: 'false'
   #cachix-paths-to-push:
   #  required: false
   #  description: 'Whitespace-separated list of paths to push. Leave empty to push every build result.'


### PR DESCRIPTION
`cachix/cachix-action` v15 validates the `skipPush` parameter and no longer accepts an empty string as a valid false value, therefore the corresponding `cachix-skip-push` parameter for the local `nix-build` action needs to have an explicit default value.