### PR TITLE
Update XKB option names for NixOS 24.05

### DIFF
--- a/modules/i18n/ru_RU.nix
+++ b/modules/i18n/ru_RU.nix
@@ -46,9 +46,9 @@ in {
     ];
 
     # Configure the X11 keymap.
-    services.xserver = mkIf config.services.xserver.enable {
+    services.xserver.xkb = mkIf config.services.xserver.enable {
       layout = "us,ru";
-      xkbOptions = "grp:shift_caps_switch,lv3:ralt_switch,grp_led:scroll,keypad:oss,kpdl:kposs,compose:menu,misc:typo,nbsp:level3n,shift:both_capslock";
+      options = "grp:shift_caps_switch,lv3:ralt_switch,grp_led:scroll,keypad:oss,kpdl:kposs,compose:menu,misc:typo,nbsp:level3n,shift:both_capslock";
     };
   };
 }


### PR DESCRIPTION
Some XKB configuration options were renamed in NixOS 24.05:

  - `services.xserver.layout` → `services.xserver.xkb.layout`;
  - `services.xserver.xkbOptions` → `services.xserver.xkb.options`.

Update the `sigprof.i18n.ru_RU` module to match these changes.