### PR TITLE
mozilla-langpack: Derive langpack names from the apparent app name

### DIFF
--- a/pkgs/mozilla-langpack/packages.nix
+++ b/pkgs/mozilla-langpack/packages.nix
@@ -53,10 +53,11 @@ in
 
     # Make language pack packages for the specified app and all available
     # languages.
-    langpackPackagesFor = mozApp: let
+    langpackPackagesFor = appName: let
+      mozApp = pkgs.${appName};
       app = functions.getAppInfo (presets // {inherit lib mozApp;});
       langpacks = presets.mozLangpackSources.${app.name}.${app.majorKey}.${app.arch} or {};
-      packageName = mozLanguage: "${app.langpackBaseName}-${mozLanguage}";
+      packageName = mozLanguage: "${appName}-langpack-${mozLanguage}";
       package = mozLanguage: makeMozillaLangpack {inherit mozApp mozLanguage;};
     in
       lib.mapAttrs' (n: v: nameValuePair (packageName n) (package n)) langpacks;
@@ -70,7 +71,7 @@ in
       }
       # Export language pack packages for all available Mozilla-originated
       # packages from the supported set and all available languages.
-      // optionalAttrs (pkgs ? firefox) (langpackPackagesFor pkgs.firefox)
-      // optionalAttrs (pkgs ? firefox-esr) (langpackPackagesFor pkgs.firefox-esr)
-      // optionalAttrs (pkgs ? thunderbird) (langpackPackagesFor pkgs.thunderbird);
+      // optionalAttrs (pkgs ? firefox) (langpackPackagesFor "firefox")
+      // optionalAttrs (pkgs ? firefox-esr) (langpackPackagesFor "firefox-esr")
+      // optionalAttrs (pkgs ? thunderbird) (langpackPackagesFor "thunderbird");
   }


### PR DESCRIPTION
The code was trying to derive the langpack package names from the attributes of the app package; in particular, it added the `-esr` component if the version of the app package had the `esr` suffix. That broke when NixOS 24.05 switched the `thunderbird` package to point to the 128.x ESR track, which has the `esr` suffix in its version number, unlike the previous 115.x track.

Instead of trying to be clever with the ESR status, just derive the langpack package names from the name of the main package as it appears in Nixpkgs, so that `thunderbird` gets `thunderbird-langpack-XX` and not `thunderbird-esr-langpack-XX`, even when the version of the `thunderbird` package has the `esr` tag.