### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,10 +56,35 @@
         "type": "github"
       }
     },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1724763886,
+        "narHash": "sha256-SzBtZs5z+YGM50oyt67R78qLhxG/wG5/SlVRsCF5kRc=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "1cd12de659fab215624c630c37d1c62aa2b7824e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks-nix",
           "nixpkgs"
         ]
       },
@@ -109,38 +134,13 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1724763886,
-        "narHash": "sha256-SzBtZs5z+YGM50oyt67R78qLhxG/wG5/SlVRsCF5kRc=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "1cd12de659fab215624c630c37d1c62aa2b7824e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devshell": "devshell",
         "flake-utils": "flake-utils",
+        "git-hooks-nix": "git-hooks-nix",
         "nixos-unstable": "nixos-unstable",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,6 @@
 
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";
-    devshell.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = inputs @ {

--- a/flake.nix
+++ b/flake.nix
@@ -10,9 +10,9 @@
     flake-utils.url = "github:numtide/flake-utils";
     flake-utils.inputs.systems.follows = "systems";
 
-    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
-    pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
-    pre-commit-hooks.inputs.nixpkgs-stable.follows = "nixpkgs";
+    git-hooks-nix.url = "github:cachix/git-hooks.nix";
+    git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
+    git-hooks-nix.inputs.nixpkgs-stable.follows = "nixpkgs";
 
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";
@@ -22,7 +22,7 @@
     self,
     nixpkgs,
     flake-utils,
-    pre-commit-hooks,
+    git-hooks-nix,
     devshell,
     ...
   }:
@@ -49,7 +49,7 @@
           x86_64-darwin
           aarch64-linux
           aarch64-darwin
-          # No `i686-linux` because `pre-commit-hooks` does not evaluate
+          # No `i686-linux` because `git-hooks-nix` does not evaluate
         ];
       in
         flake-utils.lib.eachSystem checkedSystems (system: let
@@ -58,7 +58,7 @@
         in {
           checks =
             {
-              pre-commit = pre-commit-hooks.lib.${system}.run {
+              pre-commit = git-hooks-nix.lib.${system}.run {
                 src = ./.;
                 hooks = {
                   alejandra.enable = true;
@@ -84,7 +84,7 @@
             packages = [
               alejandra
             ];
-            devshell.startup.pre-commit-hooks.text = self.checks.${system}.pre-commit.shellHook;
+            devshell.startup.git-hooks-nix.text = self.checks.${system}.pre-commit.shellHook;
           };
         })
     );


### PR DESCRIPTION
Update some flake inputs:
- The updated `devshell` version no longer has the `flake-utils` input, so drop the override for it.
- `cachix/pre-commit-hooks.nix` is now called `cachix/git-hooks.nix`; update the URL and the input name accordingly.