### PR TITLE
ci: Manually bump `cachix/install-nix-action` to v31.4.1

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -67,7 +67,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9
+      uses: cachix/install-nix-action@v31.4.1
       with:
         install_url: ${{ inputs.nix-install-url }}
         install_options: ${{ inputs.nix-install-options }}

--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9
+        uses: cachix/install-nix-action@v31.4.1
         with:
           install_url: ${{ env.CI_NIX_INSTALL_URL }}
 
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9
+        uses: cachix/install-nix-action@v31.4.1
         with:
           install_url: ${{ env.CI_NIX_INSTALL_URL }}
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9
+        uses: cachix/install-nix-action@v31.4.1
         with:
           install_url: ${{ env.CI_NIX_INSTALL_URL }}
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9
+        uses: cachix/install-nix-action@v31.4.1
         with:
           install_url: ${{ env.CI_NIX_INSTALL_URL }}
 
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9
+        uses: cachix/install-nix-action@v31.4.1
         with:
           install_url: ${{ env.CI_NIX_INSTALL_URL }}
 


### PR DESCRIPTION
For some reason Dependabot stopped updating pinned hash values for GitHub action references.  Switch `cachix/install-nix-action` to use the latest tagged release (the prerelease version is no longer required).