### PR TITLE
ci: Fix x86_64-darwin support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ env:
   nur_systems: x86_64-linux x86_64-darwin aarch64-darwin
   nur_channels: nixpkgs-unstable nixos-unstable nixos-25.11 nixos-25.05 nixos-24.11
   nur_main_channel: nixos-25.11
+  x86_64_darwin_channels: nixpkgs-26.05-darwin nixpkgs-25.11-darwin nixpkgs-25.05-darwin nixpkgs-24.11-darwin
 
   CI_NIX_INSTALL_URL: '' # https://releases.nixos.org/nix/nix-2.18.1/install
   NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
@@ -237,6 +238,19 @@ jobs:
                       # `nixos-<version>`.
                       channel_version="${channel##nixos-}"
                       channel="nixpkgs-${channel_version}-darwin"
+                      ;;
+                  esac
+                  ;;
+              esac
+              case "$system" in
+                (x86_64-darwin)
+                  # Nixpkgs >= 26.11 dropped support for x86_64-darwin
+                  case " $x86_64_darwin_channels " in
+                    (*" $channel "*)
+                      # Allow explicitly listed channels
+                      ;;
+                    (*)
+                      continue
                       ;;
                   esac
                   ;;


### PR DESCRIPTION
Nixpkgs 26.11 has dropped support for x86_64-darwin; restrict builds for that architecture to the older channels which still support it.