### PR TITLE
virt-manager-2: use `adwaita-icon-theme` instead of `gnome.adwaita-icon-theme`

### DIFF
--- a/pkgs/virt-manager/virt-manager-2.2.1.nix
+++ b/pkgs/virt-manager/virt-manager-2.2.1.nix
@@ -16,7 +16,8 @@
   gsettings-desktop-schemas,
   glib,
   libosinfo,
-  gnome,
+  gnome ? null,
+  adwaita-icon-theme ? gnome.adwaita-icon-theme,
   gtksourceview4,
   spiceSupport ? true,
   spice-gtk ? null,
@@ -48,7 +49,7 @@ with lib;
         vte
         dconf
         gtk-vnc
-        gnome.adwaita-icon-theme
+        adwaita-icon-theme
         avahi
         gsettings-desktop-schemas
         libosinfo


### PR DESCRIPTION
The package move was done in NixOS/nixpkgs#319659, but old package names were accepted with warnings until NixOS/nixpkgs#357818.  Update the old virt-manager package to use the new package name if possible.