### PR TITLE
ci: Use current Nix (2.29.1) instead of 2.18.1

### DIFF
--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 env:
-  CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.18.1/install
+  CI_NIX_INSTALL_URL: '' # https://releases.nixos.org/nix/nix-2.18.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -16,7 +16,7 @@ env:
 
   nur_channels: nixpkgs-unstable nixos-unstable nixos-25.05 nixos-24.11 nixos-24.05
 
-  CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.18.1/install
+  CI_NIX_INSTALL_URL: '' # https://releases.nixos.org/nix/nix-2.18.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ env:
   nur_channels: nixpkgs-unstable nixos-unstable nixos-25.05 nixos-24.11 nixos-24.05
   nur_main_channel: nixos-24.11
 
-  CI_NIX_INSTALL_URL: https://releases.nixos.org/nix/nix-2.18.1/install
+  CI_NIX_INSTALL_URL: '' # https://releases.nixos.org/nix/nix-2.18.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:


### PR DESCRIPTION
Some time ago the Nix version used by CI was pinned to 2.18.1 due to compatibility issues with `cpcloud/flake-update-action` (see #974). Although `cpcloud/flake-update-action` was not updated to use the new `nix flake update <dependency>` syntax (because compatibility with older Nix versions was more important at that time), on the Nix side the compatibility with the old `nix flake lock --update-input <dependency>` syntax had been restored in Nix 2.19.2 (the command prints deprecation warnings, but still works).  In the meantime it turned out that old Nix versions have some significant security issues.

Stop pinning the Nix version to 2.18.1, so that `cachix/install-nix-action` would install the current Nix version (which is actually pinned inside the action, so pinning the action implicitly pins the Nix version too).