### PR TITLE
flake: Drop `nixpkgs-stable` input override from `git-hooks-nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
 
     git-hooks-nix.url = "github:cachix/git-hooks.nix";
     git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
-    git-hooks-nix.inputs.nixpkgs-stable.follows = "nixpkgs";
 
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
The `git-hooks-nix` flake no longer has the `nixpkgs-stable` input.