### PR TITLE
ci: Avoid using `nixos-*` channels on `*-darwin` systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,35 @@ jobs:
                   fi
                   ;;
               esac
+
+              # Handle system-specific channel skipping and renaming.
+              case "$system" in
+                (*-darwin)
+                  # NixOS channels should not be used on Darwin, because NixOS
+                  # channel bumps do not wait for any Darwin builds, therefore
+                  # some packages may be missing from binary caches, which may
+                  # result in lots of rebuilds.
+                  case "$channel" in
+                    (nixos-unstable)
+                      # Use `nixpkgs-unstable` instead of `nixos-unstable`, but
+                      # be careful to avoid duplicates if `nixpkgs-unstable` is
+                      # already present in the channel list.
+                      if [ -n "$have_nixpkgs_unstable" ]; then
+                        continue
+                      else
+                        channel="nixpkgs-unstable"
+                      fi
+                      ;;
+                    (nixos-*)
+                      # Use `nixpkgs-<version>-darwin` instead of
+                      # `nixos-<version>`.
+                      channel_version="${channel##nixos-}"
+                      channel="nixpkgs-${channel_version}-darwin"
+                      ;;
+                  esac
+                  ;;
+              esac
+
               nur_jobs_part="$(
                 NIX_PATH="nixpkgs=channel:$channel" \
                   nix eval --argstr system "$system" --json -f nur.nix lib.ciData.matrix |


### PR DESCRIPTION
Only `nixpkgs-unstable` and `nixpkgs-<version>-darwin` channels wait for the corresponding Darwin builds to complete before bumping the channels; the `nixos-unstable` or `nixos-<version>` channels on Darwin may point to packages which are not present in the official binary caches.  Update the CI script to avoid that problem by adjusting the list of channels for any `*-darwin` systems:

  - Replace the `nixos-unstable` channel with `nixpkgs-unstable` (or just skip it completely if `nixpkgs-unstable` is already present in the list of channels).

  - Replace `nixos-<version>` with `nixpkgs-<version>-darwin`.

This change should fix the CI for `nixos-23.11` (even though that branch is EOL, someone might still need it); the problem with the 23.11 branch is that the latest update to the `nixos-23.11` channel was made after the updating of `nixpkgs-23.11-darwin` had been already stopped, therefore any attempt to use `nixos-23.11` on Darwin results in lots of package builds (and even GitHub job timeouts).