### PR TITLE
virt-manager-2: Fix compatibility with Python changes in Nixpkgs PR 421660

### DIFF
--- a/pkgs/virt-manager/virt-manager-2.2.1.nix
+++ b/pkgs/virt-manager/virt-manager-2.2.1.nix
@@ -36,8 +36,11 @@ with lib;
       sha256 = "06ws0agxlip6p6n3n43knsnjyd91gqhh2dadgc33wl9lx1k8vn6g";
     };
 
-    pyproject = true;
-    build-system = with python3Packages; [setuptools];
+    # Since NixOS/nixpkgs#421660 `format = "setuptools"` is no longer assumed
+    # by default.  Adding `pyproject = true; build-system = [ setuptools ];`,
+    # which is recommended, does not work without some more build fixes, so
+    # just set `format = "setuptools"` explicitly for this ancient package.
+    format = "setuptools";
 
     nativeBuildInputs = [
       intltool

--- a/pkgs/virt-manager/virt-manager-2.2.1.nix
+++ b/pkgs/virt-manager/virt-manager-2.2.1.nix
@@ -36,6 +36,9 @@ with lib;
       sha256 = "06ws0agxlip6p6n3n43knsnjyd91gqhh2dadgc33wl9lx1k8vn6g";
     };
 
+    pyproject = true;
+    build-system = with python3Packages; [setuptools];
+
     nativeBuildInputs = [
       intltool
       file


### PR DESCRIPTION
Since NixOS/nixpkgs#421660 all Python packages are required to set either `pyproject` or `format` — `format = "setuptools"` is no longer used by default.  The recommended way to fix build is to use:

```nix
pyproject = true;
build-system = with python3Packages; [setuptools];
```

However, the above fix does not actually work with the `virt-manager-2` package, because it changes the way the package is built, and needs some additional changes to fix other build problems caused by that.  So a simpler workaround is used instead (which is actually equivalent to the old default behavior):

```nix
format = "setuptools";
```