### PR TITLE
virt-manager-2.2.1: Limit Python version to < 3.12

### DIFF
--- a/pkgs/virt-manager/default.nix
+++ b/pkgs/virt-manager/default.nix
@@ -19,6 +19,12 @@
   # “virt-manager: 2.2.1 -> 3.1.0”)
   #
   virt-manager-2 = pkgs.callPackage ./virt-manager-2.2.1.nix {
+    # virt-manager 2.2.1 is not compatible with Python >= 3.12 (it uses the
+    # obsolete `imp` module, which is no longer available).
+    python3Packages =
+      if lib.versionOlder (lib.getVersion pkgs.python3Packages.python) "3.12"
+      then pkgs.python3Packages
+      else pkgs.python311Packages;
     system-libvirt = pkgs.libvirt;
   };
 in


### PR DESCRIPTION
Recently `nixpkgs-unstable` bumped the default `python3` version to 3.12.x, but the old virt-manager 2.2.1 code is not compatible with Python >= 3.12, because it uses the obsolete `imp` module which got removed in Python 3.12.  Check the Python version used by `nixpkgs` and switch to Python 3.11 if the default version is 3.12 or newer (but keep using the default Python version if it's older than 3.11 to avoid potential breakage on older `nixpkgs` branches).