### PR TITLE
Switch to NixOS 24.05

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ env:
 
   nur_systems: x86_64-linux x86_64-darwin aarch64-darwin
   nur_channels: nixpkgs-unstable nixos-unstable nixos-24.05 nixos-23.11 nixos-23.05
-  nur_main_channel: nixos-23.11
+  nur_main_channel: nixos-24.05
 
   CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.18.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -98,16 +98,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719957072,
-        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "lastModified": 1720244366,
+        "narHash": "sha256-WrDV0FPMVd2Sq9hkR5LNHudS3OSMmUrs90JUTN+MXpA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Personal NUR repository of @sigprof";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     nixos-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     systems.url = "github:nix-systems/default";

--- a/modules/hardware/sane/backend/epkowa.nix
+++ b/modules/hardware/sane/backend/epkowa.nix
@@ -16,6 +16,7 @@ in {
     hardware.sane.extraBackends = [cfg.package];
     sigprof.nixpkgs.permittedUnfreePackages = [
       "iscan"
+      "iscan-gt"
       "iscan-gt-f720-bundle"
       "iscan-nt-bundle"
       "iscan-gt-s650-bundle"
@@ -25,6 +26,7 @@ in {
       "iscan-gt-x820-bundle"
       "iscan-gt-x770-bundle"
       "iscan-gt-x750-bundle"
+      "iscan-perfection-v550-bundle"
       "iscan-data"
     ];
   };

--- a/modules/hardware/sane/backend/epkowa.nix
+++ b/modules/hardware/sane/backend/epkowa.nix
@@ -16,18 +16,18 @@ in {
     hardware.sane.extraBackends = [cfg.package];
     sigprof.nixpkgs.permittedUnfreePackages = [
       "iscan"
+      "iscan-data"
       "iscan-gt"
       "iscan-gt-f720-bundle"
-      "iscan-nt-bundle"
       "iscan-gt-s650-bundle"
       "iscan-gt-s80-bundle"
+      "iscan-gt-x750-bundle"
+      "iscan-gt-x770-bundle"
+      "iscan-gt-x820-bundle"
+      "iscan-nt-bundle"
+      "iscan-perfection-v550-bundle"
       "iscan-v330-bundle"
       "iscan-v370-bundle"
-      "iscan-gt-x820-bundle"
-      "iscan-gt-x770-bundle"
-      "iscan-gt-x750-bundle"
-      "iscan-perfection-v550-bundle"
-      "iscan-data"
     ];
   };
 }


### PR DESCRIPTION
It's time to update to the latest NixOS release — 24.05.