### PR TITLE
virt-manager: Fix breakage after #1500

### DIFF
--- a/pkgs/virt-manager/default.nix
+++ b/pkgs/virt-manager/default.nix
@@ -40,9 +40,11 @@ in
     #
     # Using `postFixup` to avoid wrapping the symlink.
     #
-    postFixup = ''
-      ln -s ${virt-manager-2}/bin/virt-manager $out/bin/virt-manager-2
-    '';
+    postFixup =
+      (oldAttrs.postFixup or "")
+      + ''
+        ln -s ${virt-manager-2}/bin/virt-manager $out/bin/virt-manager-2
+      '';
 
     meta = lib.mergeAttrs oldAttrs.meta {
       description = ''


### PR DESCRIPTION
Changing `overridePythonAttrs` to `overrideAttrs` broke the package, because at the `overrideAttrs` level the `postFixup` attribute already had a value, and the override did not use `oldAttrs.postFixup`.