### PR TITLE
virt-manager: Use `overrideAttrs`

### DIFF
--- a/pkgs/virt-manager/default.nix
+++ b/pkgs/virt-manager/default.nix
@@ -28,7 +28,7 @@
     system-libvirt = pkgs.libvirt;
   };
 in
-  pkgs.virt-manager.overridePythonAttrs (oldAttrs: rec {
+  pkgs.virt-manager.overrideAttrs (oldAttrs: rec {
     # Build a combined `virt-manager` package which included both the latest
     # version (which supports only some recent `libvirt` versions) and the 2.x
     # version (renamed to `virt-manager-2`).  This is safer than exporting the


### PR DESCRIPTION
Since NixOS/nixpkgs#359479 `virt-manager` is no longer a Python application package, therefore `overridePythonAttrs` does not work.