### PR TITLE
flake: Stop taking `alejandra` from `nixos-unstable`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,7 @@
           # No `i686-linux` because `git-hooks-nix` does not evaluate
         ];
       in
-        flake-utils.lib.eachSystem checkedSystems (system: let
-          nixos-unstable = inputs.nixos-unstable.legacyPackages.${system};
-          alejandra = nixos-unstable.alejandra;
-        in {
+        flake-utils.lib.eachSystem checkedSystems (system: {
           checks =
             {
               pre-commit = git-hooks-nix.lib.${system}.run {
@@ -62,7 +59,6 @@
                 hooks = {
                   alejandra.enable = true;
                 };
-                tools.alejandra = alejandra;
               };
             }
             // (
@@ -81,7 +77,7 @@
             name = "sigprof/nur-packages";
             motd = "{6}🔨 Welcome to {bold}sigprof/nur-packages{reset}";
             packages = [
-              alejandra
+              git-hooks-nix.packages.${system}.alejandra
             ];
             devshell.startup.git-hooks-nix.text = self.checks.${system}.pre-commit.shellHook;
           };


### PR DESCRIPTION
Effectively revert commit 18fb55a6135dcda9237d0cc3ac5c4c19e3a1d7c6 "Use the `alejandra` package from `nixos-unstable`", because upgrading Alejandra to the most recent version is no longer needed, and using `nixos-unstable` introduces some complications (in particular, the `x86_64-darwin` support breaks earlier than it should).